### PR TITLE
Fix bugs with settings panel.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,7 @@
     "core-label": "Polymer/core-label#~0.5.5",
     "core-tooltip": "Polymer/core-tooltip#~0.5.5",
     "core-collapse": "Polymer/core-collapse#~0.5.5",
-    "core-header-panel": "Polymer/core-header-panel#~0.5.5"
+    "core-header-panel": "Polymer/core-header-panel#~0.5.5",
+    "core-drawer-panel": "Polymer/core-drawer-panel#~0.5.5"
   }
 }

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -1,5 +1,7 @@
 <link rel='import' href='../lib/polymer/polymer.html'>
 <link rel='import' href='../lib/paper-input/paper-input-decorator.html'>
+<link rel='import' href='../lib/paper-button/paper-button.html'>
+<link rel='import' href='../lib/core-icons/core-icons.html'>
 
 <polymer-element name='uproxy-description' attributes=''>
   <template>
@@ -9,11 +11,48 @@
       paper-input-decorator /deep/ .cursor {
           background-color: #009688;
       }
+      paper-input-decorator {
+        font-size: 14px;
+        padding: 0;
+        margin-bottom: 5px;
+        color: rgb(112, 112, 112);
+      }
+      paper-button {
+        background: #009688;  /* dark green */
+        color: white;
+        width: 70px;
+        margin-left: 0px;
+        margin-right: 5px;
+        font-size: 10px;
+      }
+      #savedDescription {
+        font-size: 14px;
+        color: rgb(112, 112, 112);
+        padding-top: 7px;
+      }
+      core-icon[icon=create] {
+        height: 16px;
+        width: 16px;
+        margin: 0px 0px 4px 3px;
+        opacity: 0.6;
+        float: right;
+      }
+      core-icon[icon=create]:hover{
+        opacity: 1;
+      }
     </style>
 
-    <paper-input-decorator label="Description">
-      <input is="core-input" value='{{model.globalSettings.description}}' on-blur='{{update}}'>
-    </paper-input-decorator>
+    <div id='editingDescription' hidden?='{{ !editing }}'>
+      <paper-input-decorator label="Description">
+        <input is="core-input" value='{{model.globalSettings.description}}' on-blur='{{update}}'>
+      </paper-input-decorator>
+      <paper-button raised on-tap="{{ saveDescription }}">Save</paper-button>
+      <paper-button raised on-tap="{{ cancelEditing }}">Cancel</paper-button>
+    </div>
+    <div id='savedDescription' hidden?='{{ editing }}'>
+      {{model.globalSettings.description}}
+      <core-icon icon='create' on-tap='{{ editDescription }}'></core-icon>
+    </div>
   </template>
   <script src='description.js'></script>
 </polymer-element>

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -44,13 +44,13 @@
 
     <div id='editingDescription' hidden?='{{ !editing }}'>
       <paper-input-decorator label="Description">
-        <input is="core-input" value='{{model.globalSettings.description}}' on-blur='{{update}}'>
+        <input is="core-input" value='{{ descriptionInput }}'>
       </paper-input-decorator>
       <paper-button raised on-tap="{{ saveDescription }}">Save</paper-button>
       <paper-button raised on-tap="{{ cancelEditing }}">Cancel</paper-button>
     </div>
     <div id='savedDescription' hidden?='{{ editing }}'>
-      {{model.globalSettings.description}}
+      {{ model.globalSettings.description }}
       <core-icon icon='create' on-tap='{{ editDescription }}'></core-icon>
     </div>
   </template>

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -50,7 +50,7 @@
       <paper-button raised on-tap="{{ cancelEditing }}">Cancel</paper-button>
     </div>
     <div id='savedDescription' hidden?='{{ editing }}'>
-      {{ model.globalSettings.description }}
+      {{ model.globalSettings.description || 'Name this device' }}
       <core-icon icon='create' on-tap='{{ editDescription }}'></core-icon>
     </div>
   </template>

