### PR TITLE
remove bypass list

### DIFF
--- a/src/chrome/extension/scripts/proxy-config.ts
+++ b/src/chrome/extension/scripts/proxy-config.ts
@@ -19,11 +19,7 @@ class BrowserProxyConfig {
           scheme: "socks5",
           host: "127.0.0.1",
           port: 9999
-        },
-        // List of domains to bypass the proxy
-        // Bypass Google/Facebook RESTful API endpoint (used by XMPP for auth)
-        bypassList: ["<local>", "www.googleapis.com", "graph.facebook.com",
-                     "computeengineondemand.appspot.com"]
+        }
       }
     };
 


### PR DESCRIPTION
We should not need a proxy bypass list; auth should happen before proxy settings are set.

Fixes: https://github.com/uProxy/uproxy/issues/248

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uwnetworkslab/uproxy-p2p/368)
<!-- Reviewable:end -->
