### PR TITLE
Rename the id for the copy paste toolbar

### DIFF
--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -6,12 +6,12 @@
     :host {
       text-align: center;
     }
-    #toolbar {
+    #cptoolbar {
       height: 50px;
       background: grey;
       color: white;
     }
-    #toolbar * {
+    #cptoolbar * {
       line-height: 50px;
     }
     .prevArrow {
@@ -33,7 +33,7 @@
       color: white;
     }
     </style>
-    <div id='toolbar'>
+    <div id='cptoolbar'>
       <div class='prevArrow'>
         <img src='../icons/arrow-left.png' on-tap='{{prev}}' />
       </div>


### PR DESCRIPTION
For some reason, the copy paste toolbar was inheriting the styles of the
one in the contact list on the Firefox browser, this renames it and the
issue no longer seems to be present.

Tested by loading the copypaste UI in Firefox and Chrome

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/956)
<!-- Reviewable:end -->