--- a/src/generic_ui/polymer/description.ts
+++ b/src/generic_ui/polymer/description.ts
@@ -5,6 +5,19 @@ declare var core :CoreConnector;
 
 Polymer({
   model: model,
+  editing: false,
+  lastSavedDescription: model.globalSettings.description,
+  editDescription: function() {
+    this.lastSavedDescription = this.model.globalSettings.description;
+    this.editing = true;
+  },
+  saveDescription: function() {
+    this.editing = false;
+  },
+  cancelEditing: function() {
+    this.model.globalSettings.description = this.lastSavedDescription;
+    this.editing = false;
+  },
   update: function() {
     core.updateGlobalSettings(model.globalSettings);
   }

--- a/src/generic_ui/polymer/description.ts
+++ b/src/generic_ui/polymer/description.ts
@@ -4,21 +4,21 @@
 declare var core :CoreConnector;
 
 Polymer({
-  model: model,
-  editing: false,
-  lastSavedDescription: model.globalSettings.description,
   editDescription: function() {
-    this.lastSavedDescription = this.model.globalSettings.description;
+    this.descriptionInput = this.model.globalSettings.description;
     this.editing = true;
   },
   saveDescription: function() {
+    this.model.globalSettings.description = this.descriptionInput;
     this.editing = false;
+    core.updateGlobalSettings(model.globalSettings);
   },
   cancelEditing: function() {
-    this.model.globalSettings.description = this.lastSavedDescription;
     this.editing = false;
   },
-  update: function() {
-    core.updateGlobalSettings(model.globalSettings);
+  ready: function() {
+    this.model = model;
+    this.editing = false;
+    this.descriptionInput = '';
   }
 });

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -5,7 +5,9 @@ Polymer({
   feedback: '',
   logs: '',
   backToSettings: function() {
-    ui.view = uProxy.View.SETTINGS;
+    // The settings panel will still be open in the roster
+    // if the user navigated to feedback from settings.
+    ui.view = uProxy.View.ROSTER;
   },
   sendFeedback: function() {
     // TODO: Get and send real logs.

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../lib/polymer/polymer.html">
 <link rel="import" href="../lib/core-signals/core-signals.html">
 <link rel="import" href="../lib/core-header-panel/core-header-panel.html">
+<link rel="import" href="../lib/core-drawer-panel/core-drawer-panel.html">
 <link rel="import" href="../lib/core-toolbar/core-toolbar.html">
 <link rel="import" href="../lib/core-icon-button/core-icon-button.html">
 <link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
@@ -44,6 +45,9 @@
         font-size: 14px;
         text-transform: uppercase;
       }
+      core-drawer-panel {
+        overflow: auto;
+      }
       core-header-panel {
         height: 100%;
       }
@@ -53,7 +57,6 @@
       core-toolbar {
         height: 105px;
         background-color: #009688;
-        z-index: 1;
         width: 100%;
         color: #FFFFFF;
       }
@@ -85,15 +88,6 @@
       }
       #settings {
         top: 0;
-      }
-      #darkMask {
-        background-color: rgba(0, 0, 0, 0.5);
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        position: absolute;
-        z-index: 1001;
       }
       #rosterContainer {
         height: 100%;
@@ -153,85 +147,85 @@
     <uproxy-splash id='splash' hidden?='{{uProxy.View.SPLASH!=ui.view}}'>
     </uproxy-splash>
 
-    <core-header-panel
-        hidden?='{{ ui.view !== uProxy.View.ROSTER && ui.view !== uProxy.View.SETTINGS }}'>
+    <core-drawer-panel id='mainPanel' forceNarrow='true' drawerWidth='300px'
+        hidden?='{{ ui.view !== uProxy.View.ROSTER }}'>
+      <core-header-panel drawer>
+        <div class='content' fit>
+          <uproxy-settings id='settings'></uproxy-settings>
+        </div>
+      </core-header-panel>
+      <core-header-panel main
+          hidden?='{{ ui.view !== uProxy.View.ROSTER }}'>
 
-      <core-toolbar>
+        <core-toolbar>
 
-        <core-icon icon="menu" on-tap="{{ settingsView }}"></core-icon>
-        <div id='title' flex>uProxy</div>
+          <core-icon icon="menu" core-drawer-toggle></core-icon>
+          <div id='title' flex>uProxy</div>
 
-        <uproxy-bubble class='error' active='{{ ui.copyPasteError === UI.CopyPasteError.LOGGED_IN }}' on-closed='{{ dismissCopyPasteError }}'>
-          <h3>Cannot open manual connection</h3>
+          <uproxy-bubble class='error' active='{{ ui.copyPasteError === UI.CopyPasteError.LOGGED_IN }}' on-closed='{{ dismissCopyPasteError }}'>
+            <h3>Cannot open manual connection</h3>
+            <p>
+              It is not currently possible to open a manual connection at the
+              same time as being signed in to a social network.  To launch a
+              manual connection, please log out through the settings menu and
+              re-paste the link.
+            </p>
+          </uproxy-bubble>
+
+          <core-tooltip label='You are available for sharing.' position='left'>
+            <img id='sharingEnabledIcon'
+              src='../icons/sharing-enabled-toolbar.png'
+              hidden?='{{model.contacts.shareAccessContacts.onlineTrustedUproxy.length==0 && model.contacts.shareAccessContacts.offlineTrustedUproxy.length==0}}'
+              on-tap='{{ setShareMode }}'></img>
+          </core-tooltip>
+
+            <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && (model.contacts.shareAccessContacts.onlineTrustedUproxy.length > 0 || model.contacts.shareAccessContacts.offlineTrustedUproxy.length > 0) }}'>
+            <h3>Sharing Enabled</h3>
+            <p>This icon means you're available for sharing access with friends you've offered access to.</p>
+          </uproxy-bubble>
+
+          <div class='bottom fit'>
+            <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}'>
+              <paper-tab>Get Access</paper-tab>
+              <paper-tab>Share Access</paper-tab>
+            </paper-tabs>
+          </div>
+        </core-toolbar>
+
+        <uproxy-bubble on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome }}'>
+          <h3>Welcome to uProxy!</h3>
           <p>
