### PR TITLE
fixes for dependencies and freedom typing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "uProxy",
   "version": "0.4.0",
   "dependencies": {
-    "polymer": "~0.5.1",
+    "polymer": "^0.5.2",
     "paper-elements": "Polymer/paper-elements#~0.5.1",
     "core-input": "Polymer/core-input#^0.5.0",
     "core-style": "Polymer/core-style#^0.5.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "private": true,
   "scripts": {
-    "test": "grunt test --verbose",
-    "prepublish": "grunt test"
+    "test": "grunt test --verbose"
   }
 }

--- a/src/chrome/app/scripts/plumbing.ts
+++ b/src/chrome/app/scripts/plumbing.ts
@@ -13,7 +13,7 @@ var UPROXY_CHROME_EXTENSION_ID = 'pjpcdnccaekokkkeheolmpkfifcbibnj';
 
 // Remember which handlers freedom has installed.
 var installedFreedomHooks = [];
-var uProxyAppChannel;
+var uProxyAppChannel : OnAndEmit<any,any>;
 
 // See the ChromeCoreConnector, which communicates to this class.
 // TODO: Finish this class with tests and pull into its own file.
@@ -108,9 +108,9 @@ class ChromeUIConnector {
     this.onCredentials_ = onCredentials;
   }
 }
-freedom('scripts/freedom-module.json', {
+var uproxyModule = new freedom('scripts/freedom-module.json', {
   oauth: [Chrome_oauth]
-}).then(function(interface:any) {
+}).then(function(interface : () => OnAndEmit<any,any>) {
   uProxyAppChannel = interface();
   connector = new ChromeUIConnector();
   console.log('Starting uProxy app...');

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -27,7 +27,7 @@ var storage = new Core.Storage();
 // This is the channel to speak to the UI component of uProxy.
 // The UI is running from the privileged part of freedom, so we can just set
 // this to be freedom, and communicate using 'emit's and 'on's.
-var bgAppPageChannel = freedom();
+var bgAppPageChannel = new freedom();
 
 // Keep track of the current remote instance who is acting as a proxy server
 // for us.


### PR DESCRIPTION
This mini-pull request (against freedom_0.6 branch) is intended to show a way to use the freedom object as a constructor instead of a function and thereby unify usage of it (The function/constructor duality makes it a bit tricky to know what the type of the freedom object is). This solution makes the Freedom type a Thenable of the function that then gives the on/emit interface for constructed module. 

TESTED: 
1. sym-link uproxy lib from https://github.com/uProxy/uproxy-lib/pull/95 into node_modules
2. grunt test
3. Load up uproxy in Chrome and observe no errors. 

before submission, will need to update uproxy-lib npm and depend on the update. 

This pull request is just a demo for @salomegeo to help unblock the typescript faff being fought with.  
