### PR TITLE
Fix reconnection issues between extension + app.

### DIFF
--- a/src/chrome/extension/scripts/core_connector.spec.ts
+++ b/src/chrome/extension/scripts/core_connector.spec.ts
@@ -95,14 +95,16 @@ describe('core-connector', () => {
 
   var resumedPolling = false;
 
-  it('disconnection cleans up state and retries connect.', () => {
-    spyOn(window, 'setTimeout');
+  it('disconnection cleans up state and retries connect.', (done) => {
+    // This test may take up to 2 seconds (SYNC_TIMEOUT) before completion
+    // due to setTimeout call in disconnect().  If we need to speed up this
+    // test we could instead mock out window.setTimeout and verify that it
+    // is called with the expected params.
     expect(disconnect).not.toBeNull();
+    spyOn(connector, 'connect').and.callFake(() => { done(); })
     disconnect();
     expect(connector.status.connected).toEqual(false);
     expect(connector['appPort_']).toBeNull();
-    expect(window.setTimeout).toHaveBeenCalledWith(connector.connect,
-                                                   SYNC_TIMEOUT);
   });
 
   it('send_ queues message while disconnected.', () => {

--- a/src/chrome/extension/scripts/core_connector.ts
+++ b/src/chrome/extension/scripts/core_connector.ts
@@ -132,7 +132,7 @@ class ChromeCoreConnector implements uProxy.CoreAPI {
       };
       this.appPort_.onMessage.addListener(ackResponse);
       // Send 'hi', which should prompt App to respond with ack.
-      var postMessageRetVal = this.appPort_.postMessage(ChromeGlue.CONNECT);
+      this.appPort_.postMessage(ChromeGlue.CONNECT);
     }).catch((e) => {
       console.log(e);
       // Manually invoke disconnect handler which will retry connection.


### PR DESCRIPTION
Fix issue https://github.com/uProxy/uProxy/issues/129 (reconnection issues between extension + app):
- Allows for the extension to be loaded before the app.
- Allows for the app to be restarted multiple times without needing to restart the extension.

Tested manually and using "grunt test".