-            It is not currently possible to open a manual connection at the
-            same time as being signed in to a social network.  To launch a
-            manual connection, please log out through the settings menu and
-            re-paste the link.
+            To get started, choose "Get access" or "Share access" and then click
+            on a friend to connect.
           </p>
         </uproxy-bubble>
 
-        <core-tooltip label='You are available for sharing.' position='left'>
-          <img id='sharingEnabledIcon'
-            src='../icons/sharing-enabled-toolbar.png'
-            hidden?='{{model.contacts.shareAccessContacts.onlineTrustedUproxy.length==0 && model.contacts.shareAccessContacts.offlineTrustedUproxy.length==0}}'
-            on-tap='{{ setShareMode }}'></img>
-        </core-tooltip>
+        <div class='content' fit>
 
-          <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && (model.contacts.shareAccessContacts.onlineTrustedUproxy.length > 0 || model.contacts.shareAccessContacts.offlineTrustedUproxy.length > 0) }}'>
-          <h3>Sharing Enabled</h3>
-          <p>This icon means you're available for sharing access with friends you've offered access to.</p>
-        </uproxy-bubble>
-
-        <div class='bottom fit'>
-          <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}'>
-            <paper-tab>Get Access</paper-tab>
-            <paper-tab>Share Access</paper-tab>
-          </paper-tabs>
-        </div>
-      </core-toolbar>
-
-      <uproxy-bubble on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome }}'>
-        <h3>Welcome to uProxy!</h3>
-        <p>
-          To get started, choose "Get access" or "Share access" and then click
-          on a friend to connect.
-        </p>
-      </uproxy-bubble>
-
-      <div class='content' fit>
-
-        <div id='rosterContainer' vertical layout>
-          <div id='roster-panel' flex>
-            <uproxy-roster id='get-roster' class='roster'
-                hidden?='{{model.globalSettings.mode!=uProxy.Mode.GET}}'
-                contacts='{{model.contacts.getAccessContacts}}'>
-            </uproxy-roster>
-            <uproxy-roster id='share-roster' class='roster'
-                hidden?='{{model.globalSettings.mode!=uProxy.Mode.SHARE}}'
-                contacts='{{model.contacts.shareAccessContacts}}'>
-            </uproxy-roster>
-          </div>
-
-          <div id='status'>
-            <div class='statusRow' hidden?='{{!ui.gettingStatus}}'>
-              <div class='statusText'><img src='../icons/getting.png'>{{ui.gettingStatus}}</div>
+          <div id='rosterContainer' vertical layout>
+            <div id='roster-panel' flex>
+              <uproxy-roster id='get-roster' class='roster'
+                  hidden?='{{model.globalSettings.mode!=uProxy.Mode.GET}}'
+                  contacts='{{model.contacts.getAccessContacts}}'>
+              </uproxy-roster>
+              <uproxy-roster id='share-roster' class='roster'
+                  hidden?='{{model.globalSettings.mode!=uProxy.Mode.SHARE}}'
+                  contacts='{{model.contacts.shareAccessContacts}}'>
+              </uproxy-roster>
             </div>
