### PR TITLE
Change npm versions to support secure XMPP in chrome 38

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "es6-promise": "^0.1.1",
-    "freedom-social-xmpp": "~1.0.1",
+    "freedom-social-xmpp": "~0.2.1",
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-compress": "~0.6.0",
@@ -36,7 +36,7 @@
     "grunt-verbosity": "^0.2.2",
     "typescript": "^1.0.1",
     "uproxy-churn": "^0.0.5",
-    "uproxy-lib": "^11.0.2",
+    "uproxy-lib": "^13.0.0",
     "uproxy-networking": "^1.3.0"
   },
   "private": true,


### PR DESCRIPTION
Change npm version numbers to make secure XMPP work with Chrome 38

Tested in Chrome 38 and re-ran "grunt test"
