### PR TITLE
Update uProxy, Chrome webstore and dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uProxy",
   "description": "Share your pathway to the Internet",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uproxy/uproxy"

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   ],
   "devDependencies": {
     "es6-promise": "^0.1.1",
-    "freedom-social-xmpp": "~0.3.5",
-    "freedom-for-chrome": "~0.4.8",
-    "freedom-for-firefox": "~0.6.6",
+    "freedom-social-xmpp": "~0.3.6",
+    "freedom-for-chrome": "~0.4.11",
+    "freedom-for-firefox": "~0.6.7",
     "fs-extra": "^0.12.0",
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
@@ -44,7 +44,7 @@
     "uproxy-networking": "^5.0.0"
   },
   "peerDependencies" : {
-    "freedom": "~0.6.11"
+    "freedom": "~0.6.18"
   },
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-vulcanize": "^0.6.0",
     "typescript": "^1.0.1",
     "uproxy-churn": "^0.0.5",
-    "uproxy-lib": "^17.0.0",
+    "uproxy-lib": "^18.0.0",
     "uproxy-networking": "^5.0.0"
   },
   "peerDependencies" : {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uProxy",
   "description": "Share your pathway to the Internet",
-  "version": "0.5.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uproxy/uproxy"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uProxy",
   "description": "Share your pathway to the Internet",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uproxy/uproxy"

--- a/src/chrome/app/manifest.json
+++ b/src/chrome/app/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_appName__",
   "description": "__MSG_appDescription__",
   "minimum_chrome_version": "41.0.2267",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "default_locale": "en",
   "icons": {
       "128": "icons/default-128.png",

--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "__MSG_extName__",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "manifest_version": 2,
   "description": "__MSG_extDescription__",
   "minimum_chrome_version": "41.0.2267",

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -20,6 +20,11 @@ class MockCore {
 
   public getId = () => { return ['useless']; }
 
+  public getLogger = (tag) => {
+    var logger = jasmine.createSpyObj('logger-'+tag, ['log', 'info', 'error']);
+    freedom['loggers'][tag] = logger;
+    return Promise.resolve(logger);
+  }
 }  // class MockCore
 
 class MockCorePeerConnection {
@@ -106,6 +111,7 @@ var mockSocial = () => { return new MockSocial(); };
 mockSocial['api'] = 'social';
 mockSocial['manifest'] = 'I have no manifest :)';
 
+freedom['loggers'] = {};
 freedom['core'] = () => { return new MockCore(); };
 freedom['core.console'] = () => { return new MockLog(); };
 freedom['core.rtcpeerconnection'] = () => { return new MockCorePeerConnection(); };

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -1,10 +1,13 @@
 /**
  * freedom-mocks.ts
  *
+ * Mock freedom objects used for uProxy unit tests. The mock classes below
+ * implement different freedom interfaces found in freedom/typings/freedom.d.ts.
  * This file must be compiled independently of all other typescript in uProxy.
  */
 
 /// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
 /// <reference path='../freedom/typings/storage.d.ts' />
 
 


### PR DESCRIPTION
Update uProxy package.json and Chrome (app and extension) manifest.json versions to 0.6.0. Moving forward the Chrome webstore versions should be in sync with the newest uProxy release versions (meaning the minor version should be increased every 3 weeks).

Also updated uproxy-lib and freedom dependencies to the latest available packages in npm. (uproxy-networking was already up to date.) In order for tests to pass with updated uproxy-lib, freedom mocks were updated. Note that these should be cleaned up at some point (https://github.com/uProxy/uproxy/issues/838).

Ran grunt test and end-to-end test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/839)
<!-- Reviewable:end -->
