### PR TITLE
More typescriptifying app.ts

### DIFF
--- a/src/generic_ui/scripts/app.ts
+++ b/src/generic_ui/scripts/app.ts
@@ -15,19 +15,11 @@
 /// <reference path='../../interfaces/ui.d.ts'/>
 /// <reference path='../../uproxy.ts'/>
 
-'use strict';
-
-// TODO: remove this once extension model is cleaned up.
-interface modelForApp extends UI.Model {
-  clientToInstance :{[clientId :string] :string };
-  instances :{[instanceId :string] :Instance};
-}
-
 angular.module('UProxyExtension', ['angular-lodash', 'dependencyInjector'])
   //.constant('googleAuth', new OAuth2('google', OAUTH_CONFIG))
   //.constant('GOOG_PROFILE_URL', 'https://www.googleapis.com/oauth2/v1/userinfo')
   // can remove once https://github.com/angular/angular.js/issues/2963 is fixed:
-  .config(function ($provide) {
+  .config(function ($provide :ng.auto.IProvideService) {
     $provide.decorator('$sniffer', ['$delegate', function ($sniffer) {
       $sniffer.csp = true;
       return $sniffer;
@@ -35,30 +27,24 @@ angular.module('UProxyExtension', ['angular-lodash', 'dependencyInjector'])
   })
   // Run gets called every time an extension module is opened.
   .run([
-    '$filter',
-    '$http', 
     '$rootScope',
     // via dependencyInjector:
     'ui',
     'core',
     'onStateChange',
     'model',
-    function($filter, $http, $rootScope,
+    function($rootScope :UI.RootScope,
              ui :uProxy.UIAPI,
              core :uProxy.CoreAPI,
              // TODO: Change type to something cross-browser compatible
              onStateChange :chrome.Event,
-             model :modelForApp) {
+             model :UI.modelForAngular) {
       if (undefined === model) {
         console.error('model not found in dependency injections.');
       }
       $rootScope.ui = ui;
       $rootScope.core = core;
       $rootScope.model = model;
-      $rootScope.notifications = 0;
-
-      // Remember the state change hook.
-      $rootScope.update = onStateChange;
 
       $rootScope.isOnline = function(network) {
         return (model.networks[network] && model.networks[network].online)

--- a/src/interfaces/ui.d.ts
+++ b/src/interfaces/ui.d.ts
@@ -7,6 +7,7 @@
  */
 /// <reference path='user.d.ts' />
 /// <reference path='instance.d.ts' />
+/// <reference path='lib/angular.d.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/social.d.ts' />
 
 declare module UI {
@@ -80,6 +81,29 @@ declare module UI {
     description   :string;
     keyHash       :string;
     consent       :ConsentState;
+    // TODO: rosterInfo is used in app.ts, remove if unnecessary.
+    rosterInfo    ?:RosterInfo;
+  }
+
+  // TODO: remove this once extension model is cleaned up.
+  export interface modelForAngular extends UI.Model {
+    clientToInstance :{[clientId :string] :string };
+    instances :{[instanceId :string] :UI.Instance};
+  }
+
+  export interface RootScope extends ng.IRootScopeService {
+    ui :uProxy.UIAPI;
+    core :uProxy.CoreAPI;
+    model :modelForAngular;
+    isOnline(network :string) : boolean;
+    isOffline(network :string) : boolean;
+    loggedIn() : boolean;
+    loggedOut() : boolean;
+    resetState() : void;
+    instanceOfContact(contact :User) : Instance;
+    prettyNetworkName(networkId :string) : string;
+    instanceOfUserId(userId :string) : Instance;
+    updateDOM() : void;
   }
 
 }  // module UI

--- a/src/uistatic/scripts/dependencies.ts
+++ b/src/uistatic/scripts/dependencies.ts
@@ -2,13 +2,13 @@
 /// <reference path='../../uproxy.ts' />
 /// <reference path='../../interfaces/ui.d.ts'/>
 /// <reference path='../../interfaces/notify.d.ts'/>
+/// <reference path='../../interfaces/lib/angular.d.ts' />
 /// <reference path='../../generic_ui/scripts/ui.ts' />
 
 console.log('This is not a real uProxy frontend.');
 
 // TODO: Type these.
 declare var state:UI.Model;
-declare var angular:any;
 
 // Initialize model object to a mock. (state.js)
 var model = state;  // || { identityStatus: {} };
@@ -80,4 +80,3 @@ var dependencyInjector = angular.module('dependencyInjector', [])
   .constant('ui', ui)
   .constant('model', model)
   .constant('core', mockCore)
-  .constant('roster', null);


### PR DESCRIPTION
- Set correct types for angular-defined objects like $provide
- Define our own rootScope interface
- Move model interface to common ui.d.ts file
