### PR TITLE
Switch to using the freedom logger

### DIFF
--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -1,6 +1,8 @@
 /// <reference path='util.ts' />
 
 module Consent {
+  var log :Logging.Log = new Logging.Log('consent');
+
   // User-level consent state w.r.t. a remote instance. This state is stored
   // in local storage for each instance ID we know of.
   export class State implements uProxy.ConsentState {
@@ -67,7 +69,7 @@ module Consent {
         state.ignoringRemoteUserOffer = false;
         break;
       default:
-        console.warn('Invalid uProxy.ConsentUserAction! ' + action);
+        log.warn('Invalid uProxy.ConsentUserAction', action);
         return false;
     }
     return true;

--- a/src/generic_core/core.spec.ts
+++ b/src/generic_core/core.spec.ts
@@ -90,7 +90,6 @@ describe('Core', () => {
 
   it('login fails for invalid network', (done) => {
     core.login('nothing').catch(() => {
-      expect(console.warn).toHaveBeenCalled();
       done();
     });
   });

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -24,6 +24,8 @@
 // Note that the proxy runs extremely slowly in debug ('*:D') mode.
 freedom['loggingprovider']().setConsoleFilter(['*:I']);
 
+var log :Logging.Log = new Logging.Log('core');
+
 var storage = new Core.Storage();
 
 // This is the channel to speak to the UI component of uProxy.
@@ -49,7 +51,10 @@ class UIConnector implements uProxy.UIAPI {
    */
   public update = (type:uProxy.Update, data?:any) => {
     var printableType :string = uProxy.Update[type];
-    console.log('update [' + printableType + ']', data);
+    log.debug('sending message to UI', {
+      type: printableType,
+      data: data
+    });
     bgAppPageChannel.emit('' + type, data);
   }
 
@@ -66,7 +71,6 @@ class UIConnector implements uProxy.UIAPI {
   }
 
   public syncUser = (payload:UI.UserMessage) => {
-    console.log('Core: UI.syncUser ' + JSON.stringify(payload));
     this.update(uProxy.Update.USER_FRIEND, payload);
   }
 
@@ -103,12 +107,12 @@ class uProxyCore implements uProxy.CoreAPI {
   public loadGlobalSettings :Promise<void> = null;
 
   constructor() {
-    console.log('Preparing uProxy Core.');
+    log.debug('Preparing uProxy Core');
     copyPasteConnection = new Core.RemoteConnection(ui.update);
 
     this.loadGlobalSettings = storage.load<Core.GlobalSettings>('globalSettings')
         .then((globalSettingsObj :Core.GlobalSettings) => {
-          console.log('Loaded global settings: ' + JSON.stringify(globalSettingsObj));
+          log.info('Loaded global settings', globalSettingsObj);
           this.globalSettings = globalSettingsObj;
           // If no custom STUN servers were found in storage, use the default
           // servers.
@@ -126,7 +130,7 @@ class uProxyCore implements uProxy.CoreAPI {
             this.globalSettings.hasSeenWelcome = false;
           }
         }).catch((e) => {
-          console.log('No global settings loaded', e);
+          log.info('No global settings loaded', e.message);
         });
   }
 
@@ -158,7 +162,7 @@ class uProxyCore implements uProxy.CoreAPI {
       if (!args.promiseId) {
         var err = 'onPromiseCommand called for cmd ' + cmd +
                   'with promiseId undefined';
-        console.error(err)
+        log.error(err);
         return Promise.reject(new Error(err));
       }
 
@@ -199,15 +203,14 @@ class uProxyCore implements uProxy.CoreAPI {
       var loginPromise = network.login(true);
       loginPromise.then(() => {
         Social.notifyUI(networkName);
-        console.log('Logged in to manual network');
+        log.info('Logged in to manual network');
       });
       return loginPromise;
     }
 
     if (!(networkName in Social.networks)) {
-      var warn = 'Network ' + networkName + ' does not exist.';
-      console.warn(warn)
-      return Promise.reject(new Error(warn));
+      log.warn('Network does not exist', networkName);
+      return Promise.reject(new Error('Network does not exist (' + networkName + ')'));
     }
     var network = Social.pendingNetworks[networkName];
     if (typeof network === 'undefined') {
@@ -216,19 +219,22 @@ class uProxyCore implements uProxy.CoreAPI {
     }
     var loginPromise = network.login(true);
     loginPromise.then(() => {
-          var userId = network.myInstance.userId;
-          if (userId in Social.networks[networkName]) {
-            // If user is already logged in with the same (network, userId)
-            // log out from existing network before replacing it.
-            Social.networks[networkName][userId].logout();
-          }
-          Social.networks[networkName][userId] = network;
-          delete Social.pendingNetworks[networkName];
-          console.log('Successfully logged in to ' + networkName +
-                      ' with user id ' + userId);
-        }).catch(() => {
-          delete Social.pendingNetworks[networkName];
-        });
+      var userId = network.myInstance.userId;
+      if (userId in Social.networks[networkName]) {
+        // If user is already logged in with the same (network, userId)
+        // log out from existing network before replacing it.
+        Social.networks[networkName][userId].logout();
+      }
+      Social.networks[networkName][userId] = network;
+      delete Social.pendingNetworks[networkName];
+      log.info('Successfully logged in to network', {
+        network: networkName,
+        userId: userId
+      });
+    }).catch((e) => {
+      log.error('Could not log in to network', e.stack);
+      delete Social.pendingNetworks[networkName];
+    });
 
     // TODO: save the auto-login default.
     return loginPromise;
@@ -243,11 +249,11 @@ class uProxyCore implements uProxy.CoreAPI {
     var userId = networkInfo.userId;
     var network = Social.getNetwork(networkName, userId);
     if (null === network) {
-      console.warn('Could not logout of network ', networkName);
+      log.warn('Could not logout of network', networkName);
       return;
     }
     return network.logout().then(() => {
-      console.log('Successfully logged out of ' + networkName);
+      log.info('Successfully logged out of network', networkName);
     });
     // TODO: disable auto-login
     // store.saveMeToStorage();
@@ -264,7 +270,9 @@ class uProxyCore implements uProxy.CoreAPI {
    */
 
   public updateGlobalSettings = (newSettings:Core.GlobalSettings) => {
-    storage.save<Core.GlobalSettings>('globalSettings', newSettings);
+    storage.save<Core.GlobalSettings>('globalSettings', newSettings).catch((e) => {
+      log.error('Could not save globalSettings to storage', e.stack);
+    });
 
     // Clear the existing servers and add in each new server.
     // Trying globalSettings = newSettings does not correctly update
@@ -299,7 +307,7 @@ class uProxyCore implements uProxy.CoreAPI {
     // Determine which Network, User, and Instance...
     var instance = this.getInstance(command.path);
     if (!instance) {  // Error msg emitted above.
-      console.error('Cannot modify consent for non-existing instance!');
+      log.error('Cannot modify consent for non-existing instance');
       return;
     }
     // Set the instance's new consent levels. It will take care of sending new
@@ -309,7 +317,7 @@ class uProxyCore implements uProxy.CoreAPI {
 
   public startCopyPasteGet = () : Promise<Net.Endpoint> => {
     if (remoteProxyInstance) {
-      console.log('Existing proxying session! Terminating...');
+      log.warn('Existing proxying session, terminating');
       remoteProxyInstance.stop();
       remoteProxyInstance = null;
     }
@@ -341,21 +349,20 @@ class uProxyCore implements uProxy.CoreAPI {
   public start = (path :InstancePath) : Promise<Net.Endpoint> => {
     // Disable any previous proxying session.
     if (remoteProxyInstance) {
-      console.log('Existing proxying session! Terminating...');
+      log.warn('Existing proxying session, terminating');
       // Stop proxy, don't notify UI since UI request a new proxy.
       remoteProxyInstance.stop();
       remoteProxyInstance = null;
     }
     if (GettingState.NONE !== copyPasteConnection.localGettingFromRemote) {
-      console.log('Existing copy+paste proxying session! Terminating...');
+      log.warn('Existing proxying session, terminating');
       copyPasteConnection.stopGet();
     }
 
     var remote = this.getInstance(path);
     if (!remote) {
-      var err = 'Instance ' + path.instanceId + ' does not exist for proxying.';
-      console.error(err);
-      return Promise.reject(new Error(err));
+      log.error('Instance does not exist for proxying', path.instanceId);
+      return Promise.reject(new Error('Instance does not exist for proxying (' + path.instanceId + ')'));
     }
     // Remember this instance as our proxy.  Set this before start fulfills
     // in case the user decides to cancel the proxy before it begins.
@@ -365,7 +372,8 @@ class uProxyCore implements uProxy.CoreAPI {
       return endpoint;
     }).catch((e) => {
       remoteProxyInstance = null;
-      return Promise.reject(new Error('Error starting proxy'));
+      log.error('Could not start remote proxying session', e.stack);
+      return Promise.reject(e);
     });
   }
 
@@ -374,7 +382,7 @@ class uProxyCore implements uProxy.CoreAPI {
    */
   public stop = () => {
     if (!remoteProxyInstance) {
-      console.error('Cannot stop proxying when there is no proxy');
+      log.error('Cannot stop proxying when there is no proxy');
       return;
     }
     remoteProxyInstance.stop();
@@ -387,8 +395,8 @@ class uProxyCore implements uProxy.CoreAPI {
     var manualNetwork :Social.ManualNetwork =
         <Social.ManualNetwork> Social.getNetwork(Social.MANUAL_NETWORK_ID, '');
     if (!manualNetwork) {
-      console.error('Manual network does not exist; discarding inbound ' +
-                    'message. Command=' + JSON.stringify(command));
+      log.error('Manual network does not exist, discanding inbound message',
+                command);
       return;
     }
 
@@ -401,12 +409,12 @@ class uProxyCore implements uProxy.CoreAPI {
   public getInstance = (path :InstancePath) : Core.RemoteInstance => {
     var network = Social.getNetwork(path.network.name, path.network.userId);
     if (!network) {
-      console.error('No network ' + path.network.name);
+      log.error('No network', path.network.name);
       return;
     }
     var user = network.getUser(path.userId);
     if (!user) {
-      console.error('No user ' + path.userId);
+      log.error('No user', path.userId);
       return;
     }
     return user.getInstance(path.instanceId);
@@ -420,7 +428,7 @@ var core = new uProxyCore();
 
 
 function _validateKeyHash(keyHash:string) {
-  console.log('Warning: keyHash Validation not yet implemented...');
+  log.warn('keyHash validation not yet implemented');
   return true;
 }
 
@@ -457,7 +465,7 @@ core.onCommand(uProxy.Command.STOP_PROXYING, core.stop);
 
 // TODO: Implement this or remove it.
 // core.onCommand(uProxy.Command.CHANGE_OPTION, (data) => {
-//   console.warn('CHANGE_OPTION yet to be implemented!');
+//   log.warn('CHANGE_OPTION yet to be implemented');
 //   // TODO: Handle changes that might affect proxying.
 // });
 

--- a/src/generic_core/firewall.ts
+++ b/src/generic_core/firewall.ts
@@ -17,6 +17,8 @@
 /// <reference path='../freedom/typings/social.d.ts' />
 
 module Firewall {
+  var log :Logging.Log = new Logging.Log('firewall');
+
   export enum Severity {
     // Incorrect input.  No claims on intent.
     MalformedInput,
@@ -33,8 +35,10 @@ module Firewall {
 
   export class DefaultResponsePolicy implements ResponsePolicy {
     public onValidationFailure(s :string, level :Severity) {
-      console.warn("DROPPING MESSAGE ON VALIDATION FAILURE.  Severity: " +
-                   level + ", text: " + s);
+      log.warn('Message validation failure', {
+        severity: level,
+        text: s
+      });
     }
   }
 

--- a/src/generic_core/local-instance.ts
+++ b/src/generic_core/local-instance.ts
@@ -10,6 +10,7 @@
 /// <reference path='../third_party/typings/webcrypto/WebCrypto.d.ts' />
 
 module Core {
+  var log :Logging.Log = new Logging.Log('local-instance');
 
   // Small convenience wrapper for random Uint8.
   //
@@ -70,7 +71,7 @@ module Core {
      */
     public getInstanceHandshake = () : InstanceHandshake => {
       if (!this.keyHash) {
-        console.warn('Local keyhash not ready!');
+        log.warn('Local keyhash not ready');
       }
       return {
         instanceId:  this.instanceId,

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -7,8 +7,9 @@
 /// <reference path='../rtc-to-net/rtc-to-net.ts' />
 /// <reference path='../socks-to-rtc/socks-to-rtc.ts' />
 
-
 module Core {
+  var log :Logging.Log = new Logging.Log('remote-connection');
+
   export class RemoteConnection {
 
     public localGettingFromRemote = GettingState.NONE;
@@ -22,7 +23,7 @@ module Core {
 
     private isUpdatePending_ = false;
 
-    //TODO set up a better type for this
+    // TODO: set up a better type for this
     private sendUpdate_ :(x :uProxy.Update, data?:Object) => void;
 
     constructor(
@@ -40,6 +41,7 @@ module Core {
       }
     }
 
+    // TODO: should probably either return something or throw errors
     public handleSignal = (message :uProxy.Message) => {
       var target :any = null; //this will either be rtcToNet_ or socksToRtc_
       var msg;
@@ -48,13 +50,15 @@ module Core {
       } else if (uProxy.MessageType.SIGNAL_FROM_SERVER_PEER === message.type) {
         target = this.socksToRtc_;
       } else {
-        console.warn('Invalid signal! ' + uProxy.MessageType[message.type]);
+        log.warn('Invalid signal', uProxy.MessageType[message.type]);
         return;
       }
 
       if (!target) {
-        console.warn('Received unexpected ' + uProxy.MessageType[message.type],
-                     message);
+        log.warn('Received unexpected signal', {
+          type: uProxy.MessageType[message.type],
+          message: message
+        });
         return;
       }
 
@@ -102,7 +106,7 @@ module Core {
 
     public stopShare = () => {
       if (this.localSharingWithRemote === SharingState.NONE) {
-        console.warn('Cannot stop when not proxying.');
+        log.warn('Cannot stop when not proxying');
         return;
       }
 
@@ -176,7 +180,7 @@ module Core {
 
     public stopGet = () : void => {
       if (this.localGettingFromRemote === GettingState.NONE) {
-        console.warn('Cannot stop proxying when not proxying.');
+        log.warn('Cannot stop proxying when not proxying');
         return;
       }
 

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -141,14 +141,7 @@ describe('Social.FreedomNetwork', () => {
       // Pretend the social API's login failed.
       spyOn(network['freedomApi_'], 'login').and.returnValue(
           Promise.reject(new Error('mock failure')));
-      spyOn(network, 'error');
-      network.login(false).then(
-        () => { return Promise.reject('error'); },  // login should not fulfill.
-        () => {
-          expect(network['error']).toHaveBeenCalledWith('Could not login.');
-          done()
-        });
-      // We need to tick a clock in order promises to be resolved.
+      network.login(false).catch(done);
       jasmine.clock().tick(1);
     });
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -311,7 +311,7 @@ module Social {
       if (userId == this.myInstance.userId) {
         // TODO: we may want to verify that our status is ONLINE before
         // sending out any instance messages.
-        log.debug('Received own XMPP profile', profile);
+        log.info('Received own XMPP profile', profile);
 
         // Update UI with own information.
         var userProfileMessage :UI.UserProfileMessage = {
@@ -401,7 +401,7 @@ module Social {
         user.handleClient(client);
       }
 
-      log.debug('received message', {
+      log.info('received message', {
         userFrom: user.userId,
         clientFrom: client.clientId,
         instanceFrom: user.clientToInstance(client.clientId),
@@ -498,7 +498,7 @@ module Social {
                    message :uProxy.Message) : Promise<void> => {
       var messageString = JSON.stringify(message);
 
-      log.debug('sending message', {
+      log.info('sending message', {
         userTo: user.userId,
         clientTo: clientId,
         // Instance may be undefined if we are making an instance request,

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -29,8 +29,8 @@
 /// <reference path='../freedom/typings/social.d.ts' />
 /// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
 
-
 module Social {
+  var log :Logging.Log = new Logging.Log('social');
 
   var LOGIN_TIMEOUT :number = 5000;  // ms
 
@@ -81,12 +81,15 @@ module Social {
    */
   export function getNetwork(networkName :string, userId :string) : Network {
     if (!(networkName in networks)) {
-      console.warn('Network does not exist: ' + networkName);
+      log.warn('Network does not exist', networkName);
       return null;
     }
 
     if (!(userId in networks[networkName])) {
-      console.log('Not logged in with userId ' + userId + ' in network ' + networkName);
+      log.info('Not logged in to network', {
+        userId: userId,
+        network: networkName
+      });
       return null;
     }
     return networks[networkName][userId];
@@ -138,15 +141,16 @@ module Social {
     public prepareLocalInstance = (userId :string) : Promise<void> => {
       var key = this.name + userId;
       return storage.load<Instance>(key).then((result :Instance) => {
-        console.log(JSON.stringify(result));
         this.myInstance = new Core.LocalInstance(this, userId, result);
-        this.log('loaded local instance from storage: ' +
-                 this.myInstance.instanceId);
+        log.info('loaded local instance from storage',
+                 result, this.myInstance.instanceId);
       }, (e) => {
         this.myInstance = new Core.LocalInstance(this, userId);
-        this.log('generating new local instance: ' +
+        log.info('generating new local instance',
                  this.myInstance.instanceId);
-        return storage.save<Instance>(key, this.myInstance.currentState());
+        return storage.save<Instance>(key, this.myInstance.currentState()).catch((e) => {
+          log.error('Could not save new LocalInstance', this.myInstance.instanceId, e.stack);
+        });
       });
     }
 
@@ -158,9 +162,9 @@ module Social {
      */
     protected addUser_ = (userId :string) : Core.User => {
       if (!this.isNewFriend_(userId)) {
-        this.error(this.name + ': cannot add already existing user!');
+        log.error('Cannot add already existing user', userId);
       }
-      this.log('added "' + userId + '" to roster.');
+      log.debug('added user to roster', userId);
       var newUser = new Core.User(this, userId);
       this.roster[userId] = newUser;
       return newUser;
@@ -194,20 +198,6 @@ module Social {
 
     public getUser = (userId :string) : Core.User => {
       return this.roster[userId];
-    }
-
-    /**
-     * Intended to be protected, but TypeScript has no 'protected' modifier.
-     */
-    public log = (msg :string) : void => {
-      console.log('[' + this.name + '] ' + msg);
-    }
-
-    /**
-     * Intended to be protected, but TypeScript has no 'protected' modifier.
-     */
-    public error = (msg :string) : void => {
-      console.error('!!! [' + this.name + '] ' + msg);
     }
 
     public resendInstanceHandshakes = () : void => {
@@ -290,7 +280,7 @@ module Social {
     private delayForLogin_ = (handler :Function) => {
       return (arg :any) => {
         if (!this.onceLoggedIn_) {
-          this.error('Not logged in.');
+          log.error('Attempting to call delayForLogin_ before trying to login');
           return;
         }
         return this.onceLoggedIn_.then(() => {
@@ -314,14 +304,14 @@ module Social {
     public handleUserProfile = (profile :freedom_Social.UserProfile) : void => {
       var userId = profile.userId;
       if (!Firewall.isValidUserProfile(profile, null)) {
-        this.error("Firewall: invalid user profile: " + JSON.stringify(profile));
+        log.error('Firewall: invalid user profile', profile);
         return;
       }
       // Check if this is ourself, in which case we update our own info.
       if (userId == this.myInstance.userId) {
         // TODO: we may want to verify that our status is ONLINE before
         // sending out any instance messages.
-        this.log('<-- XMPP(self) [' + profile.name + ']\n' + profile);
+        log.debug('Received own XMPP profile', profile);
 
         // Update UI with own information.
         var userProfileMessage :UI.UserProfileMessage = {
@@ -338,7 +328,7 @@ module Social {
       }
       // Otherwise, this is a remote contact. Add them to the roster if
       // necessary, and update their profile.
-      this.log('<--- XMPP(friend) [' + profile.name + ']' + profile);
+      log.debug('Received XMPP profile for other user', profile);
       this.getOrAddUser_(userId).update(profile);
     }
 
@@ -356,7 +346,7 @@ module Social {
      */
     public handleClientState = (freedomClient :freedom_Social.ClientState) : void => {
       if (!Firewall.isValidClientState(freedomClient, null)) {
-        this.error("Firewall: invalid client state: " + JSON.stringify(freedomClient));
+        log.error('Firewall: invalid client state:', freedomClient);
         return;
       }
       var client :UProxyClient.State =
@@ -373,7 +363,7 @@ module Social {
             client.status === UProxyClient.Status.OFFLINE) {
           this.fulfillLogout_();
         }
-        this.log('received own ClientState: ' + JSON.stringify(client));
+        log.info('received own ClientState', client);
         return;
       }
 
@@ -392,7 +382,7 @@ module Social {
      */
     public handleMessage = (incoming :freedom_Social.IncomingMessage) : void => {
       if (!Firewall.isValidIncomingMessage(incoming, null)) {
-        this.error("Firewall: invalid incoming message: " + JSON.stringify(incoming));
+        log.error('Firewall: invalid incoming message:', incoming);
         return;
       }
       var userId = incoming.from.userId;
@@ -411,19 +401,18 @@ module Social {
         user.handleClient(client);
       }
 
-      console.log(
-          'received message from userId: ' + user.userId +
-          ', clientId: ' + client.clientId +
-          // Instance may be undefined if we have not yet created an instance
-          // for this client, e.g. if this is the first instance message we
-          // are receiving from them.  This is not an error.
-          ', instanceId: ' + user.clientToInstance(client.clientId) +
-          ', message: ' + JSON.stringify(msg));
+      log.debug('received message', {
+        userFrom: user.userId,
+        clientFrom: client.clientId,
+        instanceFrom: user.clientToInstance(client.clientId),
+        msg: msg
+      });
       user.handleMessage(client.clientId, msg);
     }
 
     public restoreFromStorage() {
       // xmpp is weird, so we need to do this.
+      log.info('Loading users from storage');
       return storage.keys().then((keys :string[]) => {
         var myKey = this.getStorePath();
         for (var i in keys) {
@@ -451,7 +440,7 @@ module Social {
           .then((freedomClient :freedom_Social.ClientState) => {
             // Upon successful login, save local client information.
             this.startMonitor_();
-            this.log('logged into uProxy');
+            log.info('logged into network', this.name);
             return this.prepareLocalInstance(freedomClient.userId).then(() => {
               this.myInstance.clientId = freedomClient.clientId;
               // Notify UI that this network is online before we fulfill
@@ -478,17 +467,17 @@ module Social {
               }
               ui.showNotification('You have been logged out of ' + this.name);
               Social.removeNetwork(this.name, this.myInstance.userId);
-              console.log('Fulfilling onceLoggedOut_');
+              log.debug('Fulfilling onceLoggedOut_');
             }).catch((e) => {
-              console.error('Error fulfilling onceLoggedOut_', e);
+              log.error('Error fulfilling onceLoggedOut_', e.message);
             });
             this.restoreFromStorage();
           })
           .catch((e) => {
-            this.error('Could not login.');
+            log.error('Could not login to network');
             ui.sendError('There was a problem signing in to ' + this.name +
                          '. Please try again. ');
-            return Promise.reject(new Error('Could not login.'));
+            throw Error('Could not login');
           });
     }
 
@@ -496,7 +485,7 @@ module Social {
       return this.freedomApi_.logout().then(() => {
         this.fulfillLogout_();
       }).catch((e) => {
-        console.error('error in this.freedomApi_.logout', e);
+        log.error('Error while logging out:', e.message);
         return Promise.reject(e);
       });
     }
@@ -508,14 +497,16 @@ module Social {
                    clientId :string,
                    message :uProxy.Message) : Promise<void> => {
       var messageString = JSON.stringify(message);
-      console.log(
-          'sending message to userId: ' + user.userId +
-          ', clientId: ' + clientId +
-          // Instance may be undefined if we are making an instance request,
-          // i.e. we know that a client is ONLINE with uProxy, but don't
-          // yet have their instance info.  This is not an error.
-          ', instanceId: ' + user.clientToInstance(clientId) +
-          ', message: ' + messageString);
+
+      log.debug('sending message', {
+        userTo: user.userId,
+        clientTo: clientId,
+        // Instance may be undefined if we are making an instance request,
+        // i.e. we know that a client is ONLINE with uProxy, but don't
+        // yet have their instance info.  This is not an error.
+        instanceTo: user.clientToInstance(clientId),
+        msg: messageString
+      });
       return this.freedomApi_.sendMessage(clientId, messageString);
     }
 
@@ -525,7 +516,7 @@ module Social {
     private startMonitor_ = () : void => {
       if (this.monitorIntervalId_) {
         // clear any existing monitor
-        console.error('startMonitor_ called with monitor already running');
+        log.error('startMonitor_ called with monitor already running');
         this.stopMonitor_();
       } else if (this.name == 'Facebook') {
         // Don't monitor (send INSTANCE_REQUEST messages) for Facebook,
@@ -534,7 +525,7 @@ module Social {
       }
 
       var monitorCallback = () => {
-        this.log('Running monitor');
+        log.debug('running monitor');
         // TODO: if too many instances are missing, we may send more messages
         // than our XMPP server will allow and be throttled.  We should change
         // monitoring to limit the number of XMPP messages it sends on each
@@ -594,10 +585,7 @@ module Social {
     public send = (user :Core.User,
                    recipientClientId :string,
                    message :uProxy.Message) : Promise<void> => {
-      this.log('Manual network sending message; recipientClientId=[' +
-               recipientClientId + '], message=' + JSON.stringify(message));
       // TODO: Batch messages.
-
       // Relay the message to the UI for display to the user.
       ui.update(uProxy.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE, message);
 
@@ -608,8 +596,8 @@ module Social {
     // message is malformed or otherwise invalid.
     public receive = (senderClientId :string,
                       message :uProxy.Message) : void => {
-      this.log('Manual network received incoming message; senderClientId=[' +
-               senderClientId + '], message=' + JSON.stringify(message));
+      log.debug('Received incoming manual message from %1: %2',
+                senderClientId, message);
 
       // Client ID and user ID are the same thing in the manual network, so the
       // sender client ID doubles as the sender user ID.

--- a/src/generic_core/user.spec.ts
+++ b/src/generic_core/user.spec.ts
@@ -137,7 +137,7 @@ describe('Core.User', () => {
     };
     spyOn(console, 'error');
     user.handleClient(clientState);
-    expect(console.error).toHaveBeenCalled();
+    // TODO: check return value for error (there should be one)
   });
 
   describe('handlers', () => {
@@ -172,7 +172,7 @@ describe('Core.User', () => {
           'baz': 3
         }
       });
-      expect(console.error).toHaveBeenCalled();
+      // TODO: check return value for error (there should be one)
     });
 
     // TODO: Determine if we care about non-existing clients, or if we should
@@ -183,7 +183,7 @@ describe('Core.User', () => {
         type: uProxy.MessageType.INSTANCE,
         data: 'meow'
       });
-      expect(console.error).toHaveBeenCalled();
+      // TODO: check return value for error (there should be one)
     });
 
   });  // describe communications

--- a/src/generic_ui/polymer/network.ts
+++ b/src/generic_ui/polymer/network.ts
@@ -13,7 +13,7 @@ Polymer({
       this.fire('update-view', {view: UI.View.ROSTER});
       ui.bringUproxyToFront();
     }).catch((e) => {
-      console.warn('Did not log in ');
+      console.warn('Did not log in ', e);
     });
   },
   ready: function() {},


### PR DESCRIPTION
This takes care of moving us away from using console.log throughout
generic_core and instead uses the freedom logger.  At the same time,
this also includes a number of general cleanups to logging and error
handling.

General principles of logging used in the restructure:
* Messages should be greppable.  If I see a message in the console, I
  should be able to grep it in the code and figure out where it is
  coming from.  Obviously there may be extra variable data at the end of
  the mesasage, but it should be clear what that is
* The same message should not be logged twice.  There are some
  exceptions with this due to the nature of passing messages between the
  app and the extension, however, in general, we will try not to log
  something too many times (e.g. log the data right before calling the
  update function which logs the same data or logging an error at every
  single step).  If the log levels we would use for data are
  dramatically different (e.g. we log everything as debug in the update
  function but this should definitely get logged as an error) we will
  log it twice.

There are obviously some areas where this changes our logging behaviour, I'm not sure if they are all the best idea, so please feel free to comment on them.

Fixes #503 
Fixes #914 
Hopefully fixes #982 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1035)
<!-- Reviewable:end -->
