### PR TITLE
stick with latest version of uproxy-networking

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "typescript": "^1.0.1",
     "uproxy-churn": "^0.0.5",
     "uproxy-lib": "^19.0.0",
-    "uproxy-networking": "^5.2.0"
+    "uproxy-networking": "^6.0.0"
   },
   "peerDependencies": {
     "freedom": "~0.6.18"


### PR DESCRIPTION
The API changed in the major version bump is not used by the uProxy UI. Just want to keep ye up to date.

Tested locally by proxying between Dexter and Bob.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1043)
<!-- Reviewable:end -->
