### PR TITLE
Fixed polymer loading in Firefox

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -85,10 +85,10 @@ FILES =
   ]
   thirdPartyUi: [
     'core-*/**',
-    'lodash/**',
     'platform/**',
     'polymer/**',
-    'paper-*/*.css'
+    'paper-*/*.css',
+    'webcomponentsjs/**'
   ]
 
 
@@ -156,9 +156,9 @@ module.exports = (grunt) ->
           src: [
             'third_party/freedom-ts-hacks/*.js',
             'third_party/lib/core-component-page/**/*.js',
-            'third_party/lib/lodash/**/*.js',
             'third_party/lib/platform/**/*.js',
-            'third_party/lib/polymer/**/*.js'
+            'third_party/lib/polymer/**/*.js',
+            'third_party/lib/webcomponentsjs/**/*.js'
             ]
           dest: 'build/'
           onlyIf: 'modified'

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "uProxy",
   "version": "0.4.0",
   "dependencies": {
-    "lodash": "~1.3.1",
     "polymer": "~0.5.1",
     "paper-elements": "Polymer/paper-elements#~0.5.1"
   },

--- a/src/generic_ui/polymer/popup.html
+++ b/src/generic_ui/polymer/popup.html
@@ -4,7 +4,7 @@
 <head>
   <title>uProxy polymer UI</title>
   <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
-  <script src='../lib/lodash/dist/lodash.compat.js'></script>
+  <script src='../lib/webcomponentsjs/webcomponents.js'></script>
 
   <script src='../scripts/ui.js'></script>
   <script src='../scripts/uproxy.js'></script>

--- a/src/generic_ui/polymer/roster-group.html
+++ b/src/generic_ui/polymer/roster-group.html
@@ -2,7 +2,7 @@
 <link rel='import' href='contact.html'>
 
 <polymer-element name='uproxy-roster-group'
-    attributes='onlineContacts, offlineContacts, title, searchQuery'>
+    attributes='onlineContacts, offlineContacts, groupTitle, searchQuery'>
 
   <template>
     <style>
@@ -15,7 +15,7 @@
 
     <div class='header'
         hidden?='{{ onlineContacts.length == 0 && offlineContacts.length == 0 }}'>
-        {{ title }}
+        {{ groupTitle }}
     </div>
 
     <template repeat='{{ c in onlineContacts }}' vertical layout>

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -33,7 +33,7 @@
 
     <!-- trusted uProxy contacts -->
     <uproxy-roster-group
-        title='Trusted uProxy Friends'
+        groupTitle='Trusted uProxy Friends'
         onlineContacts='{{ onlineTrustedUproxyContacts }}'
         offlineContacts='{{ offlineTrustedUproxyContacts }}'
         searchQuery='{{ searchQuery }}'></uproxy-roster-group>
@@ -44,7 +44,7 @@
 
     <!-- untrusted uProxy contacts -->
     <uproxy-roster-group
-        title='All uProxy Contacts'
+        groupTitle='All uProxy Contacts'
         onlineContacts='{{ onlineUntrustedUproxyContacts }}'
         offlineContacts='{{ offlineUntrustedUproxyContacts }}'
         searchQuery='{{ searchQuery }}'></uproxy-roster-group>
@@ -55,7 +55,7 @@
 
     <!-- non uProxy contacts -->
     <uproxy-roster-group
-        title='Non uProxy Contacts'
+        groupTitle='Non uProxy Contacts'
         onlineContacts='{{ onlineNonUproxyContacts }}'
         offlineContacts='{{ offlineNonUproxyContacts }}'
         searchQuery='{{ searchQuery }}'></uproxy-roster-group>


### PR DESCRIPTION
Fixed polymer loading in Firefox
- new Polymer 0.5.1 requires us to also use the webcomponents.js library in Firefox (it had been working in Chrome without this library, but Chrome continues to work with this library included as well).
- "title" is already a reserved HTML attribute, so the uproxy-roster-group needs to use some other attribute name (I chose groupTitle).  This was completely breaking Firefox before but not having any effect on Chrome
- lodash library is no longer used, removed it from bower and popup.html

Tested in Chrome, Firefox, re-ran "grunt test"