-            <div class='statusRow' hidden?='{{!ui.sharingStatus}}'>
-              <div class='statusText'><img src='../icons/sharing.png'>{{ui.sharingStatus}}</div>
+
+            <div id='status'>
+              <div class='statusRow' hidden?='{{!ui.gettingStatus}}'>
+                <div class='statusText'><img src='../icons/getting.png'>{{ui.gettingStatus}}</div>
+              </div>
+              <div class='statusRow' hidden?='{{!ui.sharingStatus}}'>
+                <div class='statusText'><img src='../icons/sharing.png'>{{ui.sharingStatus}}</div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </core-header-panel>
-
-    <uproxy-settings id='settings'
-      class='{{ { active:(uProxy.View.SETTINGS==ui.view) } | tokenList }}'>
-    </uproxy-settings>
-
-    <!-- Dark mask displayed on top of roster when settings is visible -->
-    <div id='darkMask' hidden?='{{uProxy.View.SETTINGS!=ui.view}}'
-        on-tap='{{ rosterView }}'></div>
+      </core-header-panel>
+    </core-drawer-panel>
 
     <!-- Dialog is opened when .toggle() is called in openDialog -->
     <!-- Without layered="false", styling needs to be prefixed with 'html /deep/' in order to have effect on the dialog contents.'  -->

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -17,12 +17,10 @@ Polymer({
     // this event.
     if (detail.view == uProxy.View.ROSTER && ui.view == uProxy.View.SPLASH) {
       this.fire('core-signal', {name: "login-success"});
+      this.$.mainPanel.closeDrawer();
       this.$.modeTabs.updateBar();
     }
     ui.view = detail.view;
-  },
-  settingsView: function() {
-    ui.view = uProxy.View.SETTINGS;
   },
   rosterView: function() {
     console.log('rosterView called');

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -60,15 +60,14 @@
       padding: 0;
       color: rgb(180, 180, 180);
     }
-    uproxy-description::shadow paper-input-decorator {
-      font-size: 14px;
-      padding: 0;
-      margin: 0;
-      color: rgb(112, 112, 112);
-    }
-    #advancedSettings paper-input-decorator {
+    paper-input-decorator {
       padding: 0;
       margin-bottom: 5px;
+    }
+    paper-input-decorator /deep/ .unfocused-underline,
+    paper-input-decorator /deep/ .focused-underline,
+    paper-input-decorator /deep/ .cursor {
+        background-color: #009688;
     }
     paper-button {
       background: #009688;  /* dark green */
@@ -78,11 +77,6 @@
       margin-right: 5px;
       font-size: 10px;
     }
-    paper-input-decorator /deep/ .unfocused-underline,
-    paper-input-decorator /deep/ .focused-underline,
-    paper-input-decorator /deep/ .cursor {
-        background-color: #009688;
-    }
     core-icon[icon=announcement],
     core-icon[icon=help],
     core-icon[icon=settings],
@@ -91,10 +85,6 @@
       height: 20px;
       width: 20px;
       margin-right: 5px;
-    }
-    #advancedSettings {
-      padding-left: 28px;
-      padding-right: 28px;
     }
     .advancedSettingsText {
       font-size: 12px;

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -14,44 +14,19 @@
       position: absolute;
       display: inline-block;
       box-sizing: border-box;
-      height: 100%; width: 100%;
       -webkit-transition: all 0.23s !important;
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
-      left: -100%;
-      z-index: 2000;  /* appear on top of toolbar */
-      position: absolute;
-      width: 300px;
+      min-width: 300px;
       height: 100%;
       background-color: #ffffff;
-      z-index: 2001;
       font-size: 14px;
-      visibility: hidden;
-    }
-    :host(.active) {
-      left: 0;
-      overflow: hidden;
-      visibility: visible;
     }
     .userInfo {
       background-color: #009688;  /* dark green */
-      width: 100%;
       color: white;
-      margin-bottom: 32px;
-      padding: 32px;
+      padding: 28px;
       line-height: 24px;
-    }
-    .actionLink {
-      cursor: pointer;
-      padding-left: 32px;
-      line-height: 32px;
-      color: rgb(112, 112, 112);
-      display: block;
-    }
-    #descriptionWrapper {
-      padding-left: 32px;
-      padding-right: 32px;
-      color: rgb(112, 112, 112);
     }
     .userInfoName, .userInfoIDWithoutName {
       font-size: 16px;
@@ -70,31 +45,71 @@
       border-radius: 50%;
       margin-left: -6px;
     }
