### PR TITLE
Do not show a notification if a pending shared connection is aborted

### DIFF
--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -252,6 +252,22 @@ describe('UI.UserInterface', () => {
       expect(ui.sharingStatus).toEqual(null);
     });
 
+    it('No notification when you stop sharing and are not already proxying', () => {
+      syncUserAndInstance('userId', 'Alice', 'testInstanceId');
+      updateToHandlerMap[uProxy.Update.STOP_GIVING_TO_FRIEND]
+          .call(ui, 'testInstanceId');
+      expect(ui.showNotification).not.toHaveBeenCalled();
+    });
+
+    it('Notification when you stop sharing', () => {
+      syncUserAndInstance('userId', 'Alice', 'testInstanceId');
+      updateToHandlerMap[uProxy.Update.START_GIVING_TO_FRIEND]
+          .call(ui, 'testInstanceId');
+      updateToHandlerMap[uProxy.Update.STOP_GIVING_TO_FRIEND]
+          .call(ui, 'testInstanceId');
+      expect(ui.showNotification).toHaveBeenCalled();
+    });
+
     it('Getting status updates when you start and stop getting', () => {
       // Note that setting and clearing instanceGettingAccessFrom_ is done in
       // polymer/instance.ts.

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -314,14 +314,19 @@ module UI {
 
       core.onUpdate(uProxy.Update.STOP_GIVING_TO_FRIEND,
           (instanceId :string) => {
+        var isGettingFromMe = false;
+        var user = this.mapInstanceIdToUser_[instanceId];
+
+        // only show a notification if we knew we were prokying
+        if (typeof this.instancesGivingAccessTo[instanceId] !== 'undefined') {
+          this.showNotification(user.name + ' stopped proxying through you');
+        }
         delete this.instancesGivingAccessTo[instanceId];
         if (!this.isGivingAccess()) {
           this.stopGivingInUi();
         }
 
         // Update user.isGettingFromMe
-        var isGettingFromMe = false;
-        var user = this.mapInstanceIdToUser_[instanceId];
         for (var i = 0; i < user.instances.length; ++i) {
           if (this.instancesGivingAccessTo[user.instances[i].instanceId]) {
             isGettingFromMe = true;
@@ -329,7 +334,6 @@ module UI {
           }
         }
         user.isGettingFromMe = isGettingFromMe;
-        this.showNotification(user.name + ' stopped proxying through you');
 
         this.updateSharingStatusBar_();
       });


### PR DESCRIPTION
If we (in the case, the UI) receives a message to indicate that we
stopped proxying and we did not know we were proxying, do not show any
notification about that.

This also adds tests both for the fact that the notification will be
generated in a normal case and that the notification will not be
generated in the error case.

Fixes #908 

Tested by ensuring that the first test failed beforehand and now passes

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/944)
<!-- Reviewable:end -->
