### PR TITLE
Remove non-uproxy contacts, show if specific instances are online

### DIFF
--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -102,7 +102,7 @@ describe('Social.FreedomNetwork', () => {
         var freedomClientState :freedom_Social.ClientState = {
           userId: 'fakeuser',
           clientId: 'fakeclient',
-          status: 'ONLINE_WITH_OTHER_APP',
+          status: 'ONLINE',
           timestamp: 12345
         };
         // Add user to the roster;
@@ -110,7 +110,6 @@ describe('Social.FreedomNetwork', () => {
           expect(Object.keys(network.roster).length).toEqual(2);
           var friend = network.getUser('fakeuser');
           spyOn(friend, 'monitor');
-          expect(friend.isOnline()).toEqual(true);
           // Advance clock 5 seconds and make sure monitoring was called.
           jasmine.clock().tick(5000);
           expect(friend.monitor).toHaveBeenCalled();

--- a/src/generic_core/user.spec.ts
+++ b/src/generic_core/user.spec.ts
@@ -95,20 +95,6 @@ describe('Core.User', () => {
     expect(network.sendInstanceHandshake).not.toHaveBeenCalled();
   });
 
-  it('does not send instance messages to non-uProxy clients', () => {
-    network.sendInstanceHandshake.calls.reset();
-    var clientState :UProxyClient.State = {
-      userId: 'fakeuser',
-      clientId: 'fakeclient-not-uproxy',
-      status: UProxyClient.Status.ONLINE_WITH_OTHER_APP,
-      timestamp: 12345
-    };
-    user.handleClient(clientState);
-    expect(user.clientIdToStatusMap['fakeclient-not-uproxy']).toEqual(
-        UProxyClient.Status.ONLINE_WITH_OTHER_APP);
-    expect(network.sendInstanceHandshake).not.toHaveBeenCalled();
-  });
-
   it('deletes DISCONNECTED client', () => {
     var clientState :UProxyClient.State = {
       userId: 'fakeuser',

--- a/src/generic_core/user.spec.ts
+++ b/src/generic_core/user.spec.ts
@@ -95,6 +95,17 @@ describe('Core.User', () => {
     expect(network.sendInstanceHandshake).not.toHaveBeenCalled();
   });
 
+  it('does not add clients that are ONLINE_WITH_OTHER_APP', () => {
+    var clientState :UProxyClient.State = {
+      userId: 'fakeuser',
+      clientId: 'fakeNonUproxyClient',
+      status: UProxyClient.Status.ONLINE_WITH_OTHER_APP,
+      timestamp: 12346
+    };
+    user.handleClient(clientState);
+    expect(user.clientIdToStatusMap['fakeNonUproxyClient']).not.toBeDefined();
+  });
+
   it('deletes DISCONNECTED client', () => {
     var clientState :UProxyClient.State = {
       userId: 'fakeuser',

--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -1,7 +1,7 @@
 <link rel='import' href='../lib/polymer/polymer.html'>
 <link rel='import' href='instance.html'>
 
-<polymer-element name='uproxy-contact' attributes='contact'>
+<polymer-element name='uproxy-contact' attributes='contact, isOnline'>
 
   <template>
     <style>
@@ -27,15 +27,13 @@
       -webkit-transition: all 0.23s !important;
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
+      cursor: pointer;
     }
     #avatar {
       width: 36px; height: 36px;
       margin: 8px; border: none; border-radius: 50%;
       background-color: #eee;
       vertical-align: top;
-    }
-    .offline {
-      opacity: 0.5;
     }
     #words {
       display: inline-block;
@@ -55,7 +53,7 @@
     .accessIcon {
       vertical-align: middle;
     }
-    .hasInstances #words:hover h1 {
+    #words:hover h1 {
       color: #aaa;
     }
     #instances {
@@ -64,13 +62,14 @@
     #actions {
       padding: 8px;
     }
-    .hasInstances {
-      cursor: pointer;
+    .offline #avatar,
+    .offline .nameRow {
+      opacity: 0.5;
     }
     </style>
 
     <div tabindex='-1' id='frame'
-        class='{{ contact.expanded ? "expanded" : "" }} {{ contact.instances.length > 0 ? "hasInstances" : "" }} {{ contact.isOnline ? "online" : "offline" }} '>
+        class='{{ contact.expanded ? "expanded" : "" }} {{ isOnline ? "online" : "offline" }}'>
      <!-- on-blur='{{ collapse }}'> -->
       <img id='avatar' src='{{ contact.imageData }}' on-tap='{{ toggle }}'/>
       <div id='words'>

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -10,6 +10,9 @@
       padding-bottom: 8px;
       border-top: 1px solid rgb(221, 221, 221);
     }
+    #wrapper.offline {
+      opacity: 0.5;
+    }
     paper-button {
       background: rgb(221, 221, 221);
       color: rgb(112, 112, 112);
@@ -47,77 +50,81 @@
     }
     </style>
 
-    <div id='description' hidden?='{{ !instance.description }}'>
-      {{ instance.description }}
-    </div>
+    <div id='wrapper' class='{{ instance.isOnline ? "online" : "offline" }}'>
 
-    <!-- TODO(jetpack): replace these state-dependent buttons with
-    simpler UI, exposing state bits directly. -->
-    <div id='getControls' hidden?='{{ui.mode!=UI.Mode.GET}}'>
-
-      <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal ) }}'>
-        <p class='highlighted'>
-          <img src='../icons/checkmark.png'> {{user.name || user.userId }} has granted you access
-        </p>
-        <paper-button class='highlightedButton' raised
-            hidden?='{{ instance.access.asProxy }}' on-tap='{{ start }}'>
-          Start getting access
-        </paper-button>
-        <paper-button raised hidden?='{{ !instance.access.asProxy }}' on-tap='{{ stop }}'>
-          Stop getting access
-        </paper-button>
+      <div id='description' hidden?='{{ !instance.description }}'>
+        {{ instance.description }}
       </div>
 
-      <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && !getConsentState().remoteGrantsAccessToLocal ) }}'>
-        <p class='preButtonText askingText'><img src='../icons/clock.png'> Asking for access</p>
-        <p class='preButtonText'>You will be able to get access when they accept.</p>
-        <paper-button raised on-tap='{{ cancelRequest }}'>Cancel Request</paper-button>
+      <!-- TODO(jetpack): replace these state-dependent buttons with
+      simpler UI, exposing state bits directly. -->
+      <div id='getControls' hidden?='{{ui.mode!=UI.Mode.GET}}'>
+
+        <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal ) }}'>
+          <p class='highlighted'>
+            <img src='../icons/checkmark.png'> {{user.name || user.userId }} has granted you access
+          </p>
+          <paper-button class='highlightedButton' raised
+              hidden?='{{ instance.access.asProxy }}' on-tap='{{ start }}'>
+            Start getting access
+          </paper-button>
+          <paper-button raised hidden?='{{ !instance.access.asProxy }}' on-tap='{{ stop }}'>
+            Stop getting access
+          </paper-button>
+        </div>
+
+        <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && !getConsentState().remoteGrantsAccessToLocal ) }}'>
+          <p class='preButtonText askingText'><img src='../icons/clock.png'> Asking for access</p>
+          <p class='preButtonText'>You will be able to get access when they accept.</p>
+          <paper-button raised on-tap='{{ cancelRequest }}'>Cancel Request</paper-button>
+        </div>
+
+        <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal && !getConsentState().ignoringRemoteUserOffer ) }}'>
+          <p class='preButtonText'>They've offered you access.</p>
+          <paper-button class='highlightedButton' raised on-tap='{{ request }}'>Accept Offer</paper-button>
+          <paper-button class='highlightedButton' raised on-tap='{{ ignoreOffer }}'>Decline</paper-button>
+        </div>
+
+        <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal && getConsentState().ignoringRemoteUserOffer ) }}'>
+          <p class='preButtonText'>They've offered you access.</p>
+          <paper-button raised on-tap='{{ unignoreOffer }}'>Stop ignoring offers</paper-button>
+        </div>
+
+        <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && !getConsentState().remoteGrantsAccessToLocal ) }}'>
+          <paper-button raised class='highlightedButton' on-tap='{{ request }}'>
+            Ask for access
+          </paper-button>
+        </div>
+
       </div>
 
