### PR TITLE
Fix mixing up users loaded from datastore.

### DIFF
--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -66,7 +66,7 @@ describe('Social.Network', () => {
   it('successfully initializes if api is social', () => {
     spyOn(storage, 'load').and.callFake(() => {
       loadedLocalInstance = true;
-      return Promise.resolve(undefined);
+      return Promise.resolve({});
     });
     Social.initializeNetworks();
     network = Social.getNetwork('mock');
@@ -342,5 +342,22 @@ describe('Social.Network', () => {
     network.send('fakeclient', outMsg)
     expect(JSON.stringify).toHaveBeenCalledWith(outMsg);
   });
+
+  // TODO: get this unit test to pass.
+  /*
+  it('Can deserialize multiple users', (done) => {
+    var serialNetworkData :Social.SerialNetwork = {
+      name: 'mock',
+      remember: false,
+      userIds: ['userA', 'userB', 'userC']
+    }
+    network.deserialize(serialNetworkData).then(() => {
+      expect(network.getUser('userA')).toEqual('userA');
+      expect(network.getUser('userB')).toEqual('userB');
+      expect(network.getUser('userC')).toEqual('userC');
+      done();
+    });
+  });
+  */
 
 });

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -517,15 +517,18 @@ module Social {
       this.remember = json.remember;
       // Load all users based on userIds.
       for (var i = 0 ; i < json.userIds.length ; ++i) {
-        var userId = json.userIds[i];
-        storage.load<Core.SerialUser>(this.getStorePath() + userId)
-            .then((json) => {
-          this.roster[userId] = new Core.User(this, userId);
-          this.roster[userId].deserialize(json);
-        }).catch((e) => {
-          this.error('could not load user ' + userId);
-        });
+        this.loadUserFromStorage_(json.userIds[i]);
       }
+    }
+    private loadUserFromStorage_ = (userId :string) => {
+      storage.load<Core.SerialUser>(this.getStorePath() + userId)
+          .then((json) => {
+        this.roster[userId] = new Core.User(this, userId);
+        this.roster[userId].deserialize(json);
+        this.log('successfully loaded user ' + userId);
+      }).catch((e) => {
+        this.error('could not load user ' + userId);
+      });
     }
     private saveToStorage = () => {
       var json = this.serialize();


### PR DESCRIPTION
Fix mixing up users loaded from datastore

Tested manually (no longer seeing "received client with unexpected userId") and verified no failures on "grunt test" (will add new unit test later after dogfood rush)
