### PR TITLE
Remove _ fields from consent messages/storage, better message logging, small UI cleanup to splash screen

### DIFF
--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -75,6 +75,18 @@ module Consent {
     }
   }
 
+  // Return an object with only public consent fields, and no "_" fields.
+  export function serialize(consent :Consent.State) {
+    return {
+      localGrantsAccessToRemote: consent.localGrantsAccessToRemote,
+      localRequestsAccessFromRemote: consent.localRequestsAccessFromRemote,
+      remoteGrantsAccessToLocal: consent.remoteGrantsAccessToLocal,
+      remoteRequestsAccessFromLocal: consent.remoteRequestsAccessFromLocal,
+      ignoringRemoteUserRequest: consent.ignoringRemoteUserRequest,
+      ignoringRemoteUserOffer: consent.ignoringRemoteUserOffer
+    };
+  }
+
   export function updateStateFromRemoteState(state :State, remoteState :WireState) {
     state.remoteRequestsAccessFromLocal = remoteState.isRequesting;
     state.remoteGrantsAccessToLocal = remoteState.isOffering;

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -174,7 +174,6 @@ class uProxyCore implements uProxy.CoreAPI {
             promiseId: args.promiseId,
             errorForCallback: errorForCallback.toString()
           };
-          console.warn('rejecting promise command', rejectionData);
           ui.update(uProxy.Update.COMMAND_REJECTED, rejectionData);
         }
       );

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -170,9 +170,12 @@ class uProxyCore implements uProxy.CoreAPI {
                 argsForCallback: argsForCallback });
         },
         (errorForCallback :Error) => {
-          ui.update(uProxy.Update.COMMAND_REJECTED,
-              { promiseId: args.promiseId,
-                errorForCallback: errorForCallback.toString() });
+          var rejectionData = {
+            promiseId: args.promiseId,
+            errorForCallback: errorForCallback.toString()
+          };
+          console.warn('rejecting promise command', rejectionData);
+          ui.update(uProxy.Update.COMMAND_REJECTED, rejectionData);
         }
       );
     };

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -140,11 +140,10 @@ describe('Core.RemoteInstance', () => {
     expect(instance.sendConsent).toHaveBeenCalled();
   });
 
