### PR TITLE
When we identify a bad URL, show an error to the user

### DIFF
--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -24,6 +24,9 @@
       margin: 8px;
       vertical-align: middle;
     }
+    .error {
+      color: red;
+    }
     textarea.message {
       width: 80%;
       height: 10em;
@@ -43,6 +46,14 @@
       <span hidden?='{{ SharingState.NONE === ui.copyPasteSharingState }}'>
         Share a one time connection
       </span>
+      <span hidden?='{{ ui.copyPasteSharingState !== SharingState.NONE || ui.copyPasteGettingState !== GettingState.NONE }}'>
+        Manual Connection
+      </span>
+    </div>
+
+    <div class='error' hidden?='{{ !ui.copyPasteUrlError }}'>
+      There was an error parsing the uproxy connection link, please try
+      navigating to the link again or asking your friend for a new link.
     </div>
 
     <div id='geting-link' hidden?='{{ GettingState.TRYING_TO_GET_ACCESS !== ui.copyPasteGettingState || SharingState.TRYING_TO_SHARE_ACCESS === ui.copyPasteSharingState }}'>

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -164,6 +164,7 @@ module UI {
     public copyPasteBytesSent :number = 0;
     public copyPasteBytesReceived :number = 0;
 
+    public copyPasteUrlError :boolean = false;
     public copyPasteGettingMessage :string = '';
     public copyPasteSharingMessage :string = '';
 
@@ -377,15 +378,22 @@ module UI {
       var payload;
       console.log('received url data from browser');
 
+      this.view = UI.View.COPYPASTE;
+
       var match = url.match(/https:\/\/www.uproxy.org\/(request|offer)\/(.*)/)
       if (!match) {
         console.error('parsed url that did not match');
+        this.copyPasteUrlError = true;
+        return;
       }
 
+      this.copyPasteUrlError = false;
       try {
         payload = JSON.parse(atob(decodeURIComponent(match[2])));
       } catch (e) {
         console.error('malformed string from browser');
+        this.copyPasteUrlError = true;
+        return;
       }
 
       // at this point, we assume everything is good, so let's check state
@@ -411,8 +419,6 @@ module UI {
       for (var i in payload) {
         this.core_.sendCopyPasteSignal(payload[i]);
       }
-
-      this.view = UI.View.COPYPASTE;
     }
 
     public showNotification = (notificationText :string) => {


### PR DESCRIPTION
If we encounter any errors with a url (most likely missing characters at
the end) we will now abort trying to process it and instead will show an
error to the user.

Tested by pasting invalid URLs a few times

Fixes #958

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/968)
<!-- Reviewable:end -->
