### PR TITLE
Changes to setting/resetting Firefox proxy settings

### DIFF
--- a/src/firefox/lib/firefox_proxy_config.js
+++ b/src/firefox/lib/firefox_proxy_config.js
@@ -18,7 +18,7 @@ proxyConfig.startUsingProxy = function(endpoint) {
     this.proxy_type_ = prefsvc.get("network.proxy.type");
 
     prefsvc.set("network.proxy.socks", endpoint.address);
-    prefsvc.set("network.proxy.http_port", endpoint.port);
+    prefsvc.set("network.proxy.socks_port", endpoint.port);
     prefsvc.set("network.proxy.type", 1);
   }
 };
@@ -28,8 +28,8 @@ proxyConfig.stopUsingProxy = function(askUser) {
     this.running_ = false;
     // Restore initial proxy state.
     prefsvc.set("network.proxy.socks", this.socks_server_);
-    prefsvc.set("network.proxy.http_port", this.socks_port_);
-    prefsvc.set("network.proxy.type", this.proxy_type);
+    prefsvc.set("network.proxy.socks_port", this.socks_port_);
+    prefsvc.set("network.proxy.type", this.proxy_type_);
   }
 
 };


### PR DESCRIPTION
This makes sure that we set the correct fields when configuring the
Firefox proxy and makes sure we reset the correct fields when proxying
ends

Fixes #1120

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1121)
<!-- Reviewable:end -->
