### PR TITLE
Always store User objects, even if 'pending'

### DIFF
--- a/src/generic_core/user.ts
+++ b/src/generic_core/user.ts
@@ -82,6 +82,7 @@ module Core {
       this.reconnections_ = {};
       this.clientToInstanceMap_ = {};
       this.instanceToClientMap_ = {};
+      this.saveToStorage();
     }
 
     /**


### PR DESCRIPTION
Always store User objects, even if 'pending'

Tested by verifying that loading errors goes away, grunt test still passes.
