### PR TITLE
Set default browser icon to offline icon.

### DIFF
--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -24,8 +24,8 @@
   },
   "browser_action": {
     "default_icon": {
-      "19": "icons/19_error.png",
-      "38": "icons/19_error.png"
+      "19": "icons/19_offline.gif",
+      "38": "icons/19_offline.gif"
     },
     "default_title": "__MSG_extTitle__"
   },


### PR DESCRIPTION
Addressing this: https://github.com/uProxy/uproxy/issues/1136

Upon install, don't show the error icon. However, if the app disconnects after being connected for some time, the error icon will still appear (this is existing behaviour). In that case, we should give better error recovery instructions though; bug here: https://github.com/uProxy/uproxy/issues/1148.

Tested manually.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1149)
<!-- Reviewable:end -->
