### PR TITLE
Version bump to Chrome app/extension

### DIFF
--- a/src/chrome/app/manifest.json
+++ b/src/chrome/app/manifest.json
@@ -3,7 +3,7 @@
   "name": "UProxyApp",
   "description": "Ubiquitous Proxy [Alpha]",
   "minimum_chrome_version": "31",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "icons": {
       "128": "icons/uproxy-128.png",
       "19": "icons/uproxy-19.png",

--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_appName__",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "manifest_version": 2,
   "description": "__MSG_appDescription__",
   "minimum_chrome_version": "31",


### PR DESCRIPTION
Incrementing the version of the Chrome app and extension.
Future build cops should do this before publishing a tagged release so that we can easily just upload to the WebStore
