### PR TITLE
Show who a client is proxying through, fix stop button

### DIFF
--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -260,7 +260,7 @@
     </div>
 
     <div id="status">
-      <span id="status-proxy" ng-show="ui.currentProxy" ng-cloak>
+      <span id="status-proxy" ng-show="ui.currentProxyServer" ng-cloak>
 
         <div>
           <button id="stop-btn" class="icon-btn"
@@ -268,7 +268,7 @@
               ng-mouseleave="stopTooltip=false"
               ng-click="ui.stopProxying()">
           </button>
-          Proxying through {{ui.currentProxy.user.name}}
+          Proxying through {{ui.currentProxyServer.user.name}}
         </div>
 
         <div class="tool" id="status-tooltips">

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -96,7 +96,7 @@ module UI {
     public user :User = null;
     public instance :UI.Instance = null;
     // If we are proxying, keep track of the instance and user.
-    public currentProxy :UI.CurrentProxy = null;
+    public currentProxyServer :UI.CurrentProxy = null;
 
     notifications = 0;
     advancedOptions = false;
@@ -243,7 +243,7 @@ module UI {
         instanceId: this.instance.instanceId
       };
       this.core.start(path).then(() => {
-        this.currentProxy = {
+        this.currentProxyServer = {
           instance: this.instance,
           user: this.user
         };
@@ -261,7 +261,7 @@ module UI {
         return;
       }
       this._setProxying(false);
-      this.currentProxy = null;
+      this.currentProxyServer = null;
       this.core.stop();
     }
 

--- a/src/interfaces/ui.d.ts
+++ b/src/interfaces/ui.d.ts
@@ -54,6 +54,9 @@ declare module UI {
     access        :AccessState;
   }
 
+  /**
+   * Data about a currently proxying server or client.
+   */
   export interface CurrentProxy {
     instance :Instance;
     user :UI.User;

--- a/src/uistatic/scripts/dependencies.ts
+++ b/src/uistatic/scripts/dependencies.ts
@@ -58,7 +58,7 @@ function generateFakeUserMessage() : UI.UserMessage {
 class MockCore implements uProxy.CoreAPI {
 
   public status :StatusObject;
-  private currentProxy :UI.CurrentProxy = null;
+  private currentProxyServer :UI.CurrentProxy = null;
 
   constructor() {
     this.status = { connected: true };
@@ -119,23 +119,23 @@ class MockCore implements uProxy.CoreAPI {
   start = (path) : Promise<void> => {
     console.log('Starting to proxy through ', path);
     var user :UI.User = model.networks[path.network].roster[path.userId];
-    this.currentProxy = {
+    this.currentProxyServer = {
       instance: user.instances[0],
       user: user
     };
-    console.log(this.currentProxy);
-    this.currentProxy.instance.access.asProxy = true;
+    console.log(this.currentProxyServer);
+    this.currentProxyServer.instance.access.asProxy = true;
     return Promise.resolve();
   }
 
   stop = () => {
-    if (!this.currentProxy) {
+    if (!this.currentProxyServer) {
       console.warn('No proxy to stop for.');
       return;
     }
-    console.log('Stopping proxy through ', this.currentProxy);
-    this.currentProxy.instance.access.asProxy = false;
-    this.currentProxy = null;
+    console.log('Stopping proxy through ', this.currentProxyServer);
+    this.currentProxyServer.instance.access.asProxy = false;
+    this.currentProxyServer = null;
   }
 
   updateDescription(description) {


### PR DESCRIPTION
Show who a client is proxying through, fix stop button (partial fix for https://github.com/uProxy/uProxy/issues/160).  Also cleaning up some UI code (e.g. renaming ui.proxy to ui.currentProxy and typescriptifying it)

Tested with "grunt test" and manually in the UI
