### PR TITLE
include actual local fingerprint in outgoing instance handshakes, as the keyHash attribute

### DIFF
--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -185,12 +185,14 @@ module Social {
         return this.myInstance;
       }, (e) => {
         this.myInstance = new Core.LocalInstance(this);
-        this.log('generated new local instance: ' +
+        this.log('generating new local instance: ' +
                  this.myInstance.instanceId);
-        return storage.save<Instance>(key, this.myInstance.currentState()).then((prev) => {
-          this.log('saved new local instance to storage');
-          return this.myInstance;
-        });
+        return this.myInstance.prepare().then(() => {
+            return storage.save<Instance>(key, this.myInstance.currentState());
+          }).then((prev) => {
+            this.log('saved new local instance to storage');
+            return this.myInstance;
+          });
       });
     }
 
@@ -518,6 +520,9 @@ module Social {
       }
     }
 
+    /**
+     * Promise the sending of |msg| to a client with id |clientId|.
+     */
     public send = (clientId:string, msg:uProxy.Message) : Promise<void> => {
       var msgString = JSON.stringify(msg);
       this.log('sending ------> ' + msgString);


### PR DESCRIPTION
Aside: Thus far I haven't seen anything like a TTL in the sdp headers, which we might need for expiry comparison when the verification UX is underway.

Next step: Expose local and remote fingerprints on the UI.

Tested: jasmine and manually
