### PR TITLE
Move get/share selection to welcome overlay

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -88,9 +88,10 @@ class uProxyCore implements uProxy.CoreAPI {
   // We need to use slice to copy the values, otherwise modifying this
   // variable can modify DEFAULT_STUN_SERVERS_ as well.
   public globalSettings :Core.GlobalSettings
-      = {description : '',
-         stunServers : this.DEFAULT_STUN_SERVERS_.slice(0),
-         hasSeenSharingEnabledScreen : false};
+      = {description: '',
+         stunServers: this.DEFAULT_STUN_SERVERS_.slice(0),
+         hasSeenSharingEnabledScreen: false,
+         hasSeenWelcome: false};
   public loadGlobalSettings :Promise<void> = null;
 
   constructor() {
@@ -119,6 +120,9 @@ class uProxyCore implements uProxy.CoreAPI {
           // onboarding information.
           if (this.globalSettings.hasSeenSharingEnabledScreen == null) {
             this.globalSettings.hasSeenSharingEnabledScreen = false;
+          }
+          if (this.globalSettings.hasSeenWelcome == null) {
+            this.globalSettings.hasSeenWelcome = false;
           }
         }).catch((e) => {
           console.log('No global settings loaded', e);
@@ -282,11 +286,9 @@ class uProxyCore implements uProxy.CoreAPI {
       }
     }
 
-    if (newSettings.hasSeenSharingEnabledScreen
-        != this.globalSettings.hasSeenSharingEnabledScreen) {
-      this.globalSettings.hasSeenSharingEnabledScreen
-          = newSettings.hasSeenSharingEnabledScreen;
-    }
+    this.globalSettings.hasSeenSharingEnabledScreen =
+        newSettings.hasSeenSharingEnabledScreen;
+    this.globalSettings.hasSeenWelcome = newSettings.hasSeenWelcome;
   }
 
   /**

--- a/src/generic_ui/polymer/overlay.html
+++ b/src/generic_ui/polymer/overlay.html
@@ -21,14 +21,14 @@ Example:
 </style>
 
 <uproxy-overlay id='testOverlay' hasSeenBefore='hasSeenHelloWorld'>
-  <div id='message'>Hello World!<div>
+  <div class='message'>Hello World!<div>
 </uproxy-overlay>
 
 
 Two things you must do:
 
 1) The main text in the overlay MUST be provided in a div with the
-id='message'. This is so that the main text is automatically positioned,
+class='message'. This is so that the main text is automatically positioned,
 while other components of the overlay (e.g. the sharing enabled icon)
 can be otherwise positioned.
 
@@ -49,26 +49,21 @@ to track if the overlay has been seen.
         opacity: 0.8;
         color: white;
       }
-      polyfill-next-selector { content: '#message'; }
-      ::content #message {
+      polyfill-next-selector { content: '.message'; }
+      ::content .message {
         position: relative;
-        top: 15%;
         padding: 40px 40px 0px 40px;
       }
-      #gotItContainer {
-        position: relative;
-        top: 15%;
-        padding: 0px 40px 40px 40px;
-      }
       #gotIt {
+        display: inline-block;
+        margin-left: 40px;
+        margin-top: 2em;
         cursor: pointer;
       }
     </style>
 
-    <content></content><br><br>
-    <div id="gotItContainer">
-      <span id="gotIt" on-click='{{confirmSeen}}'>GOT IT</span>
-    </div>
+    <content></content>
+    <div id="gotIt" on-click='{{confirmSeen}}'>GOT IT</div>
 
   </template>
   <script src='overlay.js'></script>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -133,6 +133,23 @@
         height: 100%;
         width: 100%;
       }
+      #welcomeOverlay {
+        position: absolute;
+        left: 0px;
+        bottom: 0px;
+        height: 220px;
+        width: 100%;
+      }
+      #welcomeOverlay h1 {
+        margin-top: 0;
+      }
+      #welcomeOverlay ul {
+        line-height: 1.5em;
+        margin-bottom: 0;
+      }
+      #welcomeOverlay .welcomeGetShareLink {
+        cursor: pointer;
+      }
       #sharingEnabledBubble {
         position: absolute;
         right: 10px;
@@ -152,20 +169,41 @@
     <uproxy-splash id='splash' hidden?='{{UI.View.SPLASH!=ui.view}}'>
     </uproxy-splash>
 
-    <uproxy-overlay id='sharingEnabledInfo'
-         hidden?='{{(model.contacts.shareAccessContacts.onlineTrustedUproxy.length==0 && model.contacts.shareAccessContacts.offlineTrustedUproxy.length==0) || model.globalSettings.hasSeenSharingEnabledScreen || UI.View.ROSTER!=ui.view}}'
-         hasSeenBefore='hasSeenSharingEnabledScreen'>
-      <div id='sharingEnabledBubble'></div>
-      <img src='../icons/sharing-enabled-toolbar.png' class='sharingEnabled'>
-      <div id='message'>
-        <p id='sharingEnabledHeader'>Sharing enabled</p>
-        <br>
-        The icon in the top right means you're available for sharing access with friends you've offered access to.
-      </div>
-    </uproxy-overlay>
-
     <div id='logged-in-controls'
         hidden?='{{ UI.View.SPLASH==ui.view || !model.onlineNetwork }}'>
+
+      <uproxy-overlay id='welcomeOverlay'
+           hidden?='{{model.globalSettings.hasSeenWelcome}}'
+           hasSeenBefore='hasSeenWelcome'>
+         <div class='message'>
+           <h1>Welcome to uProxy</h1>
+           <div>To get started</div>
+           <ul>
+             <li>
+               Please select
+               <span class='welcomeGetShareLink' on-tap='{{setGetMode}}'>GET ACCESS</span> or
+               <span class='welcomeGetShareLink' on-tap='{{setShareMode}}'>SHARE ACCESS</span>
+             </li>
+             <li>
+               Click on a friend to
+               <span hidden?='{{ui.mode!=UI.Mode.GET}}'>ask for access</span>
+               <span hidden?='{{ui.mode!=UI.Mode.SHARE}}'>offer access</span>
+             </li>
+           </ul>
+         </div>
+      </uproxy-overlay>
+
+      <uproxy-overlay id='sharingEnabledInfo'
+           hidden?='{{(model.contacts.shareAccessContacts.onlineTrustedUproxy.length==0 && model.contacts.shareAccessContacts.offlineTrustedUproxy.length==0) || model.globalSettings.hasSeenSharingEnabledScreen || UI.View.ROSTER!=ui.view}}'
+           hasSeenBefore='hasSeenSharingEnabledScreen'>
+        <div id='sharingEnabledBubble'></div>
+        <img src='../icons/sharing-enabled-toolbar.png' class='sharingEnabled'>
+        <div class='message'>
+          <p id='sharingEnabledHeader'>Sharing enabled</p>
+          <br>
+          The icon in the top right means you're available for sharing access with friends you've offered access to.
+        </div>
+      </uproxy-overlay>
 
       <div id='toolbar'>
         <img src='../icons/hamburger.png' id='btnSettings'

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -68,9 +68,6 @@
     p {
       margin-top: 1em;
     }
-    .getShareButton {
-      margin-top: 2em;
-    }
     .prevArrow {
       position: absolute;
       left: 8px;
@@ -93,23 +90,6 @@
       </div>
       <uproxy-faq-link anchor='LearnMore'>
         Learn more about uProxy
-      </uproxy-faq-link>
-    </div>
-
-    <div id='getOrShare' hidden?='{{SPLASH_STATES.GET_OR_SHARE!==ui.splashState}}'>
-      <div class='view'>
-        <h1>How would you like to start?</h1>
-        <paper-button raised class='getShareButton' on-tap='{{setGetMode}}'>
-          Get access
-        </paper-button>
-        <p>... if you need to get access from a friend</p>
-        <paper-button raised class='getShareButton' on-tap='{{setShareMode}}'>
-          Share access
-        </paper-button>
-        <p>... if you have friends who may need to get access from you</p>
-      </div>
-      <uproxy-faq-link anchor='GetOrGive'>
-        Learn more about these
       </uproxy-faq-link>
     </div>
 

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -4,8 +4,7 @@
 Polymer({
   SPLASH_STATES: {
     INTRO: 0,
-    GET_OR_SHARE: 1,
-    NETWORKS: 2
+    NETWORKS: 1
   },
   networkNames: model.networkNames,
   ui: ui,
@@ -21,14 +20,6 @@ Polymer({
   },
   prev: function() {
     this.setState(ui.splashState - 1);
-  },
-  setGetMode: function() {
-    ui.mode = UI.Mode.GET;
-    this.next();
-  },
-  setShareMode: function() {
-    ui.mode = UI.Mode.SHARE;
-    this.next();
   },
   ready: function() {}
 });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -37,10 +37,11 @@ var model :UI.Model = {
       'offlineNonUproxy': []
     }
   },
-  globalSettings : {
-    'description' : '',
-    'stunServers' : [],
-    'hasSeenSharingEnabledScreen' : false
+  globalSettings: {
+    'description': '',
+    'stunServers': [],
+    'hasSeenSharingEnabledScreen': false,
+    'hasSeenWelcome': false
   }
 };
 
@@ -381,10 +382,6 @@ module UI {
       return Object.keys(this.instancesGivingAccessTo).length > 0;
     }
 
-    public bringUproxyToFront = () => {
-      this.browserApi.bringUproxyToFront();
-    }
-
     /**
      * Synchronize a new network to be visible on this UI.
      */
@@ -503,6 +500,10 @@ module UI {
 
     public openFaq = (pageAnchor ?:string) => {
       this.browserApi.openFaq(pageAnchor);
+    }
+
+    public bringUproxyToFront = () => {
+      this.browserApi.bringUproxyToFront();
     }
   }  // class UserInterface
 

--- a/src/interfaces/persistent.d.ts
+++ b/src/interfaces/persistent.d.ts
@@ -56,6 +56,7 @@ declare module Core {
     description :string;
     stunServers :Core.StunServer[];
     hasSeenSharingEnabledScreen :boolean;
+    hasSeenWelcome :boolean;
   }
 
   export interface StunServer {


### PR DESCRIPTION
Move get/share selection to welcome overlay: https://github.com/uProxy/uproxy/issues/543

Tested in Chrome, Firefox (UI still loads but can't login), grunt test
