### PR TITLE
Allow connections to websocket router

### DIFF
--- a/src/chrome/app/manifest.json
+++ b/src/chrome/app/manifest.json
@@ -26,7 +26,8 @@
     "https://www.facebook.com/",
     "https://graph.facebook.com/",
     "https://www.googleapis.com/*",
-    "https://accounts.google.com/*"
+    "https://accounts.google.com/*",
+    "https://p2pbr.com/route/"
   ],
    "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk6KrQptZchMYwQN8CsbRVmhV/COoR0lxansERcz+OrkPctUBSTQVYJw3t17+6JyMPnKYR2DMKCTeYQGrmXzm2U0KpujEKN3WSTtZI4ynTzKbGhWIYo6exaHufcslJngEG91ua/q1fJz3e5Mla8+tIsT9bVdVf4NLfODNbky/Uo0M6KpOLO9r2zJoiO0yg4ThBH+TkNwH8icvHJbt2LzZVRSZtQ1Wl1uT15vnwJPOEYVQkpnEMY5yMBPxyOZ1AmUx714YAas80pSZ7+BlM9ReIirYB7lxeY6hAqs4u8iP5SDh5bg6YFXeYecwQyvnKglLdHq6djy9QyVLKUKxFzMH/wIDAQAB"
 }


### PR DESCRIPTION
In response to https://github.com/uProxy/uProxy/issues/136 this makes the websocket social provider work.

Tested by creating two local instances, who are able to see each other after both logging in to the web socket provider with this change.