+    #settingsLinks {
+      padding: 24px 28px;
+      color: rgb(112, 112, 112);
+      background-color: #fff;
+    }
+    uproxy-link,
+    uproxy-faq-link {
+      display: block;
+      padding: 10px 0px;
+    }
+    #descriptionWrapper {
+      font-size: 12px;
+      padding: 0;
+      color: rgb(180, 180, 180);
+    }
+    uproxy-description::shadow paper-input-decorator {
+      font-size: 14px;
+      padding: 0;
+      margin: 0;
+      color: rgb(112, 112, 112);
+    }
+    #advancedSettings paper-input-decorator {
+      padding: 0;
+      margin-bottom: 5px;
+    }
     paper-button {
       background: #009688;  /* dark green */
       color: white;
       width: 70px;
+      margin-left: 0px;
+      margin-right: 5px;
+      font-size: 10px;
     }
     paper-input-decorator /deep/ .unfocused-underline,
     paper-input-decorator /deep/ .focused-underline,
     paper-input-decorator /deep/ .cursor {
         background-color: #009688;
     }
-    core-icon {
-      height: 12px;
+    core-icon[icon=announcement],
+    core-icon[icon=help],
+    core-icon[icon=settings],
+    core-icon[icon=refresh],
+    core-icon[icon=settings-power] {
+      height: 20px;
+      width: 20px;
+      margin-right: 5px;
     }
     #advancedSettings {
-      padding-left: 32px;
-      padding-right: 32px;
+      padding-left: 28px;
+      padding-right: 28px;
     }
     .advancedSettingsText {
       font-size: 12px;
+      padding-top: 0px;
       color: rgb(112, 112, 112);
     }
-
+    hr {
+      border: 0;
+      margin: 20px -28px;
+      border-bottom: solid 1px;
+      border-color: rgb(238, 238, 238);
+    }
     </style>
 
-    <div hidden?='{{model.onlineNetwork==null}}'>
+    <div hidden?='{{model.onlineNetwork==null}}' vertical layout>
       <div class='userInfo'>
         <img class='userImage' hidden?='{{model.onlineNetwork.imageData==null}}'
             src='{{model.onlineNetwork.imageData}}'>
@@ -109,36 +124,53 @@
           <div class='userInfoIDWithoutName'>{{model.onlineNetwork.userId}}</div>
         </div>
       </div>
-      <div id='descriptionWrapper'>
-        Device description
-        <uproxy-description></uproxy-description>
-      </div>
-      <uproxy-link class='actionLink' on-tap='{{ openFeedbackForm }}' role='button'>
-        Submit Feedback
-      </uproxy-link>
-      <uproxy-link class='actionLink' on-tap='{{ toggleAdvancedSettings }}' role='button'>
-        Advanced Settings
-        <core-icon icon="expand-more" hidden?='{{displayAdvancedSettings}}'></core-icon>
-        <core-icon icon="expand-less" hidden?='{{!displayAdvancedSettings}}'></core-icon>
-      </uproxy-link>
-      <div id='advancedSettings' hidden?='{{!displayAdvancedSettings}}'>
-        <paper-input-decorator label="Custom STUN server">
-          <input is="core-input" value='{{stunServer}}'>
-        </paper-input-decorator>
-        <paper-button raised on-tap="{{setStunServer}}">Update</paper-button>
-        <paper-button raised on-tap="{{resetStunServers}}">Reset</paper-button>
-        <br><br>
-        <p id='confirmNewServer' class='advancedSettingsText' hidden>STUN server updated. New server will be used for future connections.</p>
-        <p id='confirmResetServers' class='advancedSettingsText' hidden>STUN servers reset. Default servers will be used for future connections.</p>
-      </div>
 
