### PR TITLE
remove core/consent.js from UI build

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -73,7 +73,6 @@ FILES =
   # Files which are required at run-time everywhere.
   uproxy_common: [
     'uproxy.js'
-    'generic_core/consent.js'
     'generic_core/util.js'
   ]
 
@@ -513,7 +512,6 @@ module.exports = (grunt) ->
       generic_ui:
         src: FILES.jasmine_helpers
             .concat [
-              'build/compile-src/generic_core/consent.js'
               'build/compile-src/generic_ui/scripts/user.js'
               'build/compile-src/generic_ui/scripts/ui.js'
             ]

--- a/src/generic_core/consent.spec.ts
+++ b/src/generic_core/consent.spec.ts
@@ -13,7 +13,7 @@
 describe('Consent', () => {
 
   it('all Enums are defined in js', () => {
-    expect(uProxy.UserAction).toBeDefined();
+    expect(uProxy.ConsentUserAction).toBeDefined();
   });
 
   it('all functions are defined', () => {

--- a/src/generic_core/consent.spec.ts
+++ b/src/generic_core/consent.spec.ts
@@ -13,7 +13,7 @@
 describe('Consent', () => {
 
   it('all Enums are defined in js', () => {
-    expect(Consent.UserAction).toBeDefined();
+    expect(uProxy.UserAction).toBeDefined();
   });
 
   it('all functions are defined', () => {

--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -32,42 +32,42 @@ module Consent {
     // - allow ignoring* to be true when local* is true
   }
 
-  export function updateStateFromRemoteState(state :State, remoteState :uProxy.WireState) {
+  export function updateStateFromRemoteState(state :State, remoteState :uProxy.ConsentWireState) {
     state.remoteRequestsAccessFromLocal = remoteState.isRequesting;
     state.remoteGrantsAccessToLocal = remoteState.isOffering;
   }
 
   // Returns false on invalid actions.
-  export function handleUserAction(state :State, action :uProxy.UserAction) :boolean {
+  export function handleUserAction(state :State, action :uProxy.ConsentUserAction) :boolean {
     switch(action) {
-      case uProxy.UserAction.OFFER:
+      case uProxy.ConsentUserAction.OFFER:
         state.localGrantsAccessToRemote = true;
         state.ignoringRemoteUserRequest = false;
         break;
-      case uProxy.UserAction.CANCEL_OFFER:
+      case uProxy.ConsentUserAction.CANCEL_OFFER:
         state.localGrantsAccessToRemote = false;
         break;
-      case uProxy.UserAction.IGNORE_REQUEST:
+      case uProxy.ConsentUserAction.IGNORE_REQUEST:
         state.ignoringRemoteUserRequest = true;
         break;
-      case uProxy.UserAction.UNIGNORE_REQUEST:
+      case uProxy.ConsentUserAction.UNIGNORE_REQUEST:
         state.ignoringRemoteUserRequest = false;
         break;
-      case uProxy.UserAction.REQUEST:
+      case uProxy.ConsentUserAction.REQUEST:
         state.localRequestsAccessFromRemote = true;
         state.ignoringRemoteUserOffer = false;
         break;
-      case uProxy.UserAction.CANCEL_REQUEST:
+      case uProxy.ConsentUserAction.CANCEL_REQUEST:
         state.localRequestsAccessFromRemote = false;
         break;
-      case uProxy.UserAction.IGNORE_OFFER:
+      case uProxy.ConsentUserAction.IGNORE_OFFER:
         state.ignoringRemoteUserOffer = true;
         break;
-      case uProxy.UserAction.UNIGNORE_OFFER:
+      case uProxy.ConsentUserAction.UNIGNORE_OFFER:
         state.ignoringRemoteUserOffer = false;
         break;
       default:
-        console.warn('Invalid uProxy.UserAction! ' + action);
+        console.warn('Invalid uProxy.ConsentUserAction! ' + action);
         return false;
     }
     return true;

--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -1,26 +1,9 @@
 /// <reference path='util.ts' />
 
 module Consent {
-  // The different states that uProxy consent can be in w.r.t. a peer. These
-  // are the values that get sent or received on the wire.
-  export interface WireState {
-    isRequesting :boolean;
-    isOffering   :boolean;
-  }
-
-  // Action taken by the user. These values are not on the wire. They are passed
-  // in messages from the UI to the core. They correspond to the different
-  // buttons that the user may be clicking on.
-  export enum UserAction {
-    // Actions made by user w.r.t. remote as a proxy
-    REQUEST = 5000, CANCEL_REQUEST, IGNORE_OFFER, UNIGNORE_OFFER,
-    // Actions made by user w.r.t. remote as a client
-    OFFER = 5100, CANCEL_OFFER, IGNORE_REQUEST, UNIGNORE_REQUEST,
-  }
-
   // User-level consent state w.r.t. a remote instance. This state is stored
   // in local storage for each instance ID we know of.
-  export class State {
+  export class State implements uProxy.ConsentState {
     // Local user's relationship with remote instance.
     localGrantsAccessToRemote :boolean;
     localRequestsAccessFromRemote :boolean;
@@ -49,42 +32,42 @@ module Consent {
     // - allow ignoring* to be true when local* is true
   }
 
-  export function updateStateFromRemoteState(state :State, remoteState :WireState) {
+  export function updateStateFromRemoteState(state :State, remoteState :uProxy.WireState) {
     state.remoteRequestsAccessFromLocal = remoteState.isRequesting;
     state.remoteGrantsAccessToLocal = remoteState.isOffering;
   }
 
   // Returns false on invalid actions.
-  export function handleUserAction(state :State, action :UserAction) :boolean {
+  export function handleUserAction(state :State, action :uProxy.UserAction) :boolean {
     switch(action) {
-      case UserAction.OFFER:
+      case uProxy.UserAction.OFFER:
         state.localGrantsAccessToRemote = true;
         state.ignoringRemoteUserRequest = false;
         break;
-      case UserAction.CANCEL_OFFER:
+      case uProxy.UserAction.CANCEL_OFFER:
         state.localGrantsAccessToRemote = false;
         break;
-      case UserAction.IGNORE_REQUEST:
+      case uProxy.UserAction.IGNORE_REQUEST:
         state.ignoringRemoteUserRequest = true;
         break;
-      case UserAction.UNIGNORE_REQUEST:
+      case uProxy.UserAction.UNIGNORE_REQUEST:
         state.ignoringRemoteUserRequest = false;
         break;
-      case UserAction.REQUEST:
+      case uProxy.UserAction.REQUEST:
         state.localRequestsAccessFromRemote = true;
         state.ignoringRemoteUserOffer = false;
         break;
-      case UserAction.CANCEL_REQUEST:
+      case uProxy.UserAction.CANCEL_REQUEST:
         state.localRequestsAccessFromRemote = false;
         break;
-      case UserAction.IGNORE_OFFER:
+      case uProxy.UserAction.IGNORE_OFFER:
         state.ignoringRemoteUserOffer = true;
         break;
-      case UserAction.UNIGNORE_OFFER:
+      case uProxy.UserAction.UNIGNORE_OFFER:
         state.ignoringRemoteUserOffer = false;
         break;
       default:
-        console.warn('Invalid Consent.UserAction! ' + action);
+        console.warn('Invalid uProxy.UserAction! ' + action);
         return false;
     }
     return true;

--- a/src/generic_core/core.spec.ts
+++ b/src/generic_core/core.spec.ts
@@ -54,13 +54,13 @@ describe('Core', () => {
         userId: 'user-alice',
         instanceId: 'instance-alice'
       },
-      action: Consent.UserAction.REQUEST
+      action: uProxy.UserAction.REQUEST
     };
     core.modifyConsent(command);
     expect(Social.getNetwork).toHaveBeenCalledWith('fake-network', 'fake-login');
     expect(network.getUser).toHaveBeenCalledWith('user-alice');
     expect(user.getInstance).toHaveBeenCalledWith('instance-alice');
-    expect(alice.modifyConsent).toHaveBeenCalledWith(Consent.UserAction.REQUEST);
+    expect(alice.modifyConsent).toHaveBeenCalledWith(uProxy.UserAction.REQUEST);
   });
 
   it('relays incoming manual network messages to the manual network', () => {

--- a/src/generic_core/core.spec.ts
+++ b/src/generic_core/core.spec.ts
@@ -54,13 +54,13 @@ describe('Core', () => {
         userId: 'user-alice',
         instanceId: 'instance-alice'
       },
-      action: uProxy.UserAction.REQUEST
+      action: uProxy.ConsentUserAction.REQUEST
     };
     core.modifyConsent(command);
     expect(Social.getNetwork).toHaveBeenCalledWith('fake-network', 'fake-login');
     expect(network.getUser).toHaveBeenCalledWith('user-alice');
     expect(user.getInstance).toHaveBeenCalledWith('instance-alice');
-    expect(alice.modifyConsent).toHaveBeenCalledWith(uProxy.UserAction.REQUEST);
+    expect(alice.modifyConsent).toHaveBeenCalledWith(uProxy.ConsentUserAction.REQUEST);
   });
 
   it('relays incoming manual network messages to the manual network', () => {

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -73,7 +73,7 @@ describe('Core.RemoteInstance', () => {
       };
       spyOn(instance0, 'sendConsent');
       instance0.update(handshake);
-      instance0.modifyConsent(Consent.UserAction.REQUEST);
+      instance0.modifyConsent(uProxy.UserAction.REQUEST);
 
       instance0.onceLoaded.then(() => {
         expect(saved).toBeDefined();
@@ -104,7 +104,7 @@ describe('Core.RemoteInstance', () => {
         description: 'new description'
       };
       var instance2 = new Core.RemoteInstance(user, 'instanceId', handshake);
-      var consent :Consent.WireState = {
+      var consent :uProxy.WireState = {
         isRequesting: true,
         isOffering: true,
       };
@@ -137,13 +137,13 @@ describe('Core.RemoteInstance', () => {
 
   it('modifying consent locally also sends consent bits to remote', () => {
     spyOn(instance, 'sendConsent');
-    instance.modifyConsent(Consent.UserAction.REQUEST);
+    instance.modifyConsent(uProxy.UserAction.REQUEST);
     expect(instance.sendConsent).toHaveBeenCalled();
   });
 
   it('does not send consent for invalid modification', () => {
     spyOn(instance, 'sendConsent');
-    instance.modifyConsent(<Consent.UserAction>-1);
+    instance.modifyConsent(<uProxy.UserAction>-1);
     expect(instance.sendConsent).not.toHaveBeenCalled();
   });
 
@@ -154,41 +154,41 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('can request access, and cancel that request', () => {
-      instance.modifyConsent(Consent.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.UserAction.REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
-      instance.modifyConsent(Consent.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(false);
     });
 
     it('accepts offer from remote', () => {
       instance.consent.remoteGrantsAccessToLocal = true;
-      instance.modifyConsent(Consent.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.UserAction.REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
     });
 
     it('ignores offer from remote', () => {
       instance.consent.remoteGrantsAccessToLocal = true;
-      instance.modifyConsent(Consent.UserAction.IGNORE_OFFER);
+      instance.modifyConsent(uProxy.UserAction.IGNORE_OFFER);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(true);
     });
 
     it('can re-accept even after ignoring', () => {
-      instance.modifyConsent(Consent.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.UserAction.REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
     });
 
     it('cancelling after granted still keeps remote offer', () => {
-      instance.modifyConsent(Consent.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
     });
 
     it('ignore-offers bit reset after requesting', () => {
       instance.consent.localRequestsAccessFromRemote = false;
-      instance.modifyConsent(Consent.UserAction.IGNORE_OFFER);
+      instance.modifyConsent(uProxy.UserAction.IGNORE_OFFER);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(true);
-      instance.modifyConsent(Consent.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.UserAction.REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(false);
     });
@@ -201,9 +201,9 @@ describe('Core.RemoteInstance', () => {
       var emptyConsent = new Consent.State();
 
       instance.consent = new Consent.State();
-      instance.modifyConsent(Consent.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
       expect(instance.consent).toEqual(emptyConsent);
-      instance.modifyConsent(Consent.UserAction.UNIGNORE_OFFER);
+      instance.modifyConsent(uProxy.UserAction.UNIGNORE_OFFER);
       expect(instance.consent).toEqual(emptyConsent);
       // proxy consent modifications did not touch client consent
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(false);
@@ -217,42 +217,42 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('can offer access, and cancel that offer', () => {
-      instance.modifyConsent(Consent.UserAction.OFFER);
+      instance.modifyConsent(uProxy.UserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
-      instance.modifyConsent(Consent.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(false);
     });
 
     it('allows request from remote', () => {
       instance.consent.localGrantsAccessToRemote = false;
-      instance.modifyConsent(Consent.UserAction.OFFER);
+      instance.modifyConsent(uProxy.UserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
     });
 
     it('ignores request from remote', () => {
       instance.consent.remoteRequestsAccessFromLocal = true;
       instance.consent.ignoringRemoteUserRequest = false;
-      instance.modifyConsent(Consent.UserAction.IGNORE_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.IGNORE_REQUEST);
       expect(instance.consent.remoteRequestsAccessFromLocal).toEqual(true);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(true);
     });
 
     it('can re-accept even after ignoring', () => {
-      instance.modifyConsent(Consent.UserAction.OFFER);
+      instance.modifyConsent(uProxy.UserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
     });
 
     it('cancelling after granted returns to remote offer', () => {
-      instance.modifyConsent(Consent.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(false);
       expect(instance.consent.remoteRequestsAccessFromLocal).toEqual(true);
     });
 
     it('ignore-requests bit reset after granting', () => {
       instance.consent.localGrantsAccessToRemote = false;
-      instance.modifyConsent(Consent.UserAction.IGNORE_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.IGNORE_REQUEST);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(true);
-      instance.modifyConsent(Consent.UserAction.OFFER);
+      instance.modifyConsent(uProxy.UserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(false);
     });
@@ -265,9 +265,9 @@ describe('Core.RemoteInstance', () => {
       var emptyConsent = new Consent.State();
 
       instance.consent = new Consent.State();
-      instance.modifyConsent(Consent.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
       expect(instance.consent).toEqual(emptyConsent);
-      instance.modifyConsent(Consent.UserAction.UNIGNORE_REQUEST);
+      instance.modifyConsent(uProxy.UserAction.UNIGNORE_REQUEST);
       expect(instance.consent).toEqual(emptyConsent);
 
       // Client consent modifications did not touch proxy consent
@@ -397,14 +397,14 @@ describe('Core.RemoteInstance', () => {
     });
 
     // Alice wants to proxy through Bob.
-    alice.modifyConsent(Consent.UserAction.REQUEST);
+    alice.modifyConsent(uProxy.UserAction.REQUEST);
     Promise.all([alice.onceLoaded, bob.onceLoaded]).then(() => {
       expect(alice.consent.localRequestsAccessFromRemote).toEqual(true);
       expect(alice.consent.remoteGrantsAccessToLocal).toEqual(false);
       expect(bob.consent.remoteRequestsAccessFromLocal).toEqual(true);
       expect(bob.consent.localGrantsAccessToRemote).toEqual(false);
       // Bob accepts / offers
-      bob.modifyConsent(Consent.UserAction.OFFER);
+      bob.modifyConsent(uProxy.UserAction.OFFER);
       Promise.all([alice.onceLoaded, bob.onceLoaded]).then(() => {
         expect(alice.consent.remoteGrantsAccessToLocal).toEqual(true);
         expect(bob.consent.localGrantsAccessToRemote).toEqual(true);

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -73,7 +73,7 @@ describe('Core.RemoteInstance', () => {
       };
       spyOn(instance0, 'sendConsent');
       instance0.update(handshake);
-      instance0.modifyConsent(uProxy.UserAction.REQUEST);
+      instance0.modifyConsent(uProxy.ConsentUserAction.REQUEST);
 
       instance0.onceLoaded.then(() => {
         expect(saved).toBeDefined();
@@ -104,7 +104,7 @@ describe('Core.RemoteInstance', () => {
         description: 'new description'
       };
       var instance2 = new Core.RemoteInstance(user, 'instanceId', handshake);
-      var consent :uProxy.WireState = {
+      var consent :uProxy.ConsentWireState = {
         isRequesting: true,
         isOffering: true,
       };
@@ -137,13 +137,13 @@ describe('Core.RemoteInstance', () => {
 
   it('modifying consent locally also sends consent bits to remote', () => {
     spyOn(instance, 'sendConsent');
-    instance.modifyConsent(uProxy.UserAction.REQUEST);
+    instance.modifyConsent(uProxy.ConsentUserAction.REQUEST);
     expect(instance.sendConsent).toHaveBeenCalled();
   });
 
   it('does not send consent for invalid modification', () => {
     spyOn(instance, 'sendConsent');
-    instance.modifyConsent(<uProxy.UserAction>-1);
+    instance.modifyConsent(<uProxy.ConsentUserAction>-1);
     expect(instance.sendConsent).not.toHaveBeenCalled();
   });
 
@@ -154,41 +154,41 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('can request access, and cancel that request', () => {
-      instance.modifyConsent(uProxy.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
-      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(false);
     });
 
     it('accepts offer from remote', () => {
       instance.consent.remoteGrantsAccessToLocal = true;
-      instance.modifyConsent(uProxy.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
     });
 
     it('ignores offer from remote', () => {
       instance.consent.remoteGrantsAccessToLocal = true;
-      instance.modifyConsent(uProxy.UserAction.IGNORE_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.IGNORE_OFFER);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(true);
     });
 
     it('can re-accept even after ignoring', () => {
-      instance.modifyConsent(uProxy.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
     });
 
     it('cancelling after granted still keeps remote offer', () => {
-      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_REQUEST);
       expect(instance.consent.remoteGrantsAccessToLocal).toEqual(true);
     });
 
     it('ignore-offers bit reset after requesting', () => {
       instance.consent.localRequestsAccessFromRemote = false;
-      instance.modifyConsent(uProxy.UserAction.IGNORE_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.IGNORE_OFFER);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(true);
-      instance.modifyConsent(uProxy.UserAction.REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.REQUEST);
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(true);
       expect(instance.consent.ignoringRemoteUserOffer).toEqual(false);
     });
@@ -201,9 +201,9 @@ describe('Core.RemoteInstance', () => {
       var emptyConsent = new Consent.State();
 
       instance.consent = new Consent.State();
-      instance.modifyConsent(uProxy.UserAction.CANCEL_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_REQUEST);
       expect(instance.consent).toEqual(emptyConsent);
-      instance.modifyConsent(uProxy.UserAction.UNIGNORE_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.UNIGNORE_OFFER);
       expect(instance.consent).toEqual(emptyConsent);
       // proxy consent modifications did not touch client consent
       expect(instance.consent.localRequestsAccessFromRemote).toEqual(false);
@@ -217,42 +217,42 @@ describe('Core.RemoteInstance', () => {
     });
 
     it('can offer access, and cancel that offer', () => {
-      instance.modifyConsent(uProxy.UserAction.OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
-      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(false);
     });
 
     it('allows request from remote', () => {
       instance.consent.localGrantsAccessToRemote = false;
-      instance.modifyConsent(uProxy.UserAction.OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
     });
 
     it('ignores request from remote', () => {
       instance.consent.remoteRequestsAccessFromLocal = true;
       instance.consent.ignoringRemoteUserRequest = false;
-      instance.modifyConsent(uProxy.UserAction.IGNORE_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.IGNORE_REQUEST);
       expect(instance.consent.remoteRequestsAccessFromLocal).toEqual(true);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(true);
     });
 
     it('can re-accept even after ignoring', () => {
-      instance.modifyConsent(uProxy.UserAction.OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
     });
 
     it('cancelling after granted returns to remote offer', () => {
-      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(false);
       expect(instance.consent.remoteRequestsAccessFromLocal).toEqual(true);
     });
 
     it('ignore-requests bit reset after granting', () => {
       instance.consent.localGrantsAccessToRemote = false;
-      instance.modifyConsent(uProxy.UserAction.IGNORE_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.IGNORE_REQUEST);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(true);
-      instance.modifyConsent(uProxy.UserAction.OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.OFFER);
       expect(instance.consent.localGrantsAccessToRemote).toEqual(true);
       expect(instance.consent.ignoringRemoteUserRequest).toEqual(false);
     });
@@ -265,9 +265,9 @@ describe('Core.RemoteInstance', () => {
       var emptyConsent = new Consent.State();
 
       instance.consent = new Consent.State();
-      instance.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
+      instance.modifyConsent(uProxy.ConsentUserAction.CANCEL_OFFER);
       expect(instance.consent).toEqual(emptyConsent);
-      instance.modifyConsent(uProxy.UserAction.UNIGNORE_REQUEST);
+      instance.modifyConsent(uProxy.ConsentUserAction.UNIGNORE_REQUEST);
       expect(instance.consent).toEqual(emptyConsent);
 
       // Client consent modifications did not touch proxy consent
@@ -397,14 +397,14 @@ describe('Core.RemoteInstance', () => {
     });
 
     // Alice wants to proxy through Bob.
-    alice.modifyConsent(uProxy.UserAction.REQUEST);
+    alice.modifyConsent(uProxy.ConsentUserAction.REQUEST);
     Promise.all([alice.onceLoaded, bob.onceLoaded]).then(() => {
       expect(alice.consent.localRequestsAccessFromRemote).toEqual(true);
       expect(alice.consent.remoteGrantsAccessToLocal).toEqual(false);
       expect(bob.consent.remoteRequestsAccessFromLocal).toEqual(true);
       expect(bob.consent.localGrantsAccessToRemote).toEqual(false);
       // Bob accepts / offers
-      bob.modifyConsent(uProxy.UserAction.OFFER);
+      bob.modifyConsent(uProxy.ConsentUserAction.OFFER);
       Promise.all([alice.onceLoaded, bob.onceLoaded]).then(() => {
         expect(alice.consent.remoteGrantsAccessToLocal).toEqual(true);
         expect(bob.consent.localGrantsAccessToRemote).toEqual(true);

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -230,14 +230,14 @@ module Core {
      * the consent buttons in the UI.) Sends updated consent bits to the
      * remote instance afterwards.
      */
-    public modifyConsent = (action :Consent.UserAction) => {
+    public modifyConsent = (action :uProxy.UserAction) => {
       if (!Consent.handleUserAction(this.consent, action)) {
         console.warn('Invalid user action on consent!', this.consent, action);
         return;
       }
       // If remote is currently an active client, but user revokes access, also
       // stop the proxy session.
-      if (Consent.UserAction.CANCEL_OFFER === action &&
+      if (uProxy.UserAction.CANCEL_OFFER === action &&
           this.localSharingWithRemote == SharingState.SHARING_ACCESS) {
         this.connection_.stopShare();
       }
@@ -267,13 +267,13 @@ module Core {
      * Receive consent bits from the remote, and update consent values
      * accordingly.
      */
-    public updateConsent = (bits:Consent.WireState) => {
+    public updateConsent = (bits :uProxy.WireState) => {
       this.onceLoaded.then(() => {
         this.updateConsent_(bits);
       });
     }
 
-    public updateConsent_ = (bits:Consent.WireState) => {
+    public updateConsent_ = (bits: uProxy.WireState) => {
 
       var remoteWasGrantingAccess = this.consent.remoteGrantsAccessToLocal;
       var remoteWasRequestingAccess = this.consent.remoteRequestsAccessFromLocal;
@@ -329,7 +329,7 @@ module Core {
      * consent status, from the user's point of view. These bits will be sent on
      * the wire.
      */
-    public getConsentBits = () :Consent.WireState => {
+    public getConsentBits = () :uProxy.WireState => {
       return {
         isRequesting: this.consent.localRequestsAccessFromRemote,
         isOffering: this.consent.localGrantsAccessToRemote

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -230,14 +230,14 @@ module Core {
      * the consent buttons in the UI.) Sends updated consent bits to the
      * remote instance afterwards.
      */
-    public modifyConsent = (action :uProxy.UserAction) => {
+    public modifyConsent = (action :uProxy.ConsentUserAction) => {
       if (!Consent.handleUserAction(this.consent, action)) {
         console.warn('Invalid user action on consent!', this.consent, action);
         return;
       }
       // If remote is currently an active client, but user revokes access, also
       // stop the proxy session.
-      if (uProxy.UserAction.CANCEL_OFFER === action &&
+      if (uProxy.ConsentUserAction.CANCEL_OFFER === action &&
           this.localSharingWithRemote == SharingState.SHARING_ACCESS) {
         this.connection_.stopShare();
       }
@@ -267,13 +267,13 @@ module Core {
      * Receive consent bits from the remote, and update consent values
      * accordingly.
      */
-    public updateConsent = (bits :uProxy.WireState) => {
+    public updateConsent = (bits :uProxy.ConsentWireState) => {
       this.onceLoaded.then(() => {
         this.updateConsent_(bits);
       });
     }
 
-    public updateConsent_ = (bits: uProxy.WireState) => {
+    public updateConsent_ = (bits: uProxy.ConsentWireState) => {
 
       var remoteWasGrantingAccess = this.consent.remoteGrantsAccessToLocal;
       var remoteWasRequestingAccess = this.consent.remoteRequestsAccessFromLocal;
@@ -329,7 +329,7 @@ module Core {
      * consent status, from the user's point of view. These bits will be sent on
      * the wire.
      */
-    public getConsentBits = () :uProxy.WireState => {
+    public getConsentBits = () :uProxy.ConsentWireState => {
       return {
         isRequesting: this.consent.localRequestsAccessFromRemote,
         isOffering: this.consent.localGrantsAccessToRemote

--- a/src/generic_core/user.ts
+++ b/src/generic_core/user.ts
@@ -212,7 +212,7 @@ module Core {
       }
     }
 
-    private getConsentForClient_ = (clientId :string) : Consent.WireState => {
+    private getConsentForClient_ = (clientId :string) :uProxy.WireState => {
       var instanceId = this.clientToInstanceMap_[clientId];
       if (typeof instanceId === 'undefined') {
         return null;
@@ -443,7 +443,7 @@ module Core {
       }
     }
 
-    public sendInstanceHandshake = (clientId :string, consent :Consent.WireState) : Promise<void> => {
+    public sendInstanceHandshake = (clientId :string, consent :uProxy.WireState) : Promise<void> => {
       if (!this.network.myInstance) {
         // TODO: consider waiting until myInstance is constructing
         // instead of dropping this message.

--- a/src/generic_core/user.ts
+++ b/src/generic_core/user.ts
@@ -212,7 +212,7 @@ module Core {
       }
     }
 
-    private getConsentForClient_ = (clientId :string) :uProxy.WireState => {
+    private getConsentForClient_ = (clientId :string) :uProxy.ConsentWireState => {
       var instanceId = this.clientToInstanceMap_[clientId];
       if (typeof instanceId === 'undefined') {
         return null;
@@ -443,7 +443,7 @@ module Core {
       }
     }
 
-    public sendInstanceHandshake = (clientId :string, consent :uProxy.WireState) : Promise<void> => {
+    public sendInstanceHandshake = (clientId :string, consent :uProxy.ConsentWireState) : Promise<void> => {
       if (!this.network.myInstance) {
         // TODO: consider waiting until myInstance is constructing
         // instead of dropping this message.

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -33,8 +33,8 @@ Polymer({
     core.stop();
   },
 
-  // |action| is the string end for a Consent.UserAction
-  modifyConsent: function(action :Consent.UserAction) {
+  // |action| is the string end for a uProxy.UserAction
+  modifyConsent: function(action :uProxy.UserAction) {
     var command = <uProxy.ConsentCommand>{
       path: this.path,
       action: action
@@ -44,21 +44,21 @@ Polymer({
   },
 
   // Proxy UserActions.
-  request: function() { this.modifyConsent(Consent.UserAction.REQUEST) },
+  request: function() { this.modifyConsent(uProxy.UserAction.REQUEST) },
   cancelRequest: function() {
-    this.modifyConsent(Consent.UserAction.CANCEL_REQUEST)
+    this.modifyConsent(uProxy.UserAction.CANCEL_REQUEST)
   },
-  ignoreOffer: function() { this.modifyConsent(Consent.UserAction.IGNORE_OFFER) },
-  unignoreOffer: function() { this.modifyConsent(Consent.UserAction.UNIGNORE_OFFER) },
+  ignoreOffer: function() { this.modifyConsent(uProxy.UserAction.IGNORE_OFFER) },
+  unignoreOffer: function() { this.modifyConsent(uProxy.UserAction.UNIGNORE_OFFER) },
 
   // Client UserActions
-  offer: function() { this.modifyConsent(Consent.UserAction.OFFER) },
+  offer: function() { this.modifyConsent(uProxy.UserAction.OFFER) },
   cancelOffer: function() {
     this.ui.stopGivingInUi();
-    this.modifyConsent(Consent.UserAction.CANCEL_OFFER);
+    this.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
   },
-  ignoreRequest: function() { this.modifyConsent(Consent.UserAction.IGNORE_REQUEST) },
-  unignoreRequest: function() { this.modifyConsent(Consent.UserAction.UNIGNORE_REQUEST) },
+  ignoreRequest: function() { this.modifyConsent(uProxy.UserAction.IGNORE_REQUEST) },
+  unignoreRequest: function() { this.modifyConsent(uProxy.UserAction.UNIGNORE_REQUEST) },
 
   getConsentState: function() : string {
     return this.instance.consent;

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -33,8 +33,8 @@ Polymer({
     core.stop();
   },
 
-  // |action| is the string end for a uProxy.UserAction
-  modifyConsent: function(action :uProxy.UserAction) {
+  // |action| is the string end for a uProxy.ConsentUserAction
+  modifyConsent: function(action :uProxy.ConsentUserAction) {
     var command = <uProxy.ConsentCommand>{
       path: this.path,
       action: action
@@ -44,21 +44,21 @@ Polymer({
   },
 
   // Proxy UserActions.
-  request: function() { this.modifyConsent(uProxy.UserAction.REQUEST) },
+  request: function() { this.modifyConsent(uProxy.ConsentUserAction.REQUEST) },
   cancelRequest: function() {
-    this.modifyConsent(uProxy.UserAction.CANCEL_REQUEST)
+    this.modifyConsent(uProxy.ConsentUserAction.CANCEL_REQUEST)
   },
-  ignoreOffer: function() { this.modifyConsent(uProxy.UserAction.IGNORE_OFFER) },
-  unignoreOffer: function() { this.modifyConsent(uProxy.UserAction.UNIGNORE_OFFER) },
+  ignoreOffer: function() { this.modifyConsent(uProxy.ConsentUserAction.IGNORE_OFFER) },
+  unignoreOffer: function() { this.modifyConsent(uProxy.ConsentUserAction.UNIGNORE_OFFER) },
 
   // Client UserActions
-  offer: function() { this.modifyConsent(uProxy.UserAction.OFFER) },
+  offer: function() { this.modifyConsent(uProxy.ConsentUserAction.OFFER) },
   cancelOffer: function() {
     this.ui.stopGivingInUi();
-    this.modifyConsent(uProxy.UserAction.CANCEL_OFFER);
+    this.modifyConsent(uProxy.ConsentUserAction.CANCEL_OFFER);
   },
-  ignoreRequest: function() { this.modifyConsent(uProxy.UserAction.IGNORE_REQUEST) },
-  unignoreRequest: function() { this.modifyConsent(uProxy.UserAction.UNIGNORE_REQUEST) },
+  ignoreRequest: function() { this.modifyConsent(uProxy.ConsentUserAction.IGNORE_REQUEST) },
+  unignoreRequest: function() { this.modifyConsent(uProxy.ConsentUserAction.UNIGNORE_REQUEST) },
 
   getConsentState: function() : string {
     return this.instance.consent;

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -1,5 +1,4 @@
 /// <reference path='../../third_party/typings/jasmine/jasmine.d.ts' />
-/// <reference path='../../generic_core/consent.ts' />
 /// <reference path='ui.ts' />
 
 describe('UI.UserInterface', () => {
@@ -7,6 +6,26 @@ describe('UI.UserInterface', () => {
   var ui :UI.UserInterface;
   var mockBrowserApi;
   var updateToHandlerMap = {};
+
+  function getInstance(instanceId :string, description :string) :UI.Instance {
+    return {
+      instanceId: instanceId,
+      description: description,
+      consent: {
+        localGrantsAccessToRemote: false,
+        localRequestsAccessFromRemote: false,
+        remoteGrantsAccessToLocal: false,
+        remoteRequestsAccessFromLocal: false,
+        ignoringRemoteUserRequest: false,
+        ignoringRemoteUserOffer: false
+      },
+      localSharingWithRemote: SharingState.NONE,
+      localGettingFromRemote: GettingState.NONE,
+      isOnline: true,
+      bytesSent: 0,
+      bytesReceived: 0
+    }
+  }
 
   beforeEach(() => {
     // Create a fresh UI object before each test.
@@ -35,16 +54,9 @@ describe('UI.UserInterface', () => {
         name: userName,
         imageData: 'testImageData'
       },
-      instances: [{
-        instanceId: instanceId,
-        description: 'description1',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      }]
+      instances: [
+        getInstance(instanceId, 'description1')
+      ]
     };
     ui.syncUser(payload);
   }
@@ -64,16 +76,9 @@ describe('UI.UserInterface', () => {
           name: 'Alice',
           imageData: 'testImageData'
         },
-        instances: [{
-          instanceId: 'instance1',
-          description: 'description1',
-          consent: new Consent.State(),
-          localSharingWithRemote: SharingState.NONE,
-          localGettingFromRemote: GettingState.NONE,
-          isOnline: true,
-          bytesSent: 0,
-          bytesReceived: 0
-        }]
+        instances: [
+          getInstance('instance1', 'description1')
+        ]
       };
       ui.syncUser(payload);
       var user :UI.User = model.onlineNetwork.roster['testUserId'];
@@ -94,30 +99,14 @@ describe('UI.UserInterface', () => {
                      userId: 'fakeUser',
                      online: true,
                      roster: {}});
-      var clientInstance :UI.Instance = {
-        instanceId: 'instance1',
-        description: 'description1',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      };
+      var clientInstance = getInstance('instance1', 'description1');
       clientInstance.consent.localRequestsAccessFromRemote = true;
       clientInstance.consent.remoteGrantsAccessToLocal = true;
-      var serverInstance :UI.Instance = {
-        instanceId: 'instance2',
-        description: 'description2',
-        consent: new Consent.State(),
-        localSharingWithRemote: SharingState.NONE,
-        localGettingFromRemote: GettingState.NONE,
-        isOnline: true,
-        bytesSent: 0,
-        bytesReceived: 0
-      };
+
+      var serverInstance = getInstance('instance2', 'description2');
       serverInstance.consent.localGrantsAccessToRemote = true;
       serverInstance.consent.remoteRequestsAccessFromLocal = true;
+
       var payload :UI.UserMessage = {
         network: 'testNetwork',
         user: {

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -10,11 +10,18 @@ describe('UI.User', () => {
     spyOn(console, 'log');
   });
 
-  function getInstance(id :string, description :string) {
+  function getInstance(id :string, description :string) :UI.Instance {
     return {
       instanceId: id,
       description: description,
-      consent: new Consent.State(),
+      consent: {
+        localGrantsAccessToRemote: false,
+        localRequestsAccessFromRemote: false,
+        remoteGrantsAccessToLocal: false,
+        remoteRequestsAccessFromLocal: false,
+        ignoringRemoteUserRequest: false,
+        ignoringRemoteUserOffer: false
+      },
       localSharingWithRemote: SharingState.NONE,
       localGettingFromRemote: GettingState.NONE,
       isOnline: true,

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -4,7 +4,6 @@
  * This is the UI-specific representation of a User.
  */
 /// <reference path='../../freedom/typings/social.d.ts' />
-/// <reference path='../../generic_core/consent.ts' />
 /// <reference path='../../interfaces/user.d.ts' />
 
 module UI {

--- a/src/interfaces/instance.d.ts
+++ b/src/interfaces/instance.d.ts
@@ -10,14 +10,12 @@
  * about their current status and consent level.
  */
 
-/// <reference path='../generic_core/consent.ts' />
-
 // TODO: Maybe wrap these in a module for everyting to do with Instances that
 // needs to be accessible both in core and UI.
 
 interface ConsentMessage {
   instanceId :string;
-  consent    :Consent.WireState;
+  consent    :uProxy.WireState;
 }
 
 interface NetworkInfo {
@@ -48,7 +46,7 @@ interface LocalPeerId {
 interface Instance {
   instanceId  :string;
   keyHash     :string;
-  consent     ?:Consent.State;
+  consent     ?:uProxy.ConsentState;
   status      ?:string; // Status on social network e.g. online or offline.
   notify      ?:boolean;   // TODO: replace with better notications
 }
@@ -65,5 +63,5 @@ interface InstanceHandshake {
 
 interface InstanceMessage {
   handshake :InstanceHandshake;
-  consent :Consent.WireState
+  consent   :uProxy.WireState
 }

--- a/src/interfaces/instance.d.ts
+++ b/src/interfaces/instance.d.ts
@@ -15,7 +15,7 @@
 
 interface ConsentMessage {
   instanceId :string;
-  consent    :uProxy.WireState;
+  consent    :uProxy.ConsentWireState;
 }
 
 interface NetworkInfo {
@@ -63,5 +63,5 @@ interface InstanceHandshake {
 
 interface InstanceMessage {
   handshake :InstanceHandshake;
-  consent   :uProxy.WireState
+  consent   :uProxy.ConsentWireState
 }

--- a/src/interfaces/ui.d.ts
+++ b/src/interfaces/ui.d.ts
@@ -50,7 +50,7 @@ declare module UI {
   export interface Instance {
     instanceId             :string;
     description            :string;
-    consent                :Consent.State;
+    consent                :uProxy.ConsentState;
     localGettingFromRemote :GettingState;
     localSharingWithRemote :SharingState;
     isOnline               :boolean;

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -7,7 +7,6 @@
  */
 
 // TODO: Move the notifications somewhere better.
-/// <reference path='generic_core/consent.ts' />
 /// <reference path='interfaces/ui.d.ts' />
 /// <reference path='interfaces/persistent.d.ts' />
 /// <reference path='networking-typings/communications.d.ts' />
@@ -104,6 +103,33 @@ module uProxy {
     data :Object;
   }
 
+  // The different states that uProxy consent can be in w.r.t. a peer. These
+  // are the values that get sent or received on the wire.
+  export interface WireState {
+    isRequesting :boolean;
+    isOffering   :boolean;
+  }
+
+  // the state for consent between two instances
+  export interface ConsentState {
+    localGrantsAccessToRemote :boolean;
+    localRequestsAccessFromRemote :boolean;
+    remoteGrantsAccessToLocal :boolean;
+    remoteRequestsAccessFromLocal :boolean;
+    ignoringRemoteUserRequest :boolean;
+    ignoringRemoteUserOffer :boolean;
+  }
+
+  // Action taken by the user. These values are not on the wire. They are passed
+  // in messages from the UI to the core. They correspond to the different
+  // buttons that the user may be clicking on.
+  export enum UserAction {
+    // Actions made by user w.r.t. remote as a proxy
+    REQUEST = 5000, CANCEL_REQUEST, IGNORE_OFFER, UNIGNORE_OFFER,
+    // Actions made by user w.r.t. remote as a client
+    OFFER = 5100, CANCEL_OFFER, IGNORE_REQUEST, UNIGNORE_REQUEST,
+  }
+
   /**
    * ConsentCommands are sent from the UI to the Core, to modify the consent of
    * a :RemoteInstance in the local client. (This is not sent on the wire to
@@ -112,7 +138,7 @@ module uProxy {
    */
   export interface ConsentCommand {
     path       :InstancePath;
-    action     :Consent.UserAction;
+    action     :uProxy.UserAction;
   }
 
   // The payload of a HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE command. There is a

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -105,7 +105,7 @@ module uProxy {
 
   // The different states that uProxy consent can be in w.r.t. a peer. These
   // are the values that get sent or received on the wire.
-  export interface WireState {
+  export interface ConsentWireState {
     isRequesting :boolean;
     isOffering   :boolean;
   }
@@ -123,7 +123,7 @@ module uProxy {
   // Action taken by the user. These values are not on the wire. They are passed
   // in messages from the UI to the core. They correspond to the different
   // buttons that the user may be clicking on.
-  export enum UserAction {
+  export enum ConsentUserAction {
     // Actions made by user w.r.t. remote as a proxy
     REQUEST = 5000, CANCEL_REQUEST, IGNORE_OFFER, UNIGNORE_OFFER,
     // Actions made by user w.r.t. remote as a client
@@ -138,7 +138,7 @@ module uProxy {
    */
   export interface ConsentCommand {
     path       :InstancePath;
-    action     :uProxy.UserAction;
+    action     :uProxy.ConsentUserAction;
   }
 
   // The payload of a HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE command. There is a


### PR DESCRIPTION
This removes the consent.js file from the UI build by adding a new
interface, ConsentState, and using that on the UI side instead of trying
to create actual consent objects.  It also moves the WireState interface
and UserAction enum to uProxy.

This creates the interface uProxy.ConsentState, switches the consent
field in the UI.Instance to be of type uProxy.ConsentState, and removes
some code duplication in tests (while moving them away from using
Consent.State

WireState and UserAction, both also shared state, have also been moved
to uproxy.ts

Tested through grunt test and by running in Chrome

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1031)
<!-- Reviewable:end -->
