### PR TITLE
set monitoringIntervalId to be able to stop monitoring

### DIFF
--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -571,6 +571,7 @@ module Social {
       this.stopMonitor_();
       return this.freedomApi_.logout().then(() => {
         this.myInstance.userId = null;
+        this.roster = {};
         this.log('logged out.');
       }).then(this.notifyUI);
     }


### PR DESCRIPTION
monitoringIntervalId should not be part of some "network state" object(something we've talked about we need to have), we need to make sure we stop monitoring before deleting the object.

I really think we should be using more assertions, if that even does anything in js. I haven't seen us using assertions in our code though, I'm not sure why.

If we has more tests maybe we could check there are no assertions and then they'd be useful.
