### PR TITLE
FAQ opens in firefox

### DIFF
--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -32,7 +32,9 @@ class FirefoxBrowserApi implements BrowserAPI {
 
   // For FAQ.
 
-  public openFaq = (pageAnchor ?:string) => {}
+  public openFaq = (pageAnchor ?:string) => {
+    port.emit('openURL', "faq.html#" + pageAnchor);
+  }
 
   // For proxy configuration.
   // Sends message back to add-on environment, which handles proxy settings.

--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -9,7 +9,8 @@ var proxyConfig = require('firefox_proxy_config.js').proxyConfig;
 
 // TODO: rename uproxy.js/ts to uproxy-enums.js/ts
 var uProxy = require('uproxy.js').uProxy;
-var { Ci, Cr } = require("chrome");
+var { Ci, Cc, Cr } = require("chrome");
+var self = require("sdk/self");
 var events = require("sdk/system/events");
 
 // TODO: rename freedom to uProxyFreedomModule
@@ -49,6 +50,16 @@ function setUpConnection(freedom, panel, button) {
 
   panel.port.on('showPanel', function() {
     panel.show();
+  });
+
+  panel.port.on('openURL', function(url) {
+    var win = Cc['@mozilla.org/appshell/window-mediator;1']
+        .getService(Ci.nsIWindowMediator)
+        .getMostRecentWindow('navigator:browser');
+    if (url.indexOf(':') < 0) {
+      url = self.data.url(url);
+    }
+    win.gBrowser.selectedTab = win.gBrowser.addTab(url);
   });
 }
 


### PR DESCRIPTION
Some minor plumbing to get faq links to open in firefox. should be able to roll forward to act as the more generic openURL that will appear per https://github.com/uProxy/uproxy/pull/1059

fixes #647

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1066)
<!-- Reviewable:end -->
