### PR TITLE
Set ui.view to SPLASH when app is connected

### DIFF
--- a/src/chrome/extension/scripts/chrome_core_connector.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.ts
@@ -139,6 +139,7 @@ class ChromeCoreConnector implements uProxy.CoreBrowserConnector {
         this.appPort_.onMessage.addListener(this.receive_);
         this.status.connected = true;
         // Once connected, the extension popup should show its start page.
+        ui.view = uProxy.View.SPLASH;
         chrome.browserAction.setIcon({
           path: {
             "19": "icons/19_" + UI.LOGGED_OUT_ICON,


### PR DESCRIPTION
Set ui.view to SPLASH when app is connected.  This was removed in https://github.com/uProxy/uproxy/pull/1056 but is needed to properly advance to the SPLASH screen if you first install the chrome extension then the app.

Tested in Chrome

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1081)
<!-- Reviewable:end -->