-      <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal && !getConsentState().ignoringRemoteUserOffer ) }}'>
-        <p class='preButtonText'>They've offered you access.</p>
-        <paper-button class='highlightedButton' raised on-tap='{{ request }}'>Accept Offer</paper-button>
-        <paper-button class='highlightedButton' raised on-tap='{{ ignoreOffer }}'>Decline</paper-button>
-      </div>
+      <div id='shareControls' hidden?='{{ui.mode!=UI.Mode.SHARE}}'>
 
-      <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal && getConsentState().ignoringRemoteUserOffer ) }}'>
-        <p class='preButtonText'>They've offered you access.</p>
-        <paper-button raised on-tap='{{ unignoreOffer }}'>Stop ignoring offers</paper-button>
-      </div>
+        <div hidden?='{{ !( getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal ) }}'>
+          <p class='preButtonText'>You've given them access.</p>
+          <paper-button raised on-tap='{{ cancelOffer }}'>Revoke Access</paper-button>
+        </div>
 
-      <div hidden?='{{ !( !getConsentState().localRequestsAccessFromRemote && !getConsentState().remoteGrantsAccessToLocal ) }}'>
-        <paper-button raised class='highlightedButton' on-tap='{{ request }}'>
-          Ask for access
-        </paper-button>
-      </div>
+        <div hidden?='{{ !( getConsentState().localGrantsAccessToRemote && !getConsentState().remoteRequestsAccessFromLocal ) }}'>
+          <paper-button raised on-tap='{{ cancelOffer }}'>Cancel Offer</paper-button>
+        </div>
 