-  it('warns about invalid UserAction to modify consent', () => {
+  it('does not send consent for invalid modification', () => {
     spyOn(instance, 'sendConsent');
     instance.modifyConsent(<Consent.UserAction>-1);
     expect(instance.sendConsent).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith('Invalid Consent.UserAction! -1');
   });
 
   describe('local consent towards remote proxy', () => {
@@ -528,7 +527,7 @@ describe('Core.RemoteInstance', () => {
       data: 'really fake candidate'
     };
 
-    beforeEach(() => {
+    beforeEach((done) => {
       alice = new Core.RemoteInstance(user, 'instance-alice', {
         instanceId: 'instance-alice',
         keyHash:    'fake-hash-alice',
@@ -538,17 +537,20 @@ describe('Core.RemoteInstance', () => {
       spyOn(fakeRtcToNet, 'handleSignalFromPeer');
       spyOn(SocksToRtc, 'SocksToRtc').and.returnValue(fakeSocksToRtc);
       spyOn(RtcToNet, 'RtcToNet').and.returnValue(fakeRtcToNet);
-      alice.consent.localGrantsAccessToRemote = true;
+      alice.onceLoaded.then(() => {
+        alice.consent.localGrantsAccessToRemote = true;
+        done();
+      });
     });
 
     it('ignores CANDIDATE signal from client peer as server without OFFER', () => {
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate)
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate);
       expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
       expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
     });
 
     it('handles OFFER signal from client peer as server', () => {
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeOffer)
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeOffer);
       expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
       expect(fakeRtcToNet.handleSignalFromPeer).toHaveBeenCalledWith(fakeOffer);
     });
@@ -556,7 +558,7 @@ describe('Core.RemoteInstance', () => {
     it('handles signal from server peer as client', (done) => {
       alice.consent.remoteGrantsAccessToLocal = true;
       alice.start().then(() => {
-        alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate)
+        alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate);
         expect(fakeSocksToRtc.handleSignalFromPeer).toHaveBeenCalledWith(fakeCandidate);
         expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
         done();
@@ -564,19 +566,36 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('rejects invalid signals', () => {
-      alice.handleSignal(uProxy.MessageType.INSTANCE, fakeCandidate)
+      alice.handleSignal(uProxy.MessageType.INSTANCE, fakeCandidate);
       expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
       expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(console.warn).toHaveBeenCalled();
     });
 
     it('rejects message from client if consent has not been granted', () => {
       alice.consent.localGrantsAccessToRemote = false;
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate)
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate);
       expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
       expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(console.warn).toHaveBeenCalled();
     });
 
-  });  // describe signalling
+    it('does not send private consent variables to UI', () => {
+      var state = alice.currentStateForUi();
+      expect(Object.keys(state.consent)).toEqual(
+          ['localGrantsAccessToRemote', 'localRequestsAccessFromRemote',
+           'remoteGrantsAccessToLocal', 'remoteRequestsAccessFromLocal',
+           'ignoringRemoteUserRequest', 'ignoringRemoteUserOffer']);
+    });
+
+    it('does not write private consent variables to storage', (done) => {
+      alice['saveToStorage']().then(() => {
+        storage.load<RemoteInstanceState>(alice.getStorePath()).then((state) => {
+          expect(Object.keys(state.consent)).toEqual(
+              ['localGrantsAccessToRemote', 'localRequestsAccessFromRemote',
+               'remoteGrantsAccessToLocal', 'remoteRequestsAccessFromLocal',
+               'ignoringRemoteUserRequest', 'ignoringRemoteUserOffer']);
+          done();
+        });
+      });
+    });
+  });
 });

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -588,7 +588,7 @@ describe('Core.RemoteInstance', () => {
 
     it('does not write private consent variables to storage', (done) => {
       alice['saveToStorage']().then(() => {
-        storage.load<RemoteInstanceState>(alice.getStorePath()).then((state) => {
+        storage.load<Core.RemoteInstanceState>(alice.getStorePath()).then((state) => {
           expect(Object.keys(state.consent)).toEqual(
               ['localGrantsAccessToRemote', 'localRequestsAccessFromRemote',
                'remoteGrantsAccessToLocal', 'remoteRequestsAccessFromLocal',

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -16,11 +16,12 @@ describe('Core.RemoteInstance', () => {
   var user = <Core.User><any>jasmine.createSpyObj('user', [
       'send',
       'notifyUI',
-      'instanceToClient'
+      'instanceToClient',
+      'sendInstanceHandshake'
   ]);
 
   user.network = <Social.Network><any>jasmine.createSpyObj(
-      'network', ['sendInstanceHandshake']);
+      'network', ['getUser']);
 
   user['getLocalInstanceId'] = function() {
       return 'localInstanceId';
@@ -387,7 +388,7 @@ describe('Core.RemoteInstance', () => {
       description: 'alice peer',
     });
 
-    (<any>user.network.sendInstanceHandshake).and.callFake((clientId, consent) => {
+    (<any>user.sendInstanceHandshake).and.callFake((clientId, consent) => {
       if (clientId === 'instanceId-alice') {
         bob.updateConsent(consent);
       } else if (clientId === 'instanceId-bob') {

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -105,7 +105,12 @@ module Core {
     private handleConnectionUpdate_ = (update :uProxy.Update, data?:any) => {
       switch (update) {
         case uProxy.Update.SIGNALLING_MESSAGE:
-          this.send(data);
+          var clientId = this.user.instanceToClient(this.instanceId);
+          if (!clientId) {
+            console.error('Could not find clientId for instance', this);
+            return;
+          }
+          this.user.network.send(clientId, data);
           break;
         case uProxy.Update.STOP_GIVING:
           ui.update(uProxy.Update.STOP_GIVING_TO_FRIEND, this.instanceId);
@@ -140,10 +145,6 @@ module Core {
      */
     public getStorePath = () => {
       return this.user.getLocalInstanceId() + '/' + this.instanceId;
-    }
-
-    public send = (msg :uProxy.Message) => {
-      this.user.send(this.instanceId, msg);
     }
 
     /**
@@ -335,9 +336,9 @@ module Core {
     }
 
     private saveToStorage = () => {
-      this.onceLoaded.then(() => {
+      return this.onceLoaded.then(() => {
         var state = this.currentState();
-        storage.save<RemoteInstanceState>(this.getStorePath(), state)
+        return storage.save<RemoteInstanceState>(this.getStorePath(), state)
             .then((old) => {
           console.log('Saved instance ' + this.instanceId + ' to storage.');
         });
@@ -350,7 +351,7 @@ module Core {
      */
     public currentState = () :RemoteInstanceState => {
       return cloneDeep({
-        consent:     this.consent,
+        consent:     Consent.serialize(this.consent),
         description: this.description,
         keyHash:     this.keyHash
       });
@@ -376,7 +377,7 @@ module Core {
         instanceId:             this.instanceId,
         description:            this.description,
         keyHash:                this.keyHash,
-        consent:                this.consent,
+        consent:                Consent.serialize(this.consent),
         localGettingFromRemote: this.localGettingFromRemote,
         localSharingWithRemote: this.localSharingWithRemote,
         isOnline:               this.user.isInstanceOnline(this.instanceId),

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -110,7 +110,7 @@ module Core {
             console.error('Could not find clientId for instance', this);
             return;
           }
-          this.user.network.send(clientId, data);
+          this.user.network.send(this.user, clientId, data);
           break;
         case uProxy.Update.STOP_GIVING:
           ui.update(uProxy.Update.STOP_GIVING_TO_FRIEND, this.instanceId);
@@ -256,8 +256,9 @@ module Core {
     public sendConsent = () => {
       this.onceLoaded.then(() => {
         if (this.user.isInstanceOnline(this.instanceId)) {
-          this.user.network.sendInstanceHandshake(
-              this.user.instanceToClient(this.instanceId), this.getConsentBits());
+          this.user.sendInstanceHandshake(
+              this.user.instanceToClient(this.instanceId),
+              this.getConsentBits());
         }
       });
     }

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -143,9 +143,12 @@ describe('Social.FreedomNetwork', () => {
       spyOn(network['freedomApi_'], 'login').and.returnValue(
           Promise.reject(new Error('mock failure')));
       spyOn(network, 'error');
-      network.login(false).catch(() => {
-        expect(network['error']).toHaveBeenCalledWith('Could not login.');
-      }).then(done);
+      network.login(false).then(
+        () => { return Promise.reject(); },  // login should not fulfill.
+        () => {
+          expect(network['error']).toHaveBeenCalledWith('Could not login.');
+          done()
+        });;
       // We need to tick a clock in order promises to be resolved.
       jasmine.clock().tick(1);
     });

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -148,7 +148,7 @@ describe('Social.FreedomNetwork', () => {
         () => {
           expect(network['error']).toHaveBeenCalledWith('Could not login.');
           done()
-        });;
+        });
       // We need to tick a clock in order promises to be resolved.
       jasmine.clock().tick(1);
     });

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -313,15 +313,16 @@ describe('Social.FreedomNetwork', () => {
       var msg = {type: uProxy.MessageType.INSTANCE, data: {'doge': 'wows'}};
       network.send('fakeclient', msg);
       expect(network['freedomApi_'].sendMessage).toHaveBeenCalledWith(
-        'fakeclient',
-        '{"type":' + uProxy.MessageType.INSTANCE + ',"data":{"doge":"wows"}}');
+        'fakeclient', JSON.stringify(msg));
     });
 
     it('send rejects for unknown clientId', (done) => {
       network['freedomApi_'].sendMessage = jasmine.createSpy('sendMessage');
       var msg = {type: uProxy.MessageType.INSTANCE, data: {'doge': 'wows'}};
-      network.send('unknownclient', msg).then(() => {}, (e) => { done(); });
-      expect(network['freedomApi_'].sendMessage).not.toHaveBeenCalled();
+      network.send('unknownclient', msg).then(() => {}, (e) => {
+        expect(network['freedomApi_'].sendMessage).not.toHaveBeenCalled();
+        done();
+      });
     });
 
     it('sends instance handshake', (done) => {

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -210,16 +210,14 @@ module Social {
         console.error('Not ready to send handshake');
         return;
       }
-      var handshake = {
+      var instanceHandshake = {
         type: uProxy.MessageType.INSTANCE,
         data: {
          handshake: this.myInstance.getInstanceHandshake(),
          consent: consent
         }
       };
-      return this.send(clientId, handshake).then(() => {
-        this.log('Sent instance handshake to ' + clientId);
-      });
+      return this.send(clientId, instanceHandshake);
     }
 
     /**
@@ -279,6 +277,8 @@ module Social {
 
     // ID returned by setInterval call for monitoring.
     private monitorIntervalId_ :number = null;
+
+    private mapClientIdToUserId_ :{ [clientId :string] :string } = {};
 
     private fulfillLogout_ : () => void;
     private onceLoggedOut_ : Promise<void>;
@@ -390,6 +390,7 @@ module Social {
         // Ignore clients that aren't using uProxy.
         return;
       }
+      this.mapClientIdToUserId_[client.clientId] = client.userId;
 
       if (client.userId == this.myInstance.userId) {
         // Log out if it's our own client id.
@@ -422,7 +423,6 @@ module Social {
       }
       var userId = incoming.from.userId;
       var msg :uProxy.Message = JSON.parse(incoming.message);
-      this.log('received <------ ' + incoming.message);
 
       var client :UProxyClient.State =
           freedomClientToUproxyClient(incoming.from);
@@ -436,6 +436,15 @@ module Social {
         // Add client.
         user.handleClient(client);
       }
+
+      console.log(
+          'received message from userId: ' + user.userId +
+          ', clientId: ' + client.clientId +
+          // Instance may be undefined if we have not yet created an instance
+          // for this client, e.g. if this is the first instance message we
+          // are receiving from them.  This is not an error.
+          ', instanceId: ' + user.clientToInstance(client.clientId) +
+          ', message: ' + JSON.stringify(msg));
       user.handleMessage(client.clientId, msg);
     }
 
@@ -495,6 +504,9 @@ module Social {
               }
               ui.showNotification('You have been logged out of ' + this.name);
               Social.removeNetwork(this.name, this.myInstance.userId);
+              console.log('Fulfilling onceLoggedOut_');
+            }).catch((e) => {
+              console.error('Error fulfilling onceLoggedOut_', e);
             });
             this.restoreFromStorage();
           })
@@ -508,19 +520,36 @@ module Social {
 
     public logout = () : Promise<void> => {
       return this.freedomApi_.logout().then(() => {
-        this.log('logged out.');
         this.fulfillLogout_();
+      }).catch((e) => {
+        console.error('error in this.freedomApi_.logout', e);
+        return Promise.reject(e);
       });
     }
 
     /**
      * Promise the sending of |msg| to a client with id |clientId|.
      */
-    public send = (recipientClientId :string,
+    public send = (clientId :string,
                    message :uProxy.Message) : Promise<void> => {
+      var userId = this.mapClientIdToUserId_[clientId];
+      if (!userId) {
+        return Promise.reject('userId not found for clientId ' + clientId);
+      }
+      var user = this.roster[userId];
+      if (!user) {
+        return Promise.reject('user not found for userId ' + userId);
+      }
       var messageString = JSON.stringify(message);
-      this.log('sending ------> ' + messageString);
-      return this.freedomApi_.sendMessage(recipientClientId, messageString);
+      console.log(
+          'sending message to userId: ' + userId +
+          ', clientId: ' + clientId +
+          // Instance may be undefined if we are making an instance request,
+          // i.e. we know that a client is ONLINE with uProxy, but don't
+          // yet have their instance info.  This is not an error.
+          ', instanceId: ' + user.clientToInstance(clientId) +
+          ', message: ' + messageString);
+      return this.freedomApi_.sendMessage(clientId, messageString);
     }
 
     // TODO: We should make a class for monitors or generally to encapsulate

--- a/src/generic_core/user.spec.ts
+++ b/src/generic_core/user.spec.ts
@@ -258,39 +258,4 @@ describe('Core.User', () => {
     });
 
   });  // describe client <---> instance
-
-  describe('instance sending promises', () => {
-
-    var msg :uProxy.Message = {
-      type: uProxy.MessageType.INSTANCE,
-      data: 'foo'
-    };
-    var reconnect = null;
-    var reconnected = false;
-
-    beforeEach(() => {
-      // Pretend that Social.Network.send always returns a successful promise.
-      spyOn(network, 'send').and.returnValue(Promise.resolve());
-      if (instance) {
-        spyOn(instance, 'update');
-        spyOn(instance, 'send');
-      }
-    })
-
-    it('sending message to online instanceId fulfills promise with clientId',
-        (done) => {
-      instance = user.getInstance('fakeinstance');
-      user.send('fakeinstance', msg).then((clientId) => {
-        expect(clientId).toEqual('fakeclient');
-      }).then(done);
-    });
-
-    it('sending message to invalid instanceId throws error', (done) => {
-      instance = user.getInstance('fakeinstance');
-      user.send('nobody', msg).catch((e) => {
-        expect(e.message).toEqual('Cannot send to invalid instance nobody');
-      }).then(done);
-    });
-
-  });  // describe instance sending promises
 });  // uProxy.User

--- a/src/generic_core/user.spec.ts
+++ b/src/generic_core/user.spec.ts
@@ -8,7 +8,6 @@ describe('Core.User', () => {
   // Prepare a fake Social.Network object to construct User on top of.
   var network = jasmine.createSpyObj('network', [
       'api',
-      'sendInstanceHandshake',
       'getStorePath',
       'notifyUI'
   ]);
@@ -69,6 +68,7 @@ describe('Core.User', () => {
   });
 
   it('sends an instance message to newly ONLINE clients', () => {
+    spyOn(user, 'sendInstanceHandshake');
     var clientState :UProxyClient.State = {
       userId: 'fakeuser',
       clientId: 'fakeclient',
@@ -76,12 +76,12 @@ describe('Core.User', () => {
       timestamp: 12345
     };
     user.handleClient(clientState);
-    expect(network.sendInstanceHandshake).toHaveBeenCalledWith('fakeclient', null);
+    expect(user.sendInstanceHandshake).toHaveBeenCalledWith('fakeclient', null);
     expect(user.clientIdToStatusMap['fakeclient']).toEqual(UProxyClient.Status.ONLINE);
   });
 
   it('does not re-send instance messages to the same client', () => {
-    network.sendInstanceHandshake.calls.reset();
+    spyOn(user, 'sendInstanceHandshake');
     expect(user.clientIdToStatusMap['fakeclient']).toEqual(UProxyClient.Status.ONLINE);
     var clientState :UProxyClient.State = {
       userId: 'fakeuser',
@@ -90,7 +90,7 @@ describe('Core.User', () => {
       timestamp: 12345
     };
     user.handleClient(clientState);
-    expect(network.sendInstanceHandshake).not.toHaveBeenCalled();
+    expect(user.sendInstanceHandshake).not.toHaveBeenCalled();
   });
 
   it('does not add clients that are ONLINE_WITH_OTHER_APP', () => {
@@ -116,6 +116,7 @@ describe('Core.User', () => {
   });
 
   it('re-adds an re-sends instance message to new ONLINE clients', () => {
+    spyOn(user, 'sendInstanceHandshake');
     var clientState :UProxyClient.State = {
       userId: 'fakeuser',
       clientId: 'fakeclient',
@@ -123,7 +124,7 @@ describe('Core.User', () => {
       timestamp: 12345
     };
     user.handleClient(clientState);
-    expect(network.sendInstanceHandshake).toHaveBeenCalledWith('fakeclient', null);
+    expect(user.sendInstanceHandshake).toHaveBeenCalledWith('fakeclient', null);
     expect(user.clientIdToStatusMap['fakeclient']).toEqual(UProxyClient.Status.ONLINE);
   });
 
@@ -258,4 +259,23 @@ describe('Core.User', () => {
     });
 
   });  // describe client <---> instance
+
+  it('sends instance handshake', (done) => {
+    var network = user.network;
+    network['myInstance'] = {getInstanceHandshake: function() {}};
+    spyOn(network['myInstance'], 'getInstanceHandshake').and.returnValue(
+      'fake-instance-handshake');
+    spyOn(network, 'send').and.returnValue(Promise.resolve());
+    user.sendInstanceHandshake('fakeclient', null).then(() => {
+      expect(network['myInstance']['getInstanceHandshake']).toHaveBeenCalled();
+      expect(network.send).toHaveBeenCalledWith(user, 'fakeclient', {
+          type: uProxy.MessageType.INSTANCE,
+          data: {
+            handshake: 'fake-instance-handshake',
+            consent: null
+          }
+      });
+    }).then(done);
+  });
+
 });  // uProxy.User

--- a/src/generic_core/user.ts
+++ b/src/generic_core/user.ts
@@ -217,7 +217,7 @@ module Core {
       if (typeof instanceId === 'undefined') {
         return null;
       }
-      return (this.instances_[instanceId]).getConsentBits();;
+      return (this.instances_[instanceId]).getConsentBits();
     }
 
     public getInstance = (instanceId:string) : Core.RemoteInstance => {

--- a/src/generic_core/user.ts
+++ b/src/generic_core/user.ts
@@ -114,30 +114,6 @@ module Core {
     }
 
     /**
-     * Send a message to an Instance belonging to this user.
-     * Warns if instanceId does not exist on this user.
-     * If the instanceId does exist, but is currently offline (i.e. has no
-     * client associated), then it delays the send until the next time that
-     * instance becomes online using promises.
-     *
-     * Returns a promise that the message was sent to the instanceId, fulfilled
-     * with the clientId of the recipient.
-     */
-    public send = (instanceId :string, payload :uProxy.Message)
-        : Promise<string> => {
-      if (!(instanceId in this.instances_)) {
-        console.warn('Cannot send message to non-existing instance ' +
-                     instanceId);
-        return Promise.reject(new Error(
-            'Cannot send to invalid instance ' + instanceId));
-      }
-      var clientId = this.instanceToClientMap_[instanceId];
-      return this.network.send(clientId, payload).then(() => {
-        return clientId;
-      });
-    }
-
-    /**
      * Handle 'onClientState' events from the social provider, which indicate
      * changes in status such as becoming online, offline.
      *  - Only adds uProxy clients to the clients table.
@@ -314,7 +290,7 @@ module Core {
       return this.clientToInstanceMap_[clientId];
     }
 
-    public instanceToClient= (instanceId :string) : string => {
+    public instanceToClient = (instanceId :string) : string => {
       return this.instanceToClientMap_[instanceId];
     }
 
@@ -401,11 +377,11 @@ module Core {
 
     private requestInstance_ = (clientId) : void => {
       this.log('requesting instance');
-      var instanceRequestMsg :uProxy.Message = {
+      var instanceRequest :uProxy.Message = {
         type: uProxy.MessageType.INSTANCE_REQUEST,
         data: {}
       };
-      this.network.send(clientId, instanceRequestMsg);
+      this.network.send(clientId, instanceRequest);
     }
 
     public isInstanceOnline = (instanceId :string) : boolean => {

--- a/src/generic_ui/polymer/network.html
+++ b/src/generic_ui/polymer/network.html
@@ -19,33 +19,6 @@
       paper-button.Facebook {
         background: #3b5998;
       }
-      #waiting {
-        color: #bbb;
-        position: relative;
-        cursor: default;
-      }
-      #hourglass {
-        position: absolute;
-        height: 28px; width: 28px;
-        left: 40px; top: 20px;
-        background-image: url('../icons/waiting_grey.svg');
-        -webkit-animation-name: rotate;
-        -webkit-animation-duration: 1s;
-        -webkit-animation-iteration-count: infinite;
-        -webkit-animation-timing-function: linear;
-        -moz-animation-name: rotate;
-        -moz-animation-duration: 1s;
-        -moz-animation-iteration-count: infinite;
-        -moz-animation-timing-function: linear;
-      }
-      @-webkit-keyframes rotate {
-        from {-webkit-transform: rotate(0deg);}
-        to {-webkit-transform: rotate(360deg);}
-      }
-      @-moz-keyframes rotate {
-        from {-moz-transform: rotate(0deg);}
-        to {-moz-transform: rotate(360deg);}
-      }
     </style>
 
     <div class='network'>

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -10,8 +10,11 @@ Polymer({
   logOut: function() {
     core.logout({name: model.onlineNetwork.name,
                  userId: model.onlineNetwork.userId}).then(() => {
-      ui.view = UI.View.SPLASH;
-      ui.setOfflineIcon();
+      // Nothing to do here - the UI should receive a NETWORK update
+      // saying that the network is offline, and will update the display
+      // as result of that.
+    }).catch((e) => {
+      console.error('logout returned error: ', e);
     });
   },
   restart: function() {

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -21,7 +21,7 @@
     h1 {
       font-size: 1.4em;
       color: #009688;  /* dark green */
-      margin-bottom: 2em;
+      margin-bottom: 1.5em;
     }
     #proxy-pic {
       opacity: 0.3;
@@ -44,12 +44,15 @@
       width: 150px;
     }
     uproxy-network {
-      padding-bottom: 32px;
+      padding: 1em;
     }
     #nextWrapper {
       margin-top: 50px;
       left: 0;
       width: 100%;
+    }
+    #oneTimeConnection {
+      margin-bottom: 1.5em;
     }
     uproxy-faq-link {
       position: absolute;
@@ -63,9 +66,6 @@
     }
     .uproxy-logo {
       margin-bottom: 1em;
-    }
-    p {
-      margin-top: 1em;
     }
     .prevArrow {
       position: absolute;
@@ -104,8 +104,10 @@
         <template repeat='{{ n in model.networkNames }}' vertical layout>
           <uproxy-network networkName='{{n}}'></uproxy-network>
         </template>
-        <a href='#' on-tap='{{ copypaste }}'>Set up a one time connection</a>
-        <p style="margin-top: 0">
+        <p id='oneTimeConnection'>
+          <a href='#' on-tap='{{ copypaste }}'>Set up a one time connection</a>
+        </p>
+        <p>
           We won't share your data or post publicly without your consent
         </p>
       </div>

--- a/src/interfaces/network.d.ts
+++ b/src/interfaces/network.d.ts
@@ -52,24 +52,6 @@ declare module Social {
     getUser :(userId :string) => Core.User;
 
     /**
-     * Notifies a remote uProxy installation that we are also a uProxy
-     * installation.
-     *
-     * Sends this network's instance handshake to a target clientId.
-     * Assumes that clientId is ONLINE.
-     *
-     * NOTE: This is one of the few cases where we send a Message directly to a
-     * |clientId| rather than |instanceId|. This is because there is not yet a
-     * known instanceId, and also because this is internal to
-     * Social.FreedomNetwork mechanics.
-     *
-     * TODO: Clarify terminology. "Handshake" implies participation and
-     * agreement of two parties, but here "handshake" is something that can be
-     * unilaterally sent.
-     */
-    sendInstanceHandshake :(clientId:string, consent :Consent.WireState) => Promise<void>;
-
-    /**
       * Resends the instance handeshake to all uProxy instances.
       */
     resendInstanceHandshakes :() => void;
@@ -86,7 +68,8 @@ declare module Social {
      * being invalid / offline, the promise returned from the social provider
      * will reject.
      */
-    send :(clientId:string, msg:uProxy.Message) => Promise<void>;
+    send :(user :Core.User, clientId:string, msg:uProxy.Message)
+        => Promise<void>;
   }
 
 }  // module Social

--- a/src/interfaces/network.d.ts
+++ b/src/interfaces/network.d.ts
@@ -79,8 +79,8 @@ declare module Social {
      *
      * Assumes that |clientId| is valid. Implementations of Social.Network do
      * not manually manage lists of clients or instances. (That is handled in
-     * user.ts, which calls Network.send after doing the validation
-     * checks itself.)
+     * user.ts, which calls Network.send after doing the validation checks
+     * itself.)
      *
      * Still, it is expected that if there is a problem, such as the clientId
      * being invalid / offline, the promise returned from the social provider

--- a/src/interfaces/network.d.ts
+++ b/src/interfaces/network.d.ts
@@ -79,8 +79,8 @@ declare module Social {
      *
      * Assumes that |clientId| is valid. Implementations of Social.Network do
      * not manually manage lists of clients or instances. (That is handled in
-     * user.ts, which calls Network.send after doing the validation checks
-     * itself.)
+     * user.ts, which calls Network.send after doing the validation
+     * checks itself.)
      *
      * Still, it is expected that if there is a problem, such as the clientId
      * being invalid / offline, the promise returned from the social provider


### PR DESCRIPTION
* Remove _ fields from consent messages/storage: https://github.com/uProxy/uproxy/issues/871
* better message logging and cleanup of send method (now only Network has a send method which handles logging, rather than additional methods in User and RemoteInstance): https://github.com/uProxy/uproxy/issues/1001
* small UI cleanup to splash screen (more padding around "Set up a one time connection"), now looks like:
![screen shot 2015-02-26 at 8 46 13 pm](https://cloud.githubusercontent.com/assets/6494307/6405993/8fa494ae-bdf8-11e4-9176-d6819eb419f9.png)


Tested in Chrome, new grunt test (found https://github.com/uProxy/uproxy/issues/1011)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1012)
<!-- Reviewable:end -->
