### PR TITLE
remove state.js and refresh after syncing networks

### DIFF
--- a/src/chrome/extension/scripts/state.js
+++ b/src/chrome/extension/scripts/state.js
@@ -1,2 +1,0 @@
-// Initialize a 'default' state object here if desired. This file must exist,
-// but doesn't need to do anything.

--- a/src/generic_ui/popup.html
+++ b/src/generic_ui/popup.html
@@ -16,7 +16,6 @@
     <script src="scripts/user.js"></script>
     <script src="scripts/app.js"></script>
     <script src="scripts/popup.js"></script>
-    <script src="scripts/state.js"></script>
     <script src="scripts/dependencies.js"></script>
 
   </head>

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -425,6 +425,7 @@ module UI {
       } else {
         model.networks[network.name].online = network.online;
       }
+      this.refreshDOM();
     }
 
     // Determine whether UProxy is connected to some network.


### PR DESCRIPTION
I don't know why we need state.js, it seems useless

refreshDOM should be harmless
