### PR TITLE
Handle selecting copypaste urls better

### DIFF
--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -64,7 +64,7 @@
       <p>Copy and paste this URL to your friend over a secure channel.</p>
 
       <textarea readonly hidden?='{{ !ui.copyPasteGettingMessage.length }}'
-        class='message'>https://www.uproxy.org/request/{{ ui.copyPasteGettingMessage }}</textarea>
+        class='message' on-tap='{{ select }}'>https://www.uproxy.org/request/{{ ui.copyPasteGettingMessage }}</textarea>
 
       <span class='message-loading' hidden?='{{ ui.copyPasteGettingMessage.length }}'>Loading...</span>
 
@@ -92,7 +92,7 @@
       </p>
 
       <textarea readonly hidden?='{{ !ui.copyPasteSharingMessage.length }}'
-        class='message'>https://www.uproxy.org/offer/{{ ui.copyPasteSharingMessage }}</textarea>
+        class='message' on-tap='{{ select }}'>https://www.uproxy.org/offer/{{ ui.copyPasteSharingMessage }}</textarea>
 
       <span class='message-loading' hidden?='{{ ui.copyPasteSharingMessage.length }}'>Loading...</span>
 

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -40,5 +40,9 @@ Polymer({
   stopSharing: function() {
     core.stopCopyPasteShare();
   },
+  select: function(e, d, sender) {
+    sender.focus();
+    sender.select();
+  },
   ready: function() {}
 });


### PR DESCRIPTION
When the user clicks on the textarea containing the copy-paste url, we
will immediately select the entire url

Tested by clicking on the url

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1040)
<!-- Reviewable:end -->
