### PR TITLE
Add copypaste.html to web_accessible_resources

### DIFF
--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -39,6 +39,9 @@
     "https://uproxy.org/offer/*",
     "webRequestBlocking"
   ],
+  "web_accessible_resources": [
+    "copypaste.html"
+  ],
   "options_page": "index.html",
   "externally_connectable": {
     "ids" : ["fmdppkkepalnkeommjadgbhiohihdhii"],


### PR DESCRIPTION
The copypaste.html not being in the web_accessible_resources array for
the chrome extension manifest was causing redirects to it through the
Google proxy to fail to load.  This caused clicking on the link from in
a hangout message to just endlessly load.

Fixes #1065 

Tested by clicking on a copy+paste link from hangouts

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1070)
<!-- Reviewable:end -->
