### PR TITLE
Update version of freedom-social-xmpp, use ~ to keep getting latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "es6-promise": "^0.1.1",
     "freedom": "^0.4.6",
     "freedom-for-chrome": "0.1.5",
-    "freedom-social-xmpp": "^0.0.11",
+    "freedom-social-xmpp": "~0.0.14",
     "freedom-typescript-api": "^0.1.9",
     "glob": "^3.2.6",
     "globule": "^0.2.0",


### PR DESCRIPTION
Update version of freedom-social-xmpp, use ~ to keep getting latest versions

Tested manually (ran "npm install" and verified we have the latest freedom-social-xmpp (0.0.14), also re-ran grunt test
