### PR TITLE
Remove width restriction for status text

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -99,7 +99,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-        width: 358px;
       }
       .statusText img {
         vertical-align: middle;


### PR DESCRIPTION
Status text had an absolute width set which caused a scrollbar to appear
if the window went below a width of ~380px, even without any text
present.  With this change, that scrollbar should no longer appear and
the text will fill the full width (given enough content).

Closes #881 

Tested with standard and unrealistically-long status texts, scrollbar does not appear until the width is at ~180px (seems to be because of the top toolbar which is not responsive at low widths at the moment)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/882)
<!-- Reviewable:end -->
