### PR TITLE
Make timestamp optional in firewall

### DIFF
--- a/src/generic_core/firewall.ts
+++ b/src/generic_core/firewall.ts
@@ -33,7 +33,7 @@ module Firewall {
 
   export class DefaultResponsePolicy implements ResponsePolicy {
     public onValidationFailure(s :string, level :Severity) {
-      console.warn("DROPPING MESSAGE ON VALIDATION FAILURE.  Severity: " + 
+      console.warn("DROPPING MESSAGE ON VALIDATION FAILURE.  Severity: " +
                    level + ", text: " + s);
     }
   }
@@ -68,7 +68,7 @@ module Firewall {
     if (isReservedWord(s) || hasBadChars(s) || isPredefinedOnObject(s)) {
       response.onValidationFailure(s, Severity.LikelyAttack);
       return false;
-    } 
+    }
     return true;
   }
 
@@ -79,11 +79,11 @@ module Firewall {
     } else {
       return true;
     }
-  }        
+  }
 
   var USER_PROFILE_SCHEMA = {
     'userId' : 'string',
-    'timestamp' : 'number',
+    'timestamp' : '?number',
     'name' : '?string',
     'url' : '?string',
     'imageData' : '?string'
@@ -122,11 +122,11 @@ module Firewall {
       }
     }
 
-    return remaining_required == 0 && 
+    return remaining_required == 0 &&
       object_keys_matched == 0;
   }
 
-  export function isValidUserProfile(profile :freedom_Social.UserProfile, 
+  export function isValidUserProfile(profile :freedom_Social.UserProfile,
                                      response :ResponsePolicy) : boolean {
     if (response == null) {
       response = DEFAULT_RESPONSE_POLICY;
@@ -151,7 +151,7 @@ module Firewall {
     }
 
     // TODO: Consider clamping timestamp to 'now' at the high end.
-    if (profile.timestamp < 0) {
+    if (profile.timestamp && profile.timestamp < 0) {
       fail();
       return false;
     }
@@ -163,7 +163,7 @@ module Firewall {
     'userId' : 'string',
     'clientId' : 'string',
     'status' : 'string',
-    'timestamp' : 'number'
+    'timestamp' : '?number'
   };
 
   export function isValidClientState(state :freedom_Social.ClientState,
@@ -175,7 +175,7 @@ module Firewall {
     // Call this when we're not handing the |response| object to
     // methods (where they'd call onValidationFailure themselves)
     function fail() {
-      response.onValidationFailure(JSON.stringify(state), 
+      response.onValidationFailure(JSON.stringify(state),
                                    Severity.MalformedInput);
     }
 
@@ -187,7 +187,7 @@ module Firewall {
     if (!isUserId(state.userId, response)) {
       return false;
     }
-    
+
     if (!isClientId(state.clientId, response)) {
       return false;
     }
@@ -197,11 +197,11 @@ module Firewall {
       return false;
     }
 
-    if (state.timestamp < 0) {
+    if (state.timestamp && state.timestamp < 0) {
       fail();
       return false;
     }
-    
+
     return true;
   }
 
@@ -210,7 +210,7 @@ module Firewall {
     'message' : 'string'
   };
 
-  export function isValidIncomingMessage(state :freedom_Social.IncomingMessage, 
+  export function isValidIncomingMessage(state :freedom_Social.IncomingMessage,
                                          response :ResponsePolicy) :boolean {
     if (response == null) {
       response = DEFAULT_RESPONSE_POLICY;
@@ -219,7 +219,7 @@ module Firewall {
     // Call this when we're not handing the |response| object to
     // methods (where they'd call onValidationFailure themselves)
     function fail() {
-      response.onValidationFailure(JSON.stringify(state), 
+      response.onValidationFailure(JSON.stringify(state),
                                    Severity.MalformedInput);
     }
 

--- a/src/generic_core/freedom-module.json
+++ b/src/generic_core/freedom-module.json
@@ -14,6 +14,7 @@
       "util.js",
       "auth.js",
       "consent.js",
+      "firewall.js",
       "storage.js",
       "local-instance.js",
       "remote-instance.js",


### PR DESCRIPTION
Make timestamp optional in firewall - fixes buddylist issues introduced in https://github.com/uProxy/uproxy/pull/618.  This is a short term fix, long term fix to be done in https://github.com/uProxy/uproxy/issues/668

Tested in Chrome and grunt test (can't login to Firefox yet)
