### PR TITLE
Check chrome.runtime.lastError

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -89,7 +89,7 @@ class ChromeBrowserApi implements BrowserAPI {
             this.preUproxyConfig_ = details.value;
           } else {
             this.preUproxyConfig_ = {mode: "system"};
-            console.log('Current proxy settings undefined. Received error: ' +
+            console.warn('Current proxy settings undefined. Received error: ' +
               chrome.runtime.lastError.message);
           }
           chrome.proxy.settings.set({

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -89,6 +89,8 @@ class ChromeBrowserApi implements BrowserAPI {
             this.preUproxyConfig_ = details.value;
           } else {
             this.preUproxyConfig_ = {mode: "system"};
+            console.log('Current proxy settings undefined. Received error: ' +
+              chrome.runtime.lastError.message);
           }
           chrome.proxy.settings.set({
               value: this.uproxyConfig_,


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/936
Manually tested in 40.0.2214.115 (the only channel where we seem to get this issue)
Also ran grunt test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/985)
<!-- Reviewable:end -->
