### PR TITLE
Update freedom version to use freedom v0.5.0 (via freedom-for-chrome v0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "devDependencies": {
     "es6-promise": "^0.1.1",
-    "freedom": "^0.4.6",
-    "freedom-for-chrome": "0.1.5",
-    "freedom-social-xmpp": "~0.0.14",
+    "freedom-for-chrome": "0.2.0",
+    "freedom-for-firefox": "~0.4.0",
+    "freedom-social-xmpp": "~0.1.0",
     "freedom-typescript-api": "^0.1.9",
     "glob": "^3.2.6",
     "globule": "^0.2.0",


### PR DESCRIPTION
Update freedom version to use freedom v0.5.0 (via freedom-for-chrome v0.2.0)

Tested manually by verifying that social network login and proxying works.  Also re-ran "grunt test"
