### PR TITLE
Fix Firefox button label, panel position

### DIFF
--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -50,7 +50,9 @@ function setUpConnection(freedom, panel, button) {
   });
 
   panel.port.on('showPanel', function() {
-    panel.show();
+    panel.show({
+      position: button
+    });
   });
 
   panel.port.on('openURL', function(url) {

--- a/src/firefox/lib/main.js
+++ b/src/firefox/lib/main.js
@@ -8,7 +8,7 @@ Cu.import(self.data.url('freedom-for-firefox.jsm'));
 // Main uProxy button.
 var button = buttons.ActionButton({
   id: "uProxy-button",
-  label: "uProxy-button",
+  label: "uProxy",
   icon: {
     "18": "./icons/19_offline.gif",
     "36": "./icons/38_offline.gif"
@@ -34,7 +34,7 @@ freedom(manifest, {
 
   // Set up connection between freedom and content script.
   require('glue.js').setUpConnection(new uproxy(), panel, button);
-  require('url-handler.js').setup(panel);
+  require('url-handler.js').setup(panel, button);
 });
 
 

--- a/src/firefox/lib/url-handler.js
+++ b/src/firefox/lib/url-handler.js
@@ -1,6 +1,6 @@
 var { Cc, Ci, Cr } = require('chrome');
 
-exports.setup = function(panel) {
+exports.setup = function(panel, button) {
   var observer = {
     observe: function (subject, topic, data) {
       if ('http-on-modify-request' !== topic) {
@@ -15,7 +15,9 @@ exports.setup = function(panel) {
       }
 
       panel.port.emit('handleUrlData', url);
-      panel.show();
+      panel.show({
+        position: button
+      });
 
       subject.cancel(Cr.NS_BINDING_ABORTED);
     }


### PR DESCRIPTION
Fix the label for the uProxy button in the Firefox UI to just read
"uProxy" instead of "uProxy-button"

The Firefox panel now opens up attached to the button in all cases, not
just for the initial appearance.

Fixes #1092

Tested by forcing opens of the Firefox dialog and checking they are attached to the button as well as opening up the customize menu in Firefox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1134)
<!-- Reviewable:end -->
