### PR TITLE
Improve detection of hidden elements for uproxy-tip

### DIFF
--- a/src/generic_ui/polymer/tip.ts
+++ b/src/generic_ui/polymer/tip.ts
@@ -12,8 +12,8 @@ Polymer({
     // removed once that happens.
 
     var prev = this.previousSibling;
-    if (prev.offsetLeft === 0 && prev.offsetTop === 0 && prev.offsetWidth === 0
-        && prev.offsetHeight === 0) {
+    if (window.getComputedStyle(prev).display === 'none' ||
+        window.getComputedStyle(this).display === 'none') {
       this.async(this.doReposition, null, 500);
       return;
     }
@@ -28,7 +28,11 @@ Polymer({
     }
 
     var prevCntr = prev.offsetLeft + prev.offsetWidth / 2;
-    var parentWidth = this.parentElement.offsetWidth;
+    // use width of target if the parent is not an element
+    var parentWidth = prev.offsetWidth;
+    if (this.parentElement) {
+      parentWidth = this.parentElement.offsetWidth;
+    }
 
     this.style.top = (prev.offsetHeight + prev.offsetTop) + 'px';
 


### PR DESCRIPTION
This improves the detection of hidden elements by using
window.getComputedStyle to check whether the current or target element
are currently hidden.  This works in many more cases than the previous
hacky checking of positions.

This also will treat the target element as occupying the full possible
width if there is no parent element (e.g. the previous element is a
top-level component in a web component.

This just fixes more issues that came up while working on copy+paste errors.  Tested by looking at the error messages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1072)
<!-- Reviewable:end -->
