### PR TITLE
Stop proxying and show alert if app is disconnected while proxying.

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -24,7 +24,6 @@ var core :ChromeCoreConnector;  // way for ui to speak to a uProxy.CoreAPI
 // TODO: This should be *actually* typed.
 // Proxy Configuration.
 var proxyConfig = new BrowserProxyConfig();
-proxyConfig.clearConfig();
 
 
 // Singleton model for angularjs hooks on both popup and options.
@@ -43,16 +42,6 @@ chrome.runtime.onSuspend.addListener(() => {
   console.log('onSuspend');
   //proxyConfig.stopUsingProxy();
 });
-
-/**
- * Start proxying if one instance has their proxy status enabled.
- * Otherwise, stop all proxying.
- */
-function checkRunningProxy() {
-  // TODO: Make this work with the new UI model.
-  // proxyConfig.startUsingProxy();
-  proxyConfig.stopUsingProxy();
-}
 
 /**
  * Primary initialization of the Chrome Extension. Installs hooks so that

--- a/src/chrome/extension/scripts/core_connector.spec.ts
+++ b/src/chrome/extension/scripts/core_connector.spec.ts
@@ -19,6 +19,16 @@ var mockAppPort = () => {
   };
 };
 
+// Mock UI.
+var ui :uProxy.UIAPI = {
+  sync: (state ?:string) => {},
+  update: (type :uProxy.Update, data ?:any) => {},
+  syncUser: (UserMessage :UI.UserMessage) => {},
+  showNotification: (notificationText :string) => {},
+  isProxying: () => { return false; },
+  stopProxyingInUiAndConfig: () => {},
+  refreshDOM: () => {}
+};
 
 // The ordering of the specs matter, as they provide a connect / disconnect
 // sequence on the connector object.
@@ -110,9 +120,12 @@ describe('core-connector', () => {
     // is called with the expected params.
     expect(disconnect).not.toBeNull();
     spyOn(connector, 'connect').and.callFake(() => { done(); })
+    spyOn(ui, 'isProxying').and.returnValue(true);
+    spyOn(ui, 'stopProxyingInUiAndConfig');
     disconnect();
     expect(connector.status.connected).toEqual(false);
     expect(connector['appPort_']).toBeNull();
+    expect(ui.stopProxyingInUiAndConfig).toHaveBeenCalled();
   });
 
   it('send_ queues message while disconnected.', () => {

--- a/src/chrome/extension/scripts/core_connector.ts
+++ b/src/chrome/extension/scripts/core_connector.ts
@@ -167,6 +167,11 @@ class ChromeCoreConnector implements uProxy.CoreAPI {
     this.status.connected = false;
     this.appPort_ = null;
 
+    if (ui.isProxying()) {
+      ui.showNotification('The uProxy app has exited, stopping proxy.')
+      ui.stopProxyingInUiAndConfig();
+    }
+
     console.warn('Retrying connection in ' + (SYNC_TIMEOUT/1000) + 's...');
     setTimeout(this.connect, SYNC_TIMEOUT);
   }

--- a/src/chrome/extension/scripts/proxy-config.ts
+++ b/src/chrome/extension/scripts/proxy-config.ts
@@ -26,13 +26,11 @@ class BrowserProxyConfig {
                      "computeengineondemand.appspot.com"]
       }
     };
+
+    chrome.proxy.settings.clear({scope: 'regular'});
   }
 
-  clearConfig = () => {
-    chrome.proxy.settings.clear({scope: 'regular'});
-  };
-
-  startUsingProxy = () => {
+  public startUsingProxy = () => {
     if (this.running_ == false) {
       console.log('Directing Chrome proxy settings to UProxy');
       this.running_ = true;
@@ -47,7 +45,7 @@ class BrowserProxyConfig {
     }
   };
 
-  stopUsingProxy = () => {
+  public stopUsingProxy = () => {
     if (this.running_ == true) {
       console.log('Reverting Chrome proxy settings');
       this.running_ = false;

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -78,11 +78,11 @@ class UIConnector implements uProxy.UIAPI {
     this.update(uProxy.Update.ERROR, errorText);
   }
 
-  public sendNotification = (notificationText :string) => {
+  public showNotification = (notificationText :string) => {
     this.update(uProxy.Update.NOTIFICATION, notificationText);
   }
 
-  public stopProxying = () => {
+  public stopProxyingInUiAndConfig = () => {
     this.update(uProxy.Update.STOP_PROXYING);
   }
 
@@ -92,6 +92,10 @@ class UIConnector implements uProxy.UIAPI {
       Social.networks[networkName].notifyUI();
     }
     this.update(uProxy.Update.ALL); 
+  }
+
+  public isProxying = () : boolean => {
+    return proxy != null;
   }
 
 }
@@ -358,7 +362,7 @@ socksToRtcClient.on('socksToRtcTimeout', (peerInfo :PeerInfo) => {
     return;
   }
   instance.stop();
-  ui.stopProxying();
+  ui.stopProxyingInUiAndConfig();
   ui.sendError('Darn, something went wrong with your proxying connection.' +
     ' Please try to connect again.');
 });
@@ -404,7 +408,7 @@ function updateClientProxyConnection(localPeerIdString :string,
     var user :Core.User = instance.user;
     var displayName :string = (user.name && user.name !== 'pending') ?
       user.name : user.userId;
-    ui.sendNotification(displayName + ' is now proxying through you.');
+    ui.showNotification(displayName + ' is now proxying through you.');
   }
 };
 

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -313,16 +313,16 @@ module Core {
       if (oldProxyConsent != this.consent.asProxy) {
         switch (this.consent.asProxy) {
           case Consent.ProxyState.REMOTE_OFFERED:
-            ui.sendNotification(this.user.name + ' offered you access.');
+            ui.showNotification(this.user.name + ' offered you access.');
             break;
           case Consent.ProxyState.GRANTED:
-            ui.sendNotification(this.user.name + ' granted you access.');
+            ui.showNotification(this.user.name + ' granted you access.');
             break;
           case Consent.ProxyState.USER_REQUESTED:
             // The only way to land in USER_REQUESTED upon reciving consent bits
             // is if the remote has revoked access after previously being in
             // GRANTED.
-            ui.sendNotification(this.user.name + ' revoked your access.');
+            ui.showNotification(this.user.name + ' revoked your access.');
             break;
           default:
             // Don't display notification for ignoring, and any other states.
@@ -332,10 +332,10 @@ module Core {
       if (oldClientConsent != this.consent.asClient) {
         switch (this.consent.asClient) {
           case Consent.ClientState.REMOTE_REQUESTED:
-            ui.sendNotification(this.user.name + ' is requesting access.');
+            ui.showNotification(this.user.name + ' is requesting access.');
             break;
           case Consent.ClientState.GRANTED:
-            ui.sendNotification(this.user.name + ' has accepted your offer of access.');
+            ui.showNotification(this.user.name + ' has accepted your offer of access.');
             break;
           default:
             // Don't display notification for ignoring, and any other states.

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -411,7 +411,7 @@ module Social {
           // TODO: Only fire a popup notification the 1st few times.
           // (what's a 'few'?)
           .then(() => {
-            ui.sendNotification('You successfully signed on to ' + this.name +
+            ui.showNotification('You successfully signed on to ' + this.name +
                                 ' as ' + this.myInstance.userId);
           })
           .catch(() => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -183,7 +183,7 @@ module UI {
         this.showNotification(notificationText);
       });
       core.onUpdate(uProxy.Update.STOP_PROXYING, () => {
-        this.stopProxyingInUiAndConfig_();
+        this.stopProxyingInUiAndConfig();
       });
 
       console.log('Created the UserInterface');
@@ -303,7 +303,7 @@ module UI {
         console.warn('Stop Proxying called while not proxying.');
         return;
       }
-      this.stopProxyingInUiAndConfig_();
+      this.stopProxyingInUiAndConfig();
       this.core.stop();
     }
 
@@ -311,7 +311,7 @@ module UI {
      * Removes proxy indicators from UI and undoes proxy configuration
      * (e.g. chrome.proxy settings).
      */