-      <uproxy-faq-link class='actionLink'>Get Help</uproxy-faq-link>
-      <uproxy-link class='actionLink' on-tap='{{ logOut }}' role='button'>
-        Log-out of uProxy
-      </uproxy-link>
-      <uproxy-link class='actionLink' on-tap='{{ restart }}' hidden?='{{ browser !== "chrome" }}' role='button'>
-        Restart
-      </uproxy-link>
+      <div id='settingsLinks'>
+        <div id='descriptionWrapper'>
+          Device description
+          <uproxy-description></uproxy-description>
+        </div>
+
+        <hr></hr>
+
+        <uproxy-link on-tap='{{ openFeedbackForm }}' role='button'>
+          <core-icon icon="announcement"></core-icon>
+          Submit Feedback
+        </uproxy-link>
+
+        <uproxy-faq-link>
+          <core-icon icon="help"></core-icon>
+          Get Help
+        </uproxy-faq-link>
+
+        <uproxy-link on-tap='{{ toggleAdvancedSettings }}' role='button'>
+          <core-icon icon="settings"></core-icon>
+          Advanced Settings
+          <!--<core-icon icon="expand-more" hidden?='{{displayAdvancedSettings}}'></core-icon>
+          <core-icon icon="expand-less" hidden?='{{!displayAdvancedSettings}}'></core-icon>-->
+        </uproxy-link>
+        <div id='advancedSettings' hidden?='{{!displayAdvancedSettings}}'>
+          <paper-input-decorator label="Custom STUN server">
+            <input is="core-input" value='{{stunServer}}'>
+          </paper-input-decorator>
+          <paper-button raised on-tap="{{setStunServer}}">Update</paper-button>
+          <paper-button raised on-tap="{{resetStunServers}}">Reset</paper-button>
+          <p id='confirmNewServer' class='advancedSettingsText' hidden>STUN server updated. New server will be used for future connections.</p>
+          <p id='confirmResetServers' class='advancedSettingsText' hidden>STUN servers reset. Default servers will be used for future connections.</p>
+        </div>
+
+        <hr></hr>
+
+        <uproxy-link on-tap='{{ restart }}' hidden?='{{ browser !== "chrome" }}' role='button'>
+          <core-icon icon="refresh"></core-icon>
+          Restart
+        </uproxy-link>
+
+        <uproxy-link on-tap='{{ logOut }}' role='button'>
+          <core-icon icon="settings-power"></core-icon>
+          Log-out of uProxy
+        </uproxy-link>
+      </div>
     </div>
 
   </template>

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -131,7 +131,7 @@
           <uproxy-description></uproxy-description>
         </div>
 
-        <hr></hr>
+        <hr>
 
         <uproxy-link on-tap='{{ openFeedbackForm }}' role='button'>
           <core-icon icon="announcement"></core-icon>
@@ -157,7 +157,7 @@
           <p id='confirmResetServers' class='advancedSettingsText' hidden>STUN servers reset. Default servers will be used for future connections.</p>
         </div>
 
-        <hr></hr>
+        <hr>
 
         <uproxy-link on-tap='{{ restart }}' hidden?='{{ browser !== "chrome" }}' role='button'>
           <core-icon icon="refresh"></core-icon>

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -146,8 +146,6 @@
         <uproxy-link on-tap='{{ toggleAdvancedSettings }}' role='button'>
           <core-icon icon="settings"></core-icon>
           Advanced Settings
-          <!--<core-icon icon="expand-more" hidden?='{{displayAdvancedSettings}}'></core-icon>
-          <core-icon icon="expand-less" hidden?='{{!displayAdvancedSettings}}'></core-icon>-->
         </uproxy-link>
         <div id='advancedSettings' hidden?='{{!displayAdvancedSettings}}'>
           <paper-input-decorator label="Custom STUN server">

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -277,7 +277,6 @@ module uProxy {
     SPLASH = 0,
     COPYPASTE,
     ROSTER,
-    SETTINGS,
     BROWSER_ERROR,
     FEEDBACK
   }


### PR DESCRIPTION
Tested manually and grunt test.

- Resolve this issue: https://github.com/uProxy/uproxy/issues/1150
- Before, if the window is too narrow, you can't close the settings panel. Now you can close it by swiping the right edge of the panel. 
- Remove the SETTINGS view. Settings is now part of the roster view.
- Update styling:

![image](https://cloud.githubusercontent.com/assets/8723127/6871861/dfdcea68-d47b-11e4-9b94-a57bce39c6b5.png)

The only weirdness is opening the advanced settings in the default window size:
![image](https://cloud.githubusercontent.com/assets/8723127/6871927/516ae130-d47c-11e4-80b2-9c3f39bfd515.png)
Log out is pretty close to the bottom :( although the panel is now scrollable so you could get this:
![image](https://cloud.githubusercontent.com/assets/8723127/6871945/69ae66c2-d47c-11e4-9820-c0d0d2e0f88f.png)
@zahoriea would you prefer to shrink things so that it fits nicely? or did we want to keep an issue to move advanced settings to its own full panel, which would resolve this?

A lot of this CL was fixing tabs and moving things into new divs, if someone wants to walk through the code together that might be faster than looking in reviewable to see what's changed. Let me know!





<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1169)
<!-- Reviewable:end -->
