### PR TITLE
Remove the unsafe-content-script permission from Firefox

### DIFF
--- a/src/firefox/package.json
+++ b/src/firefox/package.json
@@ -7,7 +7,6 @@
   "license": "MPL 2.0",
   "version": "0.1",
   "permissions": {
-    "private-browsing": true,
-    "unsafe-content-script": true
+    "private-browsing": true
   }
 }


### PR DESCRIPTION
The unsafe-content-script permission is no longer needed in Firefox,
remove it from the manifest.

Fixes #680

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1146)
<!-- Reviewable:end -->
