### PR TITLE
remove core/consent.js  from UI build

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -513,7 +513,6 @@ module.exports = (grunt) ->
       generic_ui:
         src: FILES.jasmine_helpers
             .concat [
-              'build/compile-src/generic_core/consent.js'
               'build/compile-src/generic_ui/scripts/user.js'
               'build/compile-src/generic_ui/scripts/ui.js'
             ]

--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -20,7 +20,7 @@ module Consent {
 
   // User-level consent state w.r.t. a remote instance. This state is stored
   // in local storage for each instance ID we know of.
-  export class State {
+  export class State implements uProxy.ConsentState {
     // Local user's relationship with remote instance.
     localGrantsAccessToRemote :boolean;
     localRequestsAccessFromRemote :boolean;

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -1,5 +1,4 @@
 /// <reference path='../../third_party/typings/jasmine/jasmine.d.ts' />
-/// <reference path='../../generic_core/consent.ts' />
 /// <reference path='ui.ts' />
 
 describe('UI.UserInterface', () => {
@@ -7,6 +6,26 @@ describe('UI.UserInterface', () => {
   var ui :UI.UserInterface;
   var mockBrowserApi;
   var updateToHandlerMap = {};
+
+  function getInstance(instanceId :string, description :string) :UI.Instance {
+    return {
+      instanceId: instanceId,
+      description: description,
+      consent: {
+        localGrantsAccessToRemote: false,
+        localRequestsAccessFromRemote: false,
+        remoteGrantsAccessToLocal: false,
+        remoteRequestsAccessFromLocal: false,
+        ignoringRemoteUserRequest: false,
+        ignoringRemoteUserOffer: false
+      },
+      localSharingWithRemote: SharingState.NONE,
+      localGettingFromRemote: GettingState.NONE,
+      isOnline: true,
+      bytesSent: 0,
+      bytesReceived: 0
+    }
+  }
 
   beforeEach(() => {
     // Create a fresh UI object before each test.
@@ -35,16 +54,9 @@ describe('UI.UserInterface', () => {
         name: userName,
         imageData: 'testImageData'
       },
-      instances: [{
-        instanceId: instanceId,
-        description: 'description1',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      }]
+      instances: [
+        getInstance(instanceId, 'description1')
+      ]
     };
     ui.syncUser(payload);
   }
@@ -64,16 +76,9 @@ describe('UI.UserInterface', () => {
           name: 'Alice',
           imageData: 'testImageData'
         },
-        instances: [{
-          instanceId: 'instance1',
-          description: 'description1',
-          consent: new Consent.State(),
-          localSharingWithRemote: SharingState.NONE,
-          localGettingFromRemote: GettingState.NONE,
-          isOnline: true,
-          bytesSent: 0,
-          bytesReceived: 0
-        }]
+        instances: [
+          getInstance('instance1', 'description1')
+        ]
       };
       ui.syncUser(payload);
       var user :UI.User = model.onlineNetwork.roster['testUserId'];
@@ -94,30 +99,14 @@ describe('UI.UserInterface', () => {
                      userId: 'fakeUser',
                      online: true,
                      roster: {}});
-      var clientInstance :UI.Instance = {
-        instanceId: 'instance1',
-        description: 'description1',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      };
+      var clientInstance = getInstance('instance1', 'description1');
       clientInstance.consent.localRequestsAccessFromRemote = true;
       clientInstance.consent.remoteGrantsAccessToLocal = true;
-      var serverInstance :UI.Instance = {
-        instanceId: 'instance2',
-        description: 'description2',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      };
+
+      var serverInstance = getInstance('instance2', 'description2');
       serverInstance.consent.localGrantsAccessToRemote = true;
       serverInstance.consent.remoteRequestsAccessFromLocal = true;
+
       var payload :UI.UserMessage = {
         network: 'testNetwork',
         user: {

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -10,11 +10,18 @@ describe('UI.User', () => {
     spyOn(console, 'log');
   });
 
-  function getInstance(id :string, description :string) {
+  function getInstance(id :string, description :string) :UI.Instance {
     return {
       instanceId: id,
       description: description,
-      consent: new Consent.State(),
+      consent: {
+        localGrantsAccessToRemote: false,
+        localRequestsAccessFromRemote: false,
+        remoteGrantsAccessToLocal: false,
+        remoteRequestsAccessFromLocal: false,
+        ignoringRemoteUserRequest: false,
+        ignoringRemoteUserOffer: false
+      },
       localSharingWithRemote: SharingState.NONE,
       localGettingFromRemote: GettingState.NONE,
       isOnline: true,

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -4,7 +4,6 @@
  * This is the UI-specific representation of a User.
  */
 /// <reference path='../../freedom/typings/social.d.ts' />
-/// <reference path='../../generic_core/consent.ts' />
 /// <reference path='../../interfaces/user.d.ts' />
 
 module UI {

--- a/src/interfaces/ui.d.ts
+++ b/src/interfaces/ui.d.ts
@@ -50,7 +50,7 @@ declare module UI {
   export interface Instance {
     instanceId             :string;
     description            :string;
-    consent                :Consent.State;
+    consent                :uProxy.ConsentState;
     localGettingFromRemote :GettingState;
     localSharingWithRemote :SharingState;
     isOnline               :boolean;

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -104,6 +104,16 @@ module uProxy {
     data :Object;
   }
 
+  // the state for consent between two instances
+  export interface ConsentState {
+    localGrantsAccessToRemote :boolean;
+    localRequestsAccessFromRemote :boolean;
+    remoteGrantsAccessToLocal :boolean;
+    remoteRequestsAccessFromLocal :boolean;
+    ignoringRemoteUserRequest :boolean;
+    ignoringRemoteUserOffer :boolean;
+  }
+
   /**
    * ConsentCommands are sent from the UI to the Core, to modify the consent of
    * a :RemoteInstance in the local client. (This is not sent on the wire to


### PR DESCRIPTION
This removes the consent.js file from the UI build by adding a new
interface, ConsentState, and using that on the UI side instead of trying
to create actual consent objects.

This creates the interface uProxy.ConsentState, switches the consent
field in the UI.Instance to be of type uProxy.ConsentState, and removes
some code duplication in tests (while moving them away from using
Consent.State

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1028)
<!-- Reviewable:end -->
