### PR TITLE
Add some accessibility features to the settings pane

### DIFF
--- a/src/generic_ui/polymer/faq-link.html
+++ b/src/generic_ui/polymer/faq-link.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../lib/polymer/polymer.html">
+<link rel='import' href='link.html'>
 
 <!--
 
@@ -12,14 +13,9 @@ a new tab linking to faq.html#privacy
 <polymer-element name='uproxy-faq-link' attributes='anchor'>
 
   <template>
-    <style>
-      span {
-        cursor: pointer;
-      }
-    </style>
-
-    <span on-click='{{ openFaq }}'><content></content></span>
-
+    <uproxy-link role='link' on-tap='{{ openFaq }}'>
+      <content></content>
+    </uproxy-link>
   </template>
 
   <script src='faq-link.js'></script>

--- a/src/generic_ui/polymer/link.html
+++ b/src/generic_ui/polymer/link.html
@@ -1,0 +1,27 @@
+<link rel="import" href='../lib/core-a11y-keys/core-a11y-keys.html'>
+
+<!--
+This is a link element we can use in UProxy that will automatically enable
+basic acessibility features (being able to tab-select and access it through
+keypresses).
+
+Usage: <uproxy-link role='(button|link)' on-tap='{{ EVENT }}'>CONTENT</uproxy-link>
+-->
+
+<polymer-element name='uproxy-link' tabindex='0'>
+  <template>
+    <style>
+      span {
+        cursor: pointer;
+      }
+    </style>
+
+    <span>
+      <content></content>
+    </span>
+
+    <core-a11y-keys keys='space enter' target='{{}}' on-keys-pressed='{{ handleKey }}'></core-a11y-keys>
+  </template>
+
+  <script src='link.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/link.ts
+++ b/src/generic_ui/polymer/link.ts
@@ -1,0 +1,7 @@
+Polymer({
+  handleKey: function() {
+    // fire both on-click (builtin) and on-tap (added by polymer) handlers
+    this.click();
+    this.fire('tap');
+  }
+});

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -3,7 +3,8 @@
 <link rel='import' href='../lib/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../lib/core-icons/core-icons.html'>
 <link rel="import" href='description.html'>
-<link rel="import" href='faq-link.html'>
+<link rel="import" href="faq-link.html">
+<link rel='import' href='link.html'>
 
 <polymer-element name='uproxy-settings'>
 
@@ -45,6 +46,7 @@
       padding-left: 32px;
       line-height: 32px;
       color: rgb(112, 112, 112);
+      display: block;
     }
     #descriptionWrapper {
       padding-left: 32px;
@@ -71,6 +73,9 @@
       background: #009688;  /* dark green */
       color: white;
       width: 70px;
+    }
+    paper-button:focus {
+      border: 1px solid #008074;
     }
     paper-input-decorator {
       max-width: 60%;
@@ -113,22 +118,29 @@
         Device description
         <uproxy-description></uproxy-description>
       </div>
-      <div class='actionLink' on-tap='{{toggleAdvancedSettings}}'>
+      <uproxy-link class='actionLink' on-tap='{{ toggleAdvancedSettings }}' role='button'>
         Advanced Settings
         <core-icon icon="expand-more" hidden?='{{displayAdvancedSettings}}'></core-icon>
         <core-icon icon="expand-less" hidden?='{{!displayAdvancedSettings}}'></core-icon>
-      </div>
+      </uproxy-link>
       <div id='advancedSettings' hidden?='{{!displayAdvancedSettings}}'>
         <paper-input-decorator label="Custom STUN server">
           <input is="core-input" value='{{stunServer}}'>
         </paper-input-decorator>
-         <paper-button on-tap="{{setStunServer}}">Update</paper-button> <paper-button on-tap="{{resetStunServers}}">Reset</paper-button><br><br>
+        <paper-button class='button' on-tap="{{setStunServer}}">Update</paper-button>
+        <paper-button class='button' on-tap="{{resetStunServers}}">Reset</paper-button>
+        <br><br>
         <p id='confirmNewServer' class='advancedSettingsText' hidden>STUN server updated. New server will be used for future connections.</p>
         <p id='confirmResetServers' class='advancedSettingsText' hidden>STUN servers reset. Default servers will be used for future connections.</p>
       </div>
+
       <uproxy-faq-link class='actionLink'>Get Help</uproxy-faq-link>
-      <div class='actionLink' on-tap='{{logOut}}'>Log-out of uProxy</div>
-      <div class='actionLink' on-tap='{{restart}}' hidden?='{{browser!=="chrome"}}'>Restart</div>
+      <uproxy-link class='actionLink' on-tap='{{ logOut }}' role='button'>
+        Log-out of uProxy
+      </uproxy-link>
+      <uproxy-link class='actionLink' on-tap='{{ restart }}' hidden?='{{ browser !== "chrome" }}' role='button'>
+        Restart
+      </uproxy-link>
     </div>
 
   </template>


### PR DESCRIPTION
The links in the settings pane can now all be accessed through pushing
the tab keys.  Pushing either enter or spacebar when over those links
will now fire the on-tap handler as well.

This also adds a small highlight to the update and reset buttons when
they are focused since paper-button does not do so by default.

Fixes #929

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/951)
<!-- Reviewable:end -->