-    </div>
+        <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal && !getConsentState().ignoringRemoteUserRequest ) }}'>
+          <p class='preButtonText'>They requested access through you.</p>
+          <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Grant</paper-button>
+          <paper-button raised class='highlightedButton' on-tap='{{ ignoreRequest }}'>Ignore</paper-button>
+        </div>
 
-    <div id='shareControls' hidden?='{{ui.mode!=UI.Mode.SHARE}}'>
+        <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal && getConsentState().ignoringRemoteUserRequest ) }}'>
+          <p class='preButtonText'>They requested access through you.</p>
+          <paper-button raised on-tap='{{ unignoreRequest }}'>Stop ignoring requests</paper-button>
+        </div>
 
-      <div hidden?='{{ !( getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal ) }}'>
-        <p class='preButtonText'>You've given them access.</p>
-        <paper-button raised on-tap='{{ cancelOffer }}'>Revoke Access</paper-button>
-      </div>
+        <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && !getConsentState().remoteRequestsAccessFromLocal ) }}'>
+          <p class='preButtonText'>You have not granted them access.</p>
+          <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Offer Access</paper-button>
+        </div>
 
-      <div hidden?='{{ !( getConsentState().localGrantsAccessToRemote && !getConsentState().remoteRequestsAccessFromLocal ) }}'>
-        <paper-button raised on-tap='{{ cancelOffer }}'>Cancel Offer</paper-button>
-      </div>
-
-      <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal && !getConsentState().ignoringRemoteUserRequest ) }}'>
-        <p class='preButtonText'>They requested access through you.</p>
-        <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Grant</paper-button>
-        <paper-button raised class='highlightedButton' on-tap='{{ ignoreRequest }}'>Ignore</paper-button>
-      </div>
-
-      <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && getConsentState().remoteRequestsAccessFromLocal && getConsentState().ignoringRemoteUserRequest ) }}'>
-        <p class='preButtonText'>They requested access through you.</p>
-        <paper-button raised on-tap='{{ unignoreRequest }}'>Stop ignoring requests</paper-button>
-      </div>
-
-      <div hidden?='{{ !( !getConsentState().localGrantsAccessToRemote && !getConsentState().remoteRequestsAccessFromLocal ) }}'>
-        <p class='preButtonText'>You have not granted them access.</p>
-        <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Offer Access</paper-button>
       </div>
 
     </div>

--- a/src/generic_ui/polymer/roster-group.html
+++ b/src/generic_ui/polymer/roster-group.html
@@ -20,13 +20,15 @@
 
     <template repeat='{{ c in onlineContacts }}' vertical layout>
       <uproxy-contact contact='{{ c }}'
-          hidden?='{{ hideForSearch(c.name, searchQuery) }}'>
+          hidden?='{{ hideForSearch(c.name, searchQuery) }}'
+          isOnline='{{ true }}'>
       </uproxy-contact>
     </template>
 
     <template repeat='{{ c in offlineContacts }}' vertical layout>
       <uproxy-contact contact='{{ c }}'
-          hidden?='{{ hideForSearch(c.name, searchQuery) }}'>
+          hidden?='{{ hideForSearch(c.name, searchQuery) }}'
+          isOnline='{{ false }}'>
       </uproxy-contact>
     </template>
 

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -60,17 +60,6 @@
         offlineContacts='{{ offlineUntrustedUproxyContacts }}'
         searchQuery='{{ searchQuery }}'></uproxy-roster-group>
 
