### PR TITLE
Fix descriptions in new UI

### DIFF
--- a/src/generic_ui/polymer/description.ts
+++ b/src/generic_ui/polymer/description.ts
@@ -4,11 +4,8 @@
 declare var core :uProxy.CoreAPI;
 
 Polymer({
-  description: 'a computer',
-  update: () => {
-    console.log('updating description to ' + this.description);
-    // TODO(keroserene): Actually check that the description update propogates
-    // through.
+  description: 'My Computer',
+  update: function() {
     core.updateDescription(this.description);
   }
 });

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -20,13 +20,9 @@
       margin: 0;
       color: #888;
     }
-    #instanceId {
-      font-size: 8px;
-      color: #bbb;
-    }
     </style>
 
-    <span id='instanceId'>{{ instance.instanceId }}</span>
+    <span>{{ instance.description }}</span>
     <div id='bytesSent' hidden?='{{ instance.bytesSent == 0 }}'>Bytes Sent: {{ instance.bytesSent }}</div>
     <div id='bytesReceived' hidden?='{{ instance.bytesReceived == 0 }}'>Bytes Received: {{ instance.bytesReceived }}</div>
 

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -39,16 +39,6 @@
     </style>
 
     <div class='setting'>
-      <h1>Device</h1>
-      <uproxy-description></uproxy-description>
-      <p>
-      Giving this device a name will let your contacts know how they are
-      connecting with you. It also means you can have more than one device with
-      uProxy installed and proxy from one to the other.
-      </p>
-    </div>
-
-    <div class='setting'>
       <h1>Your security phrase<h1>
       <span id='sas'>melon toast horse rocket</span>
     </div>


### PR DESCRIPTION
Fix descriptions in new UX:
- Descriptions are now sent in instance messages and appear in the buddylist (instead of instanceIds)
- The description field in the settings screen (after login) is now removed, as the uProxy core currently does not support dynamically updating the description

Tested manually in UI and with "grunt test"
