### PR TITLE
Match missing extension page to missing app page.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -283,6 +283,22 @@ module.exports = (grunt) ->
           expand: true, cwd: 'node_modules/uproxy-networking/dist/',
           src: FILES.uproxy_networking_common,
           dest: chromeAppDevPath + 'scripts/uproxy-networking/'
+        }, {
+          # Copy third party UI files required for polymer.
+          expand: true, cwd: 'third_party/lib'
+          src: FILES.thirdPartyUi
+          dest: chromeAppDevPath + 'lib'
+        }, {
+          # Chrome app polymer.
+          # (Assumes vulcanize tasks have executed)
+          expand: true, cwd: 'build/compile-src/chrome/app/polymer'
+          src: ['vulcanized.*']
+          dest: chromeAppDevPath + 'polymer'
+        }, {
+          # Copy font from styles.
+          expand: true, cwd: 'src/generic_ui',
+          src: ['styles/**']
+          dest: chromeExtDevPath
         }]
 
       # Firefox. Assumes the top-level tasks generic_core and generic_ui
@@ -531,6 +547,18 @@ module.exports = (grunt) ->
           strip: true
         files:
           'build/compile-src/chrome/extension/polymer/vulcanized-chrome.html': 'build/compile-src/chrome/extension/polymer/vulcanized-inline.html'
+      chromeappinline:
+        options:
+          inline: true
+        files:
+          'build/compile-src/chrome/app/polymer/vulcanized-inline.html': 'build/compile-src/chrome/app/polymer/ext-missing.html'
+      chromeappcsp:
+        options:
+          csp: true
+          strip: true
+        files:
+          'build/compile-src/chrome/app/polymer/vulcanized.html': 'build/compile-src/chrome/app/polymer/vulcanized-inline.html'
+
 
     clean: ['build/**', '.tscache']
 
@@ -584,6 +612,8 @@ module.exports = (grunt) ->
     'build_generic_ui'
     'build_generic_core'
     'ts:chrome'
+    'vulcanize:chromeappinline'
+    'vulcanize:chromeappcsp'
     'vulcanize:chromeinline'
     'vulcanize:chromecsp'
     'copy:chrome_app'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -294,11 +294,6 @@ module.exports = (grunt) ->
           expand: true, cwd: 'build/compile-src/chrome/app/polymer'
           src: ['vulcanized.*']
           dest: chromeAppDevPath + 'polymer'
-        }, {
-          # Copy font from styles.
-          expand: true, cwd: 'src/generic_ui',
-          src: ['styles/**']
-          dest: chromeExtDevPath
         }]
 
       # Firefox. Assumes the top-level tasks generic_core and generic_ui

--- a/src/chrome/app/install-incomplete.html
+++ b/src/chrome/app/install-incomplete.html
@@ -12,7 +12,6 @@ ext-missing Polymer element. -->
   <style>
   @font-face {
     font-family: Roboto, sans-serif;
-    src: url('styles/eurostile.ttf');
   }
   body {
     display: block;

--- a/src/chrome/app/install-incomplete.html
+++ b/src/chrome/app/install-incomplete.html
@@ -1,1 +1,32 @@
-Please install the extension.
+<!doctype html>
+<!-- Popup displayed if the Chrome Ext is not installed. Contains just the
+ext-missing Polymer element. -->
+<html>
+
+<head>
+  <script src='lib/webcomponentsjs/webcomponents.js'></script>
+
+  <link rel='import' href='polymer/vulcanized.html'>
+  <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
+
+  <style>
+  @font-face {
+    font-family: Roboto, sans-serif;
+    src: url('styles/eurostile.ttf');
+  }
+  body {
+    display: block;
+    text-align: center;
+    font-family: Roboto, sans-serif;
+    font-size: 13px;
+    margin: 0px;
+  }
+  </style>
+</head>
+
+<body>
+  <uproxy-ext-missing></uproxy-ext-missing>
+</body>
+
+</html>
+

--- a/src/chrome/app/polymer/ext-missing.html
+++ b/src/chrome/app/polymer/ext-missing.html
@@ -1,0 +1,29 @@
+<link rel="import" href="../../../generic_ui/lib/polymer/polymer.html">
+<link rel="import" href="../../../generic_ui/lib/paper-button/paper-button.html">
+
+<polymer-element name='uproxy-ext-missing'>
+  <template>
+    <style>
+      :host {
+        text-align: center;
+        font-size: 1em;
+        color: rgb(112, 112, 112);
+      }
+      h1 {
+        font-size: 1.4em;
+        color: #009688;  /* dark green */
+      }
+      .highlightedButton {
+        background: #009688;  /* dark green */
+        color: white;
+      }
+    </style>
+
+    <h1>You're almost ready to use uProxy!</h1>
+    Download and enable part 1 of uProxy to get started.
+    <br><br>
+    <paper-button class='highlightedButton' raised on-tap='{{ downloadExt }}'>NEXT</paper-button>
+
+  </template>
+  <script src='ext-missing.js'></script>
+</polymer-element>

--- a/src/chrome/app/polymer/ext-missing.ts
+++ b/src/chrome/app/polymer/ext-missing.ts
@@ -1,0 +1,5 @@
+Polymer({
+  downloadExt: function() {
+    window.open('http://www.uproxy.org/chrome-install');
+  }
+});


### PR DESCRIPTION
ran grunt test and manually tested to make sure the page changes to index.html upon install.
should be last piece of Chrome install flow, resolving: https://github.com/uProxy/uproxy/issues/627 and https://github.com/uProxy/uproxy/issues/576

looks like this now:
![image](https://cloud.githubusercontent.com/assets/8723127/6353897/fa2906b0-bc19-11e4-89fc-a12dc457a105.png)
