### PR TITLE
Show "Trying to get access from <name>" and cancel button after clicking start

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -328,11 +328,15 @@ class uProxyCore implements uProxy.CoreAPI {
       console.error(err);
       return Promise.reject(err);
     }
-    // remote.start will send an update to the UI.
+    // Remember this instance as our proxy.  Set this before start fulfills
+    // in case the user decides to cancel the proxy before it begins.
+    remoteProxyInstance = remote;
     return remote.start().then((endpoint:Net.Endpoint) => {
-      // Remember this instance as our proxy.
-      remoteProxyInstance = remote;
+      // remote.start will send an update to the UI.
       return endpoint;
+    }).catch((e) => {
+      console.error('Error starting proxy: ', e);
+      remoteProxyInstance = null;
     });
   }
 

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -432,35 +432,38 @@ describe('Core.RemoteInstance', () => {
     };
 
     it('can start proxying', (done) => {
+      expect(alice.access.localGettingFromRemote).toEqual(GettingState.NONE);
       alice.consent.localRequestsAccessFromRemote = true;
       alice.consent.remoteGrantsAccessToLocal = true;
       // The module & constructor of SocksToRtc may change in the near future.
       spyOn(SocksToRtc, 'SocksToRtc').and.returnValue(fakeSocksToRtc);
       console.log(JSON.stringify(SocksToRtc));
       alice.start().then(() => {
-        expect(alice.access.asProxy).toEqual(true);
+        expect(alice.access.localGettingFromRemote)
+            .toEqual(GettingState.GETTING_ACCESS);
         done();
       });
       expect(SocksToRtc.SocksToRtc).toHaveBeenCalled();
-      expect(alice.access.asProxy).toEqual(false);
+      expect(alice.access.localGettingFromRemote)
+          .toEqual(GettingState.TRYING_TO_GET_ACCESS);
     });
 
     it('can stop proxying', () => {
       alice.stop();
-      expect(alice.access.asProxy).toEqual(false);
+      expect(alice.access.localGettingFromRemote).toEqual(GettingState.NONE);
     });
 
     it('refuses to start proxy without permission', () => {
       spyOn(SocksToRtc, 'SocksToRtc').and.returnValue(fakeSocksToRtc);
       alice.consent = new Consent.State();
-      alice.access.asProxy = false;
+      alice.access.localGettingFromRemote = GettingState.NONE;
       alice.start();
-      expect(alice.access.asProxy).toEqual(false);
+      expect(alice.access.localGettingFromRemote).toEqual(GettingState.NONE);
     });
 
     it('does not stop proxying when already stopped', () => {
       alice.stop();
-      expect(alice.access.asProxy).toEqual(false);
+      expect(alice.access.localGettingFromRemote).toEqual(GettingState.NONE);
     });
 
   });  // describe proxying

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -47,8 +47,8 @@ module Core {
     // Current proxy access activity of the remote instance with respect to the
     // local instance of uProxy.
     public access      :AccessState = {
-      asClient: false,
-      asProxy:  false
+      localGettingFromRemote:  GettingState.NONE,
+      localSharingWithRemote: SharingState.NONE
     };
     private transport  :Transport;
     // Whether or not there is a UI update (triggered by this.user.notifyUI())
@@ -189,7 +189,7 @@ module Core {
                 this.rtcNetPcConfig, this.rtcNetProxyConfig);
             this.rtcToNet_.onceClosed.then(() => {
               console.log('rtcToNet_.onceClosed called');
-              this.access.asClient = false;
+              this.access.localSharingWithRemote = SharingState.NONE;
               ui.update(uProxy.Update.STOP_GIVING_TO_FRIEND, this.instanceId);
               this.rtcToNet_ = null;
               this.bytesSent = 0;
@@ -220,9 +220,12 @@ module Core {
               this.updateBytesInUI();
             });
             this.rtcToNet_.onceReady.then(() => {
-              this.access.asClient = true;
+              this.access.localSharingWithRemote = SharingState.SHARING_ACCESS;
               ui.update(uProxy.Update.START_GIVING_TO_FRIEND, this.instanceId);
               this.user.notifyUI();
+            }).catch((e) => {
+              console.error('error start rtcToNet: ', e);
+              this.rtcToNet_ = null;
             });
           }
           // TODO: signalFromRemote needs to get converted into a
@@ -257,7 +260,7 @@ module Core {
       if (!this.consent.remoteGrantsAccessToLocal) {
         console.warn('Lacking permission to proxy!');
         return Promise.reject('Lacking permission to proxy!');
-      } else if (this.access.asProxy) {
+      } else if (this.access.localGettingFromRemote !== GettingState.NONE) {
         // This should not happen. If it does, something else is broken. Still, we
         // continue to actually proxy through the instance.
         console.warn('Already proxying through ' + this.instanceId);
@@ -278,6 +281,7 @@ module Core {
           address: '127.0.0.1',
           port: 0
       }
+
       this.socksToRtc_ = new SocksToRtc.SocksToRtc();
       this.socksToRtc_.on('signalForPeer', (signal) => {
         this.send({
@@ -285,6 +289,7 @@ module Core {
           data: signal
         });
       });
+
       // When bytes are sent to or received through the proxy, notify the
       // UI about the increase in data exchanged. Increment the bytes
       // sent/received variables in real time, but use a timer to control
@@ -297,57 +302,68 @@ module Core {
         this.bytesSent += numBytes;
         this.updateBytesInUI();
       });
+
       this.socksToRtc_.on('stopped', () => {
         console.log('socksToRtc_.once(\'stopped\', ...) called');
+        // Stopped event is only considered an error if the user had been
+        // getting access and we hadn't called this.socksToRtc_.stop
+        // If there is an error when trying to start proxying, and a stopped
+        // event is fired, an error will be displayed as a result of the start
+        // promise rejecting.
+        var isError =
+            this.access.localGettingFromRemote == GettingState.GETTING_ACCESS;
         ui.update(uProxy.Update.STOP_GETTING_FROM_FRIEND,
-                  {instanceId: this.instanceId,
-                   error: this.access.asProxy});
-        this.access.asProxy = false;
+                  {instanceId: this.instanceId, error: isError});
+
+        this.access.localGettingFromRemote = GettingState.NONE;
         this.bytesSent = 0;
         this.bytesReceived = 0;
-        // TODO: notification to the user on remote-close?
         this.user.notifyUI();
         this.socksToRtc_ = null;
         // Update global remoteProxyInstance to indicate we are no longer
         // getting access.
         remoteProxyInstance = null;
       });
+
+      // Set flag to indicate that we are currently trying to get access
+      this.access.localGettingFromRemote = GettingState.TRYING_TO_GET_ACCESS;
+      this.user.notifyUI();
+
       return this.socksToRtc_.start(
           endpoint,
           this.socksRtcPcConfig)
         .then((endpoint:Net.Endpoint) => {
           console.log('Proxy now ready through ' + this.user.userId);
-          this.access.asProxy = true;
+          this.access.localGettingFromRemote = GettingState.GETTING_ACCESS;
           this.user.notifyUI();
           return endpoint;
-        })
-        // TODO: remove catch & error print: that should happen at the level
-        // above.
-        .catch((e:Error) => {
-          console.error('Could not start proxy through ' + this.user.userId +
+        }).catch((e:Error) => {
+          // This may not be an error if the user cancelled proxying
+          // before start had a chance to complete.  In that case a 'stopped'
+          // event should still be emitted, and all cleanup can happen there.
+          console.warn('Could not start proxy through ' + this.user.userId +
               '; ' + e.toString());
+          this.access.localGettingFromRemote = GettingState.NONE;
           return Promise.reject('Could not start proxy');
         });
     }
 
     public updateClientProxyConnection = (isConnected :boolean) => {
-      this.access.asClient = isConnected;
+      this.access.localSharingWithRemote =
+          isConnected ? SharingState.SHARING_ACCESS : SharingState.NONE;
       this.user.notifyUI();
     }
 
     /**
      * Stop using this remote instance as a proxy server.
      */
-    public stop = () :void => {
-      if (!this.access.asProxy) {
+    public stop = () : void => {
+      if (this.access.localGettingFromRemote === GettingState.NONE) {
         console.warn('Cannot stop proxying when not proxying.');
         return;
       }
-      this.access.asProxy = false;
-
+      this.access.localGettingFromRemote = GettingState.NONE;
       this.socksToRtc_.stop();
-      // TODO: Remove the access.asProxy/asClient, maybe replace with getters
-      // once whether socksToRtc_ or rtcToNet_ objects are null means the same.
     }
 
     /**
@@ -379,7 +395,8 @@ module Core {
       }
       // If remote is currently an active client, but user revokes access, also
       // stop the proxy session.
-      if (Consent.UserAction.CANCEL_OFFER === action && this.access.asClient) {
+      if (Consent.UserAction.CANCEL_OFFER === action &&
+          this.access.localSharingWithRemote == SharingState.SHARING_ACCESS) {
         this.rtcToNet_.close();
       }
       // Send new consent bits to the remote client, and save to storage.

--- a/src/generic_ui/index.html
+++ b/src/generic_ui/index.html
@@ -8,6 +8,7 @@
 
   <script src='scripts/ui_enums.js'></script>
   <script src='scripts/dependencies.js'></script>
+  <script src='scripts/uproxy.js'></script>
 
   <link rel='import' href='polymer/vulcanized.html'>
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -42,7 +42,7 @@
     p.askingText {
       margin-bottom: 0;
     }
-    p.askingText img {
+    img.clock {
       vertical-align: bottom;
     }
     </style>
@@ -56,20 +56,36 @@
     <div id='getControls' hidden?='{{ui.mode!=UI.Mode.GET}}'>
 
       <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && getConsentState().remoteGrantsAccessToLocal ) }}'>
-        <p class='highlighted'>
-          <img src='../icons/checkmark.png'> {{user.name || user.userId }} has granted you access
-        </p>
-        <paper-button class='highlightedButton' raised
-            hidden?='{{ instance.access.asProxy }}' on-tap='{{ start }}'>
-          Start getting access
-        </paper-button>
-        <paper-button raised hidden?='{{ !instance.access.asProxy }}' on-tap='{{ stop }}'>
-          Stop getting access
-        </paper-button>
+        <!-- not getting or trying to get access -->
+        <div hidden?='{{ instance.access.localGettingFromRemote != GettingState.NONE }}'>
+          <p class='highlighted'>
+            <img src='../icons/checkmark.png'> {{user.name || user.userId }} has granted you access
+          </p>
+          <paper-button class='highlightedButton' raised on-tap='{{ start }}'>
+            Start getting access
+          </paper-button>
+        </div>
+
+        <!-- trying to get access -->
+        <div hidden?='{{ instance.access.localGettingFromRemote != GettingState.TRYING_TO_GET_ACCESS }}'>
+          <p class='preButtonText'>
+            <img src='../icons/clock.png' class='clock'> Trying to get access from {{user.name || user.userId }}
+          </p>
+          <paper-button raised on-tap='{{ stop }}'>
+            Cancel
+          </paper-button>
+        </div>
+
+        <!-- currently getting access -->
+        <div hidden?='{{ instance.access.localGettingFromRemote != GettingState.GETTING_ACCESS }}'>
+          <paper-button raised on-tap='{{ stop }}'>
+            Stop getting access
+          </paper-button>
+        </div>
       </div>
 
       <div hidden?='{{ !( getConsentState().localRequestsAccessFromRemote && !getConsentState().remoteGrantsAccessToLocal ) }}'>
-        <p class='preButtonText askingText'><img src='../icons/clock.png'> Asking for access</p>
+        <p class='preButtonText askingText'><img src='../icons/clock.png' class='clock'> Asking for access</p>
         <p class='preButtonText'>You will be able to get access when they accept.</p>
         <paper-button raised on-tap='{{ cancelRequest }}'>Cancel Request</paper-button>
       </div>

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -1,4 +1,6 @@
 Polymer({
+  // Make GettingState enum available to polymer
+  GettingState: GettingState,
 
   ready: function() {
     this.path = <InstancePath>{
@@ -21,6 +23,8 @@ Polymer({
       console.log('[polymer] received core.start promise fulfillment.');
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
+    }).catch((e) => {
+      ui.showNotification('Unable to get access from ' + this.user.name);
     });
   },
   stop: function() {

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -42,7 +42,8 @@ describe('UI.UserInterface', () => {
         instanceId: instanceId,
         description: 'description1',
         consent: new Consent.State(),
-        access: {asClient: false, asProxy: false},
+        access: {localSharingWithRemote: SharingState.NONE,
+                 localGettingFromRemote: GettingState.NONE},
         isOnline: true,
         bytesSent: 0,
         bytesReceived: 0
@@ -98,7 +99,8 @@ describe('UI.UserInterface', () => {
         instanceId: 'instance1',
         description: 'description1',
         consent: new Consent.State(),
-        access: {asClient: false, asProxy: false},
+        access: {localSharingWithRemote: SharingState.NONE,
+                 localGettingFromRemote: GettingState.NONE},
         isOnline: true,
         bytesSent: 0,
         bytesReceived: 0
@@ -109,7 +111,8 @@ describe('UI.UserInterface', () => {
         instanceId: 'instance2',
         description: 'description2',
         consent: new Consent.State(),
-        access: {asClient: false, asProxy: false},
+        access: {localSharingWithRemote: SharingState.NONE,
+                 localGettingFromRemote: GettingState.NONE},
         isOnline: true,
         bytesSent: 0,
         bytesReceived: 0

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -15,7 +15,8 @@ describe('UI.User', () => {
       instanceId: id,
       description: description,
       consent: new Consent.State(),
-      access: {asClient: false, asProxy: false},
+      access: {localSharingWithRemote: SharingState.NONE,
+               localGettingFromRemote: GettingState.NONE},
       isOnline: true,
       bytesSent: 0,
       bytesReceived: 0

--- a/src/interfaces/instance.d.ts
+++ b/src/interfaces/instance.d.ts
@@ -20,12 +20,6 @@ interface ConsentMessage {
   consent    :Consent.WireState;
 }
 
-// Describing whether or not a remote instance is currently accessing or not,
-// assuming consent is GRANTED for that particular pathway.
-interface AccessState {
-  asClient :boolean;
-  asProxy  :boolean;
-}
 interface NetworkInfo {
   name :string;
   userId :string;

--- a/src/uistatic/scripts/dependencies.ts
+++ b/src/uistatic/scripts/dependencies.ts
@@ -33,8 +33,8 @@ function generateFakeUserMessage() :UI.UserMessage {
         isOnline: true,
         consent: new Consent.State(),
         access: {
-          asClient: false,
-          asProxy: false
+          localSharingWithRemote: LocalSharingWithRemote.NONE,
+          localGettingFromRemote: GettingState.NONE
         },
         bytesSent: 0,
         bytesReceived: 0

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -256,3 +256,20 @@ interface OAuthInfo {
   url :string;
   redirect :string
 }
+
+
+// Describing whether or not a remote instance is currently accessing or not,
+// assuming consent is GRANTED for that particular pathway.
+enum GettingState {
+  NONE = 100,
+  TRYING_TO_GET_ACCESS,
+  GETTING_ACCESS
+};
+enum SharingState {
+  NONE = 200,
+  SHARING_ACCESS
+};
+interface AccessState {
+  localGettingFromRemote :GettingState;
+  localSharingWithRemote :SharingState;
+}


### PR DESCRIPTION
Front-end / UX work for https://github.com/uProxy/uproxy/issues/754
* After clicking start, shows "Trying to get access from <name>" and a cancel button
* Show error popup if proxying fails to start (socksToRtc.start rejects).  This will show both if there is an error starting proxying, or if the user cancels proxying before it starts (if needed we could skip the error message if the user clicks cancel, but it's much simpler in the code to just show it any time socksToRtc.start rejects)
* Rename access booleans and use enums (e.g. asProxy with values true/false is now localGettingFromRemote with values "NONE", "TRYING_TO_GET_ACCESS", and "GETTING_ACCESS")

Tested in Chrome, Firefox, and update grunt test