### PR TITLE
Change G+ to Google in the UI

### DIFF
--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -186,7 +186,7 @@
             <div class="picCover"></div>
             <div class="description">
               <p>{{ui.instance.description}}</p>
-              <span ng-show="ui.user.onGoogle"> G+ </span>
+              <span ng-show="ui.user.onGoogle"> Google </span>
               <span ng-show="ui.user.onFB"> FB </span>
             </div>
 

--- a/src/generic_ui/scripts/app.ts
+++ b/src/generic_ui/scripts/app.ts
@@ -68,7 +68,7 @@ app.run([
 
       $s.prettyNetworkName = (networkId) => {
         switch (networkId) {
-          case 'google': return 'G+';
+          case 'google': return 'Google';
           case 'facebook': return 'FB';
           case 'xmpp': return 'XMPP';
           case 'websocket': return 'websocket';


### PR DESCRIPTION
Change G+ to Google in the UI, since we are really communicating over GoogleTalk, not through G+ (and G+ contacts won't even appear in the roster unless they are also GoogleTalk contacts).

Tested manually in UI and re-ran "grunt test"
