### PR TITLE
UI Fixes: only show uProxy contacts, handle contacts with the same name

### DIFF
--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -99,6 +99,8 @@
                     ng-blur="showFilterTip=false"
                     ng-class="{on:ui.filters.friendsAccess}"
                     ng-click="ui.toggleFilter('friendsAccess')"></button>
+            <!-- TODO: re-enable when we can show 1000+ non-uProxy contacts
+                 without slowing down (https://github.com/uProxy/uProxy/issues/201)
             <button id="uproxy-filter" class="filter"
                     ng-mouseenter="showFilter('uproxy')"
                     ng-focus="showFilter('uproxy')"
@@ -107,6 +109,7 @@
                     ng-mouseleave="showFilterTip=false"
                     ng-class="{on:ui.filters.uproxy}"
                     ng-click="ui.toggleFilter('uproxy')"></button>
+            -->
             <!-- TODO: re-enable when online filter works
             <button id="online-filter" class="filter"
                     ng-mouseenter="showFilter('online')"
@@ -147,9 +150,9 @@
 
         <div id="roster-frame" ng-show="ui.isRoster()">
           <ul class="contacts">
-            <li ng-repeat="contact in model.roster | orderBy : ['-canUProxy', 'name']"
+            <!-- TODO: re-add sort by canUProxy once we are able to show all contacts -->
+            <li ng-repeat="contact in model.roster | filter:ui.doesContactPassFilter() | orderBy : 'name' track by $index"
                 ng-click="ui.focusOnUser(contact)"
-                ng-hide="ui.contactIsFiltered(contact)"
                 ng-class="{offline:!contact.online}"
                 >
               {{contact.name}}
@@ -171,6 +174,9 @@
               <span class="c-notification" ng-show='contact.hasNotification'> ! </span>
             </li>
           </ul>
+          <div class="no-contacts-found" ng-hide="ui.hasOnlineUProxyBuddies()">
+            No online contacts found with uProxy
+          </div>
         </div>
 
         <div class="contact-info" id="their-info"

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -124,7 +124,7 @@ module UI {
         'online': false,
         'myAccess': false,
         'friendsAccess': false,
-        'uproxy': false
+        'uproxy': true
     };
 
     /**
@@ -334,27 +334,29 @@ module UI {
     }
 
     /**
-     * Returns |true| if contact |c| should *not* currently be visible in the
+     * Returns |false| if contact |c| should *not* currently be visible in the
      * roster.
      */
-    contactIsFiltered = (user:UI.User) => {
-      var searchText = this.search,
-          compareString = user.name.toLowerCase();
-      // First, compare filters.
-      if ((this.filters.online        && !user.online)    ||
-          (this.filters.uproxy        && !user.canUProxy) ||
-          (this.filters.myAccess      && !user.givesMe)   ||
-          (this.filters.friendsAccess && !user.usesMe)) {
-        return true;
-      }
-      // Otherwise, if there is no search text, this.user is visible.
-      if (!searchText) {
-        return false;
-      }
-      if (compareString.indexOf(searchText) >= 0) {
-        return false;
-      }
-      return true;  // Does not match the search text, should be hidden.
+    doesContactPassFilter = () => {
+      return (user :UI.User) : boolean => {
+        var searchText = this.search,
+            compareString = user.name.toLowerCase();
+        // First, compare filters.
+        if ((this.filters.online        && !user.online)    ||
+            (this.filters.uproxy        && !user.canUProxy) ||
+            (this.filters.myAccess      && !user.givesMe)   ||
+            (this.filters.friendsAccess && !user.usesMe)) {
+          return false;
+        }
+        // Otherwise, if there is no search text, this.user is visible.
+        if (!searchText) {
+          return true;
+        }
+        if (compareString.indexOf(searchText) >= 0) {
+          return true;
+        }
+        return false;  // Does not match the search text, should be hidden.
+      };
     }
 
     // --------------------------- Focus & Notifications ---------------------------
@@ -499,6 +501,18 @@ module UI {
       console.log('Synchronized user.', user);
       this.refreshDOM();
     };
+
+    // TODO: this might be more efficient if we just had a ui.hasUProxyBuddies
+    // boolean that we could keep up to date.
+    public hasOnlineUProxyBuddies = () => {
+      for (var i = 0; i < model.roster.length; ++i) {
+        var user :UI.User = model.roster[i]; 
+        if (user.instances.length > 0 && user.online) {
+          return true;
+        }
+      }
+      return false;
+    }
 
     public login = (network) => {
       this.core.login(network).then(

--- a/src/generic_ui/styles/main.sass
+++ b/src/generic_ui/styles/main.sass
@@ -443,6 +443,15 @@ input[type=text]
     @include un-ng-hide
     left: -400px
 
+.no-contacts-found
+  position: absolute
+  background-color: #fafafa
+  width: 100%
+  min-height: 100%
+  margin: 0
+  padding: 0.5em 0.5em
+  @include smooth
+
 .contacts
   position: absolute
   background-color: #fafafa


### PR DESCRIPTION
- Only show uProxy contacts (temporary fix for issue https://github.com/uProxy/uProxy/issues/201)
  - Add indicator that no online uProxy clients are found, so the user doesn't think its broken / slow
  - Change filtering so that we don't create hidden DOM elements for filtered items (switch from using ng-hide to | filter in the repeat expression)
- Handle contacts with the same name (issue https://github.com/uProxy/uProxy/issues/199)

Tested in the UI and re-ran grunt test
