### PR TITLE
Add transparency to the paper-tab ink effect

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -49,6 +49,7 @@
       }
       #toolbar paper-tab::shadow #ink {
         color: #20F1DE;
+        opacity: .4;
       }
       #toolbar paper-tab {
         opacity: .6;


### PR DESCRIPTION
This (hopefully) fixes the UI issue of the ink effect appearing to be
too jarring on the navigation tabs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1013)
<!-- Reviewable:end -->
