### PR TITLE
mark uProxy as private to prevent publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/UWNetworksLab/UProxy"
+    "url": "https://github.com/uProxy/UProxy"
   },
   "bugs": {
     "url": "http://github.com/uproxy/uproxy/issues",


### PR DESCRIPTION
that would be bad at the moment.
