### PR TITLE
Remove private Consent.State fields so we no longer need serialize

### DIFF
--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -21,27 +21,21 @@ module Consent {
   // User-level consent state w.r.t. a remote instance. This state is stored
   // in local storage for each instance ID we know of.
   export class State {
-    // Local user's relationship with remote instance. These are
-    // managed by getters and setters to maintain the invariant
-    // relationship with the corresponding ignoring* fields below.
-    private localGrantsAccessToRemote_ :boolean;
-    private localRequestsAccessFromRemote_ :boolean;
+    // Local user's relationship with remote instance.
+    localGrantsAccessToRemote :boolean;
+    localRequestsAccessFromRemote :boolean;
 
     // Cached values from remote user's instance sent over signalling channel.
     remoteGrantsAccessToLocal :boolean;
     remoteRequestsAccessFromLocal :boolean;
 
     // Local user's UI controls for remote requests and offers.
-    // Invariants: If localGrantsAccessToRemote is true,
-    // ignoringRemoteUserRequest must be false. If
-    // localRequestsAccessFromRemote is true, ignoringRemoteUserOffer
-    // must be false.
     ignoringRemoteUserRequest :boolean;
     ignoringRemoteUserOffer :boolean;
 
     constructor() {
-      this.localGrantsAccessToRemote_ = false;
-      this.localRequestsAccessFromRemote_ = false;
+      this.localGrantsAccessToRemote = false;
+      this.localRequestsAccessFromRemote = false;
       this.remoteGrantsAccessToLocal = false;
       this.remoteRequestsAccessFromLocal = false;
       this.ignoringRemoteUserRequest = false;
@@ -53,38 +47,6 @@ module Consent {
     // - set the local* val to false
     // - ignore attempt to set ignoring* val
     // - allow ignoring* to be true when local* is true
-
-    // setters to guarantee invariants
-    public get localGrantsAccessToRemote() :boolean {
-      return this.localGrantsAccessToRemote_;
-    }
-    public set localGrantsAccessToRemote(granted :boolean) {
-      this.localGrantsAccessToRemote_ = granted;
-      if (granted) {
-        this.ignoringRemoteUserRequest = false;
-      }
-    }
-    public get localRequestsAccessFromRemote() :boolean {
-      return this.localRequestsAccessFromRemote_;
-    }
-    public set localRequestsAccessFromRemote(requested :boolean) {
-      this.localRequestsAccessFromRemote_ = requested;
-      if (requested) {
-        this.ignoringRemoteUserOffer = false;
-      }
-    }
-  }
-
-  // Return an object with only public consent fields, and no "_" fields.
-  export function serialize(consent :Consent.State) {
-    return {
-      localGrantsAccessToRemote: consent.localGrantsAccessToRemote,
-      localRequestsAccessFromRemote: consent.localRequestsAccessFromRemote,
-      remoteGrantsAccessToLocal: consent.remoteGrantsAccessToLocal,
-      remoteRequestsAccessFromLocal: consent.remoteRequestsAccessFromLocal,
-      ignoringRemoteUserRequest: consent.ignoringRemoteUserRequest,
-      ignoringRemoteUserOffer: consent.ignoringRemoteUserOffer
-    };
   }
 
   export function updateStateFromRemoteState(state :State, remoteState :WireState) {
@@ -97,6 +59,7 @@ module Consent {
     switch(action) {
       case UserAction.OFFER:
         state.localGrantsAccessToRemote = true;
+        state.ignoringRemoteUserRequest = false;
         break;
       case UserAction.CANCEL_OFFER:
         state.localGrantsAccessToRemote = false;
@@ -109,6 +72,7 @@ module Consent {
         break;
       case UserAction.REQUEST:
         state.localRequestsAccessFromRemote = true;
+        state.ignoringRemoteUserOffer = false;
         break;
       case UserAction.CANCEL_REQUEST:
         state.localRequestsAccessFromRemote = false;

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -352,7 +352,7 @@ module Core {
      */
     public currentState = () :RemoteInstanceState => {
       return cloneDeep({
-        consent:     Consent.serialize(this.consent),
+        consent:     this.consent,
         description: this.description,
         keyHash:     this.keyHash
       });
@@ -378,7 +378,7 @@ module Core {
         instanceId:             this.instanceId,
         description:            this.description,
         keyHash:                this.keyHash,
-        consent:                Consent.serialize(this.consent),
+        consent:                this.consent,
         localGettingFromRemote: this.localGettingFromRemote,
         localSharingWithRemote: this.localSharingWithRemote,
         isOnline:               this.user.isInstanceOnline(this.instanceId),


### PR DESCRIPTION
Fixes #1025 and provides a better fix for #871.

Tested in "grunt test" and Chrome

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1026)
<!-- Reviewable:end -->
