### PR TITLE
Remove access fields from tests, uistatic

### DIFF
--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -42,8 +42,8 @@ describe('UI.UserInterface', () => {
         instanceId: instanceId,
         description: 'description1',
         consent: new Consent.State(),
-        access: {localSharingWithRemote: SharingState.NONE,
-                 localGettingFromRemote: GettingState.NONE},
+        localSharingWithRemote: SharingState.NONE,
+        localGettingFromRemote: GettingState.NONE,
         isOnline: true,
         bytesSent: 0,
         bytesReceived: 0

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -15,8 +15,8 @@ describe('UI.User', () => {
       instanceId: id,
       description: description,
       consent: new Consent.State(),
-      access: {localSharingWithRemote: SharingState.NONE,
-               localGettingFromRemote: GettingState.NONE},
+      localSharingWithRemote: SharingState.NONE,
+      localGettingFromRemote: GettingState.NONE,
       isOnline: true,
       bytesSent: 0,
       bytesReceived: 0

--- a/src/uistatic/scripts/dependencies.ts
+++ b/src/uistatic/scripts/dependencies.ts
@@ -32,10 +32,8 @@ function generateFakeUserMessage() :UI.UserMessage {
         description: 'fake instance for alice',
         isOnline: true,
         consent: new Consent.State(),
-        access: {
-          localSharingWithRemote: SharingState.NONE,
-          localGettingFromRemote: GettingState.NONE
-        },
+        localSharingWithRemote: SharingState.NONE,
+        localGettingFromRemote: GettingState.NONE,
         bytesSent: 0,
         bytesReceived: 0
       }


### PR DESCRIPTION
Remove access fields from tests, uistatic - these should have been part of https://github.com/uProxy/uproxy/pull/762

Tested in grunt test, chrome, firefox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/767)
<!-- Reviewable:end -->
