### PR TITLE
Fixed use of "login" and "logout". They are not verbs.

### DIFF
--- a/src/generic_ui/options.html
+++ b/src/generic_ui/options.html
@@ -29,9 +29,9 @@
       </label>
         <span ng-repeat="(network, detail) in model.networks">
           <button class="btn" ng-show="!isOnline(network)"
-            ng-click="core.login(network)">Login to {{ prettyNetworkName(network) }}</button>
+            ng-click="core.login(network)">Sign in to {{ prettyNetworkName(network) }}</button>
           <button class="btn" ng-show="isOnline(network)"
-            ng-click="core.logout(network)">Logout from {{ prettyNetworkName(network) }}</button>
+            ng-click="core.logout(network)">Sign out from {{ prettyNetworkName(network) }}</button>
         </span>
     <h4>Instances</h4>
     <div id="contacts-frame">

--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -57,9 +57,9 @@
           <div class="network-btn">
             <span ng-repeat="(network, detail) in model.networks">
               <button class="btn" ng-show="!isOnline(network)"
-              ng-click="login(network)">Login to {{ prettyNetworkName(network) }}</button>
+              ng-click="login(network)">Sign in to {{ prettyNetworkName(network) }}</button>
               <button class="btn" ng-show="isOnline(network)"
-                ng-click="core.logout(network)">Logout from {{ prettyNetworkName(network) }}</button>
+                ng-click="core.logout(network)">Sign out from {{ prettyNetworkName(network) }}</button>
             </span>
           </div>
         </div>


### PR DESCRIPTION
The verb forms are "log in" and "log out". Google uses "sign in" and
"sign out", which are perhaps a bit clearer, so switched to using those
instead.
