### PR TITLE
When the app is missing, redirect to uproxy.org when appropriate from within the extension.

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -47,30 +47,29 @@ chrome.runtime.onMessageExternal.addListener(
 // Launch the Chrome webstore page for the uProxy app,
 // or activate the user's tab open to uproxy.org/chrome-install
 function openDownloadAppPage() : void {
-  chrome.windows.get(mainWindowId, {populate: true},
-      (windowThatLaunchedUproxy) => {
-        if (windowThatLaunchedUproxy) {
-          for (var i = 0; i < windowThatLaunchedUproxy.tabs.length; i++) {
-            // If the user is installing via the inline install flow,
-            // instead of sending them to the webstore to install the app,
-            // bring them back to uproxy.org/chrome-install
-            if ((windowThatLaunchedUproxy.tabs[i].url.indexOf("uproxysite.appspot.com/chrome-install") > -1) ||
-                (windowThatLaunchedUproxy.tabs[i].url.indexOf("uproxy.org/chrome-install") > -1)) {
-              chrome.tabs.update(windowThatLaunchedUproxy.tabs[i].id, {active:true});
-              chrome.windows.update(mainWindowId, {focused: true});
-              return;
-            }
-          }
+  chrome.windows.get(mainWindowId, {populate: true}, (windowThatLaunchedUproxy) => {
+    if (windowThatLaunchedUproxy) {
+      for (var i = 0; i < windowThatLaunchedUproxy.tabs.length; i++) {
+        // If the user is installing via the inline install flow,
+        // instead of sending them to the webstore to install the app,
+        // bring them back to uproxy.org/chrome-install
+        if ((windowThatLaunchedUproxy.tabs[i].url.indexOf("uproxysite.appspot.com/chrome-install") > -1) ||
+            (windowThatLaunchedUpfroxy.tabs[i].url.indexOf("uproxy.org/chrome-install") > -1)) {
+          chrome.tabs.update(windowThatLaunchedUproxy.tabs[i].id, {active:true});
+          chrome.windows.update(mainWindowId, {focused: true});
+          return;
         }
-        // Only reached if the user didn't have uproxy.org/chrome-install open.
-        chromeCoreConnector.waitingForAppInstall = true;
-        chrome.tabs.create(
-            {url: 'https://chrome.google.com/webstore/detail/uproxyapp/fmdppkkepalnkeommjadgbhiohihdhii'},
-            (tab) => {
-              // Focus on the new Chrome Webstore tab.
-              chrome.windows.update(tab.windowId, {focused: true});
-            });
-      });
+      }
+    }
+    // Only reached if the user didn't have uproxy.org/chrome-install open.
+    chromeCoreConnector.waitingForAppInstall = true;
+    chrome.tabs.create(
+        {url: 'https://chrome.google.com/webstore/detail/uproxyapp/fmdppkkepalnkeommjadgbhiohihdhii'},
+        (tab) => {
+          // Focus on the new Chrome Webstore tab.
+          chrome.windows.update(tab.windowId, {focused: true});
+        });
+  });
 }
 
 /**

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -63,14 +63,16 @@ function openDownloadAppPage() : void {
     }
     // Only reached if the user didn't have uproxy.org/chrome-install open,
     // allowing us to assume the user is completeing the webstore install flow.
-    // After the app is installed via the webstore, open up uProxy.
-    chromeCoreConnector.onceConnected.then(chromeBrowserApi.bringUproxyToFront);
+    // For consistency, we direct them to the app download page in the webstore
+    // instead of uproxy.org.
     chrome.tabs.create(
         {url: 'https://chrome.google.com/webstore/detail/uproxyapp/fmdppkkepalnkeommjadgbhiohihdhii'},
         (tab) => {
           // Focus on the new Chrome Webstore tab.
           chrome.windows.update(tab.windowId, {focused: true});
         });
+    // After the app is installed via the webstore, open up uProxy.
+    chromeCoreConnector.onceConnected.then(chromeBrowserApi.bringUproxyToFront);
   });
 }
 


### PR DESCRIPTION
ran grunt test

If the app is not installed, the popup shows an error prompting the user to install the app. The button in the extension used to always open the Chrome webstore app install page, but with this change, if the user has uproxy.org/chrome-install open, it will activate that tab instead.

This is assuming that uproxy.org is not blocked (which is why it's open).


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/811)
<!-- Reviewable:end -->
