### PR TITLE
Show userId in expanded contact view

### DIFF
--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -41,6 +41,10 @@
     .offline {
       opacity: 0.5;
     }
+    #userId {
+      color: #888;
+      margin-top: 0.5em;
+    }
     #words {
       display: inline-block;
       width: 282px; height: 100%;
@@ -73,6 +77,7 @@
       <img id='avatar' src='{{ contact.imageData }}' />
       <div id='words'>
         <h1>{{ contact.name }}</h1>
+        <div id='userId' hidden?='{{!expanded}}'>{{ contact.userId }}</div>
         <div id='instances' hidden?='{{!expanded}}'>
           <template repeat='{{ i in contact.instances }}' vertical layout>
             <uproxy-instance


### PR DESCRIPTION
Show userId in expanded contact view.  Addresses issues raised in https://github.com/uProxy/uproxy/issues/412

For Google, this userId is often a @gmail.com address, but is sometimes a @public.talk.google.com address (I believe this is based on whether the users find each other initially through email, chat, or G+). For Facebook, we currently have a unique numeric userId, but will look for something more human-readable, like a @facebook.com email address or the unique URL of the contact.
