### PR TITLE
Add warning to login screen of uProxy

### DIFF
--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -64,7 +64,13 @@
           </div>
         </div>
       </div>
-    </div>
+      <div id="uproxy-warning">
+          <strong>WARNING</strong>: Some of uProxy’s critical security and privacy features are
+          still under development. If <strong>having your internet usage become public
+          knowledge</strong> might put you at risk in any way, please <strong>do not use
+          uProxy</strong> at this time.
+      </div>
+    </div>  <!-- end of #login-splash -->
 
     <button id="options-btn" ng-click="toggleOptions()"
         ng-show="ui.loggedIn()"

--- a/src/generic_ui/styles/main.sass
+++ b/src/generic_ui/styles/main.sass
@@ -208,6 +208,11 @@ ul
     vertical-align: middle
     margin-bottom: 23px
 
+#uproxy-warning
+  margin-left: 1em
+  margin-right: 1em
+  margin-top: 5em
+
 .description
   color: #222
   text-shadow: 1px 2px 2px #aaa


### PR DESCRIPTION
Add warning to login screen of uProxy, for https://github.com/uProxy/uProxy/issues/163

Screenshot of what this looks like can be seen here: https://drive.google.com/a/google.com/file/d/0B6oXFcuW01xTakxqblFCQmRyY3M/edit?usp=sharing

Tested manually in UI and re-ran grunt test
