### PR TITLE
Create a new rtcToNet_ object on each OFFER

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -429,7 +429,7 @@ module.exports = (grunt) ->
         src: FILES.jasmine_helpers
             .concat [
               'build/compile-src/mocks/freedom-mocks.js'
-              'node_modules/uproxy-lib/dist/logging/logging.js'
+              'build/dev/chrome/app/scripts/uproxy-lib/logging/logging.js'
               'build/compile-src/socks-to-rtc/socks-to-rtc.js'
               'build/compile-src/rtc-to-net/rtc-to-net.js'
               'build/compile-src/uproxy.js'
@@ -445,6 +445,7 @@ module.exports = (grunt) ->
               'build/compile-src/generic_core/storage.js'
               'build/compile-src/generic_core/social.js'
               'build/compile-src/generic_core/core.js'
+              'build/dev/chrome/app/scripts/uproxy-lib/webrtc/peerconnection.js'
             ]
         options:
           specs: 'build/compile-src/generic_core/**/*.spec.js'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -383,6 +383,9 @@ module.exports = (grunt) ->
       generic_core: Rule.typescriptSrcLenient 'compile-src/generic_core'
       generic_core_specs: Rule.typescriptSpecDeclLenient 'compile-src/generic_core'
 
+      logging: Rule.typescriptSrcLenient 'compile-src/logging'
+      webrtc: Rule.typescriptSrcLenient 'compile-src/webrtc'
+
       # TODO: Remove uistatic / make it the same as uipolymer once polymer is
       # fully integrated.
       uistatic: Rule.typescriptSrcLenient 'compile-src/uistatic'
@@ -429,7 +432,8 @@ module.exports = (grunt) ->
         src: FILES.jasmine_helpers
             .concat [
               'build/compile-src/mocks/freedom-mocks.js'
-              'build/dev/chrome/app/scripts/uproxy-lib/logging/logging.js'
+              'build/compile-src/logging/logging.js'
+              'build/compile-src/webrtc/peerconnection.js'
               'build/compile-src/socks-to-rtc/socks-to-rtc.js'
               'build/compile-src/rtc-to-net/rtc-to-net.js'
               'build/compile-src/uproxy.js'
@@ -445,7 +449,6 @@ module.exports = (grunt) ->
               'build/compile-src/generic_core/storage.js'
               'build/compile-src/generic_core/social.js'
               'build/compile-src/generic_core/core.js'
-              'build/dev/chrome/app/scripts/uproxy-lib/webrtc/peerconnection.js'
             ]
         options:
           specs: 'build/compile-src/generic_core/**/*.spec.js'
@@ -590,6 +593,8 @@ module.exports = (grunt) ->
   # --- Testing tasks ---
   taskManager.add 'test_core', [
     'build_generic_core'
+    'ts:logging'
+    'ts:webrtc'
     'ts:generic_core_specs'
     'ts:mocks'
     'jasmine:generic_core'

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -7,6 +7,7 @@
  * correct consent values between remote instances.
  */
 /// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
+/// <reference path='../webrtc/peerconnection.d.ts' />
 /// <reference path='remote-instance.ts' />
 
 describe('Core.RemoteInstance', () => {

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -544,9 +544,6 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('handles signal from server peer as client', (done) => {
-      // Alice needs to already have a socksToRtc_ objected created in order
-      // to handle signals from the server peer.
-      // alice['socksToRtc_'] = fakeSocksToRtc;
       alice.consent.remoteGrantsAccessToLocal = true;
       alice.start().then(() => {
         alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate)

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -494,7 +494,7 @@ describe('Core.RemoteInstance', () => {
   describe('signalling', () => {
 
     // Build a mock Alice with fake signals and networking hooks.
-    var alice;  // Reset before each test in beforeEach
+    var alice :Core.RemoteInstance;  // Reset before each test in beforeEach
     var fakeSocksToRtc = {
       'handleSignalFromPeer': () => {},
       'on': () => {},

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -174,6 +174,7 @@ module Core {
      * instance, and pass it along to the relevant socks-rtc module.
      * TODO: spec
      * TODO: assuming that signal is valid, should we remove signal?
+     * TODO: return a boolean on success/failure
      */
     public handleSignal = (type:uProxy.MessageType,
                            signalFromRemote:Object) => {


### PR DESCRIPTION
Fix for #761.  We now create a new rtcToNet_ object for each OFFER (i.e. for each attempt to start proxying).

Tested in grunt test with updated test cases, Chrome.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/786)
<!-- Reviewable:end -->
