### PR TITLE
Remove content_security_policy from Chrome extension (use default)

### DIFF
--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -29,7 +29,6 @@
     },
     "default_title": "__MSG_extTitle__"
   },
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "permissions": [
     "tabs",
     "proxy",


### PR DESCRIPTION
Fixes #679

Tested in Chrome

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1069)
<!-- Reviewable:end -->
