### PR TITLE
fix unwanted scrollbars for chromium

### DIFF
--- a/src/generic_ui/styles/main.sass
+++ b/src/generic_ui/styles/main.sass
@@ -916,6 +916,7 @@ img.c-icon
 #popup
   width: 370.8204px
   height: 600px
+  overflow: hidden
   .footer
     text-align: right
 


### PR DESCRIPTION
fixes #200 

chromium has slightly different border behavior from google-chrome. This tiny change ensures the overall popup never has scrollbars in the wrong place.

Tested: jasmine and manual UI test
