### PR TITLE
Make sure uproxy tab stays in front with URL pasting

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -220,7 +220,7 @@ module.exports = (grunt) ->
         files: [ {
           # The platform specific non-compiled stuff, and...
           expand: true, cwd: 'src/chrome/extension'
-          src: ['**', '!**/*.md', '!**/*.ts', '!**/*.html']
+          src: ['**', '!**/*.md', '!**/*.ts', '!polymer/*.html']
           dest: chromeExtDevPath
         }, {
           # generic_ui compiled source.

--- a/src/chrome/extension/copypaste.html
+++ b/src/chrome/extension/copypaste.html
@@ -13,6 +13,8 @@
     You just pasted a link to try to set up a direct connection to uProxy.
     Please see the app window for more information.
   </p>
+
+  <script src='scripts/copypaste.js'></script>
 </body>
 
 </html>

--- a/src/chrome/extension/scripts/copypaste.ts
+++ b/src/chrome/extension/scripts/copypaste.ts
@@ -1,0 +1,4 @@
+(() => {
+  var extension_id = 'pjpcdnccaekokkkeheolmpkfifcbibnj';
+  chrome.runtime.sendMessage(extension_id, { openWindow: true });
+})();

--- a/src/firefox/lib/url-handler.js
+++ b/src/firefox/lib/url-handler.js
@@ -15,6 +15,7 @@ exports.setup = function(panel) {
       }
 
       panel.port.emit('handleUrlData', url);
+      panel.port.emit('showPanel');
 
       subject.cancel(Cr.NS_BINDING_ABORTED);
     }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -370,7 +370,6 @@ module UI {
         return;
       }
 
-      this.browserApi.bringUproxyToFront();
       this.view = uProxy.View.COPYPASTE;
 
       var match = url.match(/https:\/\/www.uproxy.org\/(request|offer)\/(.*)/)


### PR DESCRIPTION
This fixes an issues where the uProxy popup would, in Chrome, not
actually be at the front by the end of the page redirect.  This seems to
be due to the main window regaining focus when the tab loads.

To get around this, we register a callback from that tab to send a
message to the extension telling it to bring the uProxy window to the
front.  This message is handled in the background script for the
extension.

This also moves the responsibility of launching the window out of
generic_ui and into the browser-specific code.

Fixes #1064

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1078)
<!-- Reviewable:end -->