-    <!-- Hide HR if there are no Non-uProxy contacts, or if there are only Non-uProxy contacts -->
-    <hr color="#eee"
-        hidden?='{{ (onlineNonUproxyContacts.length == 0 && offlineNonUproxyContacts.length == 0) || ((onlineUntrustedUproxyContacts.length == 0 && offlineUntrustedUproxyContacts.length == 0) && (onlineTrustedUproxyContacts.length == 0 && offlineTrustedUproxyContacts.length == 0) && (onlinePending.length == 0 && offlinePending.length == 0)) }}'></hr>
-
-    <!-- non uProxy contacts -->
-    <uproxy-roster-group
-        groupTitle='Non uProxy Contacts'
-        onlineContacts='{{ onlineNonUproxyContacts }}'
-        offlineContacts='{{ offlineNonUproxyContacts }}'
-        searchQuery='{{ searchQuery }}'></uproxy-roster-group>
-
   </template>
 
   <script src='roster.js'></script>

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -23,8 +23,6 @@ Polymer({
     this.offlineTrustedUproxyContacts = this.contacts.offlineTrustedUproxy;
     this.onlineUntrustedUproxyContacts = this.contacts.onlineUntrustedUproxy;
     this.offlineUntrustedUproxyContacts = this.contacts.offlineUntrustedUproxy;
-    this.onlineNonUproxyContacts = this.contacts.onlineNonUproxy;
-    this.offlineNonUproxyContacts = this.contacts.offlineNonUproxy;
   },
   searchQuery: ''
 });

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -35,8 +35,7 @@ describe('UI.UserInterface', () => {
       user: {
         userId: userId,
         name: userName,
-        imageData: 'testImageData',
-        isOnline: true
+        imageData: 'testImageData'
       },
       instances: [{
         instanceId: instanceId,
@@ -64,27 +63,28 @@ describe('UI.UserInterface', () => {
         user: {
           userId: 'testUserId',
           name: 'Alice',
-          imageData: 'testImageData',
-          isOnline: true
+          imageData: 'testImageData'
         },
-        instances: []
+        instances: [{
+          instanceId: 'instance1',
+          description: 'description1',
+          consent: new Consent.State(),
+          access: {asClient: false, asProxy: false},
+          isOnline: true,
+          bytesSent: 0,
+          bytesReceived: 0
+        }]
       };
       ui.syncUser(payload);
       var user :UI.User = model.onlineNetwork.roster['testUserId'];
       expect(user).toBeDefined();
-      expect(model.contacts.getAccessContacts.onlineNonUproxy.length).toEqual(1);
-      expect(model.contacts.getAccessContacts.onlineNonUproxy[0]).toEqual(user);
-      expect(model.contacts.getAccessContacts.offlineNonUproxy.length).toEqual(0);
       expect(model.contacts.getAccessContacts.onlineTrustedUproxy.length).toEqual(0);
       expect(model.contacts.getAccessContacts.offlineTrustedUproxy.length).toEqual(0);
-      expect(model.contacts.getAccessContacts.onlineUntrustedUproxy.length).toEqual(0);
+      expect(model.contacts.getAccessContacts.onlineUntrustedUproxy.length).toEqual(1);
       expect(model.contacts.getAccessContacts.offlineUntrustedUproxy.length).toEqual(0);
-      expect(model.contacts.shareAccessContacts.onlineNonUproxy.length).toEqual(1);
-      expect(model.contacts.shareAccessContacts.onlineNonUproxy[0]).toEqual(user);
-      expect(model.contacts.shareAccessContacts.offlineNonUproxy.length).toEqual(0);
       expect(model.contacts.shareAccessContacts.onlineTrustedUproxy.length).toEqual(0);
       expect(model.contacts.shareAccessContacts.offlineTrustedUproxy.length).toEqual(0);
-      expect(model.contacts.shareAccessContacts.onlineUntrustedUproxy.length).toEqual(0);
+      expect(model.contacts.shareAccessContacts.onlineUntrustedUproxy.length).toEqual(1);
       expect(model.contacts.shareAccessContacts.offlineUntrustedUproxy.length).toEqual(0);
     });
 
@@ -121,8 +121,7 @@ describe('UI.UserInterface', () => {
         user: {
           userId: 'testUserId',
           name: 'Alice',
-          imageData: 'testImageData',
-          isOnline: true
+          imageData: 'testImageData'
         },
         instances: [clientInstance, serverInstance]
       };

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -23,9 +23,7 @@ var model :UI.Model = {
       'onlineTrustedUproxy': [],
       'offlineTrustedUproxy': [],
       'onlineUntrustedUproxy': [],
-      'offlineUntrustedUproxy': [],
-      'onlineNonUproxy': [],
-      'offlineNonUproxy': []
+      'offlineUntrustedUproxy': []
     },
     'shareAccessContacts': {
       'onlinePending': [],
@@ -33,9 +31,7 @@ var model :UI.Model = {
       'onlineTrustedUproxy': [],
       'offlineTrustedUproxy': [],
       'onlineUntrustedUproxy': [],
-      'offlineUntrustedUproxy': [],
-      'onlineNonUproxy': [],
-      'offlineNonUproxy': []
+      'offlineUntrustedUproxy': []
     }
   },
   globalSettings: {
@@ -61,8 +57,6 @@ module UI {
       offlineTrustedUproxy :UI.User[];
       onlineUntrustedUproxy :UI.User[];
       offlineUntrustedUproxy :UI.User[];
-      onlineNonUproxy :UI.User[];
-      offlineNonUproxy :UI.User[];
     };
     shareAccessContacts : {
       onlinePending :UI.User[];
@@ -71,8 +65,6 @@ module UI {
       offlineTrustedUproxy :UI.User[];
       onlineUntrustedUproxy :UI.User[];
       offlineUntrustedUproxy :UI.User[];
-      onlineNonUproxy :UI.User[];
-      offlineNonUproxy :UI.User[];
     }
   }
 
@@ -420,6 +412,10 @@ module UI {
         // get an update for the user when the peerconnection has closed - in
         // this case the user should already have been removed from the roster
         // in the UI and stay removed.
+        return;
+      } else if (payload.instances.length === 0) {
+        // Core should not send the UI any Users without instances.
+        console.error('Received User with no instances', payload);
         return;
       }
 

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -33,8 +33,7 @@ describe('UI.User', () => {
       userId: 'fakeuser',
       name: 'fakename',
       imageData: 'fakeimage.uri',
-      timestamp: Date.now(),
-      isOnline: true
+      timestamp: Date.now()
     });
     expect(user.name).toEqual('fakename');
     expect(user.imageData).toEqual('fakeimage.uri');

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -45,6 +45,8 @@ module UI {
     // Returns two strings, where each matches an array name in model.contacts.
     // Does not use an enum because we need a string value, and typescript
     // enums evaluate to numbers.
+    // CONSIDER: Avoid strings for values and string-param dependencies
+    // https://github.com/uProxy/uproxy/issues/769
     public getCategories = () : UI.UserCategories => {
       var isOnline = false;
       var isTrustedForSharing = false;

--- a/src/interfaces/ui.d.ts
+++ b/src/interfaces/ui.d.ts
@@ -22,7 +22,6 @@ declare module UI {
     userId       :string;
     name         ?:string;
     imageData    ?:string; // Image URI (e.g. data:image/png;base64,adkwe329...)
-    isOnline     :boolean;
   }
 
   export interface UserMessage {

--- a/src/uistatic/scripts/dependencies.ts
+++ b/src/uistatic/scripts/dependencies.ts
@@ -23,8 +23,7 @@ function generateFakeUserMessage() :UI.UserMessage {
     user: {
       userId: 'alice',
       name: 'Alice uProxy',
-      timestamp: Date.now(),
-      isOnline: true
+      timestamp: Date.now()
     },
     instances: [
       {


### PR DESCRIPTION
Fix for https://github.com/uProxy/uproxy/issues/718 and https://github.com/uProxy/uproxy/issues/699
* Remove non-uProxy contacts from the uProxy UI
 * Clients that are ONLINE_WITH_OTHER_APP are ignored in the core
 * User objects with no instances are not sent to the UI
* Removed user.isOnline method in core and property in UI.  Now the core only tells the UI which instances are online (rather than which user).  The UI then uses the existing model.contacts categories to tell whether a user is online (i.e. whether any of their instances are online), so there is no need for a redundant user.isOnline property.
* Now showing which instances are online in the UI (offline instances appear 0.5 opacity) - before this change it was impossible to tell which instances were online for multi-instance users.

Tested in Chrome, Firefox, updated grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/757)
<!-- Reviewable:end -->
