### PR TITLE
some fixes to setup instructions and grunt clean

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -499,7 +499,7 @@ module.exports = (grunt) ->
         files:
           'build/compile-src/chrome/extension/vulcanized-chrome.html': 'build/compile-src/chrome/extension/vulcanized-inline.html'
 
-    clean: ['build/**', '.tscache']
+    clean: ['build', '.tscache', 'third_party/lib']
 
  # grunt.initConfig
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -499,7 +499,7 @@ module.exports = (grunt) ->
         files:
           'build/compile-src/chrome/extension/vulcanized-chrome.html': 'build/compile-src/chrome/extension/vulcanized-inline.html'
 
-    clean: ['build', '.tscache', 'third_party/lib']
+    clean: ['build/**', '.tscache']
 
  # grunt.initConfig
 

--- a/README.md
+++ b/README.md
@@ -54,17 +54,11 @@ modify (`/usr/local`) to being editable by your user (sudo chown -R $USER /usr/l
 
 ### Setup of uProxy codebase
 
-1. Clone uProxy and its submodules (and its submodules' submodules...):
-`git clone https://github.com/uProxy/uProxy.git`
-or `git clone git@github.com:uProxy/uproxy.git` if you have your ssh access to github set up (useful if you use 2-step auth for github, which you should do).
+ 1. Clone uProxy and its submodules (and its submodules' submodules...): `git clone https://github.com/uProxy/uProxy.git` or `git clone git@github.com:uProxy/uproxy.git` if you have your ssh access to github set up (useful if you use 2-step auth for github, which you should do).
 
-2. In the uProxy repository's root directory, run `bower install` to install any bower dependencies.
-
-3. In the uProxy repository's root directory, run `npm install`. This will install all local dependencies,
-as appropriate to run in Chrome and Firefox. The first time you run this, you'll see lots of npm, bower and grunt messages. Check the last couple of lines in case there is an error.
+ 1. In the uProxy repository's root directory, run `npm install`. This will install all local dependencies, as appropriate to run in Chrome and Firefox. The first time you run this, you'll see lots of npm, bower and grunt messages. Check the last couple of lines in case there is an error.
 
 Note that if any local dependencies have changed (i.e. changes to bower dependencies, updates to FreeDOM), you will have to run `npm update` and/or `bower install` to update the dependencies.
-
 
 ### Building and installing and running for Chrome
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ modify (`/usr/local`) to being editable by your user (sudo chown -R $USER /usr/l
 
 - [Grunt](http://gruntjs.com/): Install globally with `npm install -g grunt-cli`
 
-- [Typescript](http://www.typescriptlang.org/): Install globally with  `npm install -g typescript`
-
-    - This is assuming you have `ruby` and `rubygems` installed.
-
-
 ### Setup of uProxy codebase
 
 1. Clone uProxy and its submodules (and its submodules' submodules...):


### PR DESCRIPTION
Three things I noticed while acting as build cop this morning:
* there's no need for users to install the typescript compiler globally since it's specified as a dependency in our package.json and grunt-ts will find it there
* `bower install` is part of our `npm prepublish` script so there's no need to ask users to run it manually
* `grunt clean` should clear the bower directory (just like it clears `build/`)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/768)
<!-- Reviewable:end -->
