### PR TITLE
Fix networkNames binding

### DIFF
--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -97,7 +97,7 @@
       <div class='view'>
         <h1>Where can you find your contacts the quickest?</h1>
         <p>Sign into a network to load your friends</p>
-        <template repeat='{{ n in networkNames }}' vertical layout>
+        <template repeat='{{ n in model.networkNames }}' vertical layout>
           <uproxy-network networkName='{{n}}'></uproxy-network>
         </template>
         <p style="margin-top: 0">

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -6,7 +6,7 @@ Polymer({
     INTRO: 0,
     NETWORKS: 1
   },
-  networkNames: model.networkNames,
+  model: model,
   ui: ui,
   setState: function(state) {
     if (state < 0 || state > Object.keys(this.SPLASH_STATES).length) {


### PR DESCRIPTION
Fix networkNames binding.  Binding to networkNames instead of model.networkNames meant that when we reassigned model.networkNames, the UI didn't get the latest values.

Tested in Chrome, grunt test
