### PR TITLE
Add new Polymer element without setting innerHTML.

### DIFF
--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -90,10 +90,8 @@ Polymer({
     this.ui = ui;
     this.uProxy = uProxy;
     if(ui.browserApi.browserSpecificElement){
-      var div = document.createElement("div");
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
-      div.innerHTML = browserCustomElement.outerHTML;
-      this.$.browserElementContainer.appendChild(div.childNodes[0]);
+      this.$.browserElementContainer.appendChild(browserCustomElement);
     }
   },
 


### PR DESCRIPTION
The code was originally added here https://github.com/uProxy/uproxy/pull/971 because Polymer used to error when I tried this before. Seems to be working now without using the extra div.

Addressing this: https://github.com/uProxy/uproxy/issues/1091 
This was the only place in uproxy/src setting innerHTML

ran grunt test and tested manually (made sure the 'application missing' page showed up when it should)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1099)
<!-- Reviewable:end -->
