### PR TITLE
Work around for chrome.proxy.settings.get bug.

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -75,9 +75,15 @@ class ChromeBrowserApi implements BrowserAPI {
       this.uproxyConfig_.rules.singleProxy.port = endpoint.port;
       console.log('Directing Chrome proxy settings to uProxy');
       this.running_ = true;
-      chrome.proxy['settings']['get']({incognito:false},
+      chrome.proxy.settings.get({incognito:false},
         (details) => {
-          this.preUproxyConfig_ = details.value;
+          // TODO (lucyhe): Remove this if statement when Chrome issue 448172
+          // is resolved and we can safely assume that details is defined.
+          if (details) {
+            this.preUproxyConfig_ = details.value;
+          } else {
+            this.preUproxyConfig_ = {mode: "system"};
+          }
           chrome.proxy.settings.set({
               value: this.uproxyConfig_,
               scope: 'regular'


### PR DESCRIPTION
This is a work around for an issue in Canary detailed here: https://code.google.com/p/chromium/issues/detail?id=448172&thanks=448172&ts=1421102735
Once Canary behaviour is as expected, we can resolve this issue: https://github.com/uProxy/uproxy/issues/777

ran grunt test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/778)
<!-- Reviewable:end -->