-    private stopProxyingInUiAndConfig_ = () => {
+    public stopProxyingInUiAndConfig = () => {
       if (!this.proxyServerInstance) {
         console.warn('Stop Proxying called while not proxying.');
         return;
@@ -584,6 +584,10 @@ module UI {
         // this.syncMe();
       // }
       // return true;
+    }
+
+    public isProxying = () : boolean => {
+      return this.currentProxyServer != null;
     }
 
   }  // class UserInterface

--- a/src/interfaces/browser-proxy-config.d.ts
+++ b/src/interfaces/browser-proxy-config.d.ts
@@ -1,5 +1,4 @@
 interface BrowserProxyConfig {
-  clearConfig() : void;
   startUsingProxy() : void;
   stopUsingProxy() : void;
 }

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -158,6 +158,10 @@ module uProxy {
     // updateIdentity(identity) : void;
     // addNotification() : void;
 
+    showNotification(notificationText :string) : void;
+    isProxying() : boolean;
+    stopProxyingInUiAndConfig() : void;
+
     // TODO: explain why this is needed. Seems like a hack to refresh the dom.
     refreshDOM() : void;
 


### PR DESCRIPTION
Stop proxying and show alert if app is disconnected while proxying, fix for https://github.com/uProxy/uProxy/issues/185

Also includes related small changes:
- Remove proxyConfig.clearConfig method.  This method was unclear and only called once, immediately after the constructor, so I moved the code into the constructor.
- Removed unused checkRunningProxy function
- Renamed sendNotification to showNotification, and stopProxying to stopProxyingInUiAndConfig in core.ts, so these functions could be added to the uProxy.UIAPI interface definition.

Tested manually (started a proxy, then disabled the app on the client side, and verified that an alert appears and chrome works again), also updated and re-ran "grunt test"
