### PR TITLE
Reposition the close button for uproxy-tip, update comment

### DIFF
--- a/src/generic_ui/polymer/tip.html
+++ b/src/generic_ui/polymer/tip.html
@@ -16,6 +16,9 @@ uproxy-tip::shadow #box {
 uproxy-tip::shadow #arrow {
   border-bottom-color: red;
 }
+uproxy-tip::shadow #done {
+  background: (some off-shade);
+}
 -->
 
 <polymer-element name='uproxy-tip'>
@@ -54,9 +57,7 @@ uproxy-tip::shadow #arrow {
       padding: 10px;
     }
     #close {
-      position: absolute;
-      top: 0;
-      right: 0;
+      float: right;
     }
     #actions {
       text-align: right;


### PR DESCRIPTION
This uses float: right for the tooltip close button instead of setting
an absolute position.  It should have no real effect on the actual
display unless the content would intersect with the close button
previously.

Tested by experimenting in UI

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1062)
<!-- Reviewable:end -->
