### PR TITLE
Move the tabindex field for uproxy-link to inner content

### DIFF
--- a/src/generic_ui/polymer/link.html
+++ b/src/generic_ui/polymer/link.html
@@ -8,7 +8,7 @@ keypresses).
 Usage: <uproxy-link role='(button|link)' on-tap='{{ EVENT }}'>CONTENT</uproxy-link>
 -->
 
-<polymer-element name='uproxy-link' tabindex='0'>
+<polymer-element name='uproxy-link'>
   <template>
     <style>
       span {
@@ -16,7 +16,7 @@ Usage: <uproxy-link role='(button|link)' on-tap='{{ EVENT }}'>CONTENT</uproxy-li
       }
     </style>
 
-    <span>
+    <span tabindex='0'>
       <content></content>
     </span>
 


### PR DESCRIPTION
This moves the tabindex field for uproxy-link to the span inside of the
polymer element which should cause less content to appear in the
outline when the link is tab-selected

Fixes #972 

Tested by pressing tab in the settings pane.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/974)
<!-- Reviewable:end -->
