### PR TITLE
Add NAT to logs. Show in new view-logs page.

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -440,22 +440,6 @@ class uProxyCore implements uProxy.CoreAPI {
   public sendFeedback = (feedback :uProxy.UserFeedback) : void => {
     var sendXhr = (logs) : void => {
       var xhr = freedom["core.xhr"]();
-
-      /*
-      TODO: check if POST fails by registering onreadystatechange
-            callback.
-      xhr.on('onreadystatechange', () => {
-        Promise.all([xhr.getReadyState(), xhr.getStatus()])
-          .then((stateAndStatus) => {
-            log.info('getReadyState: ' + stateAndStatus[0]);
-            log.info('getStatus: ' + stateAndStatus[1]);
-            if (stateAndStatus[0] === 4 && stateAndStatus[1] != 200) {
-              // Reject the promise.
-            }
-          });
-      });
-      */
-
       var params = JSON.stringify(
         {'email' : feedback.email,
          'feedback' : feedback.feedback,
@@ -476,27 +460,6 @@ class uProxyCore implements uProxy.CoreAPI {
     } else {
       sendXhr('');
     }
-
-    /*
-    TODO: Allow users to submit just network info or just logs.
-    The new logic should be like below.
-
-    if (feedback.logs && feedback.networkInfo) {
-      this.getLogsAndNetworkInfo().then((logsWithNetworkInfo) => {
-        sendXhr(browserInfo + logsWithNetworkInfo);
-      });
-    } else if (feedback.logs) {
-      this.getLogs().then((logs) => {
-        sendXhr(browserInfo + logs);
-      });
-    } else if (feedback.networkInfo) {
-      this.getNetworkInfo().then((networkInfo) => {
-        sendXhr(networkInfo);
-      });
-    } else {
-      sendXhr('');
-    }
-    */
   }
 
   public getNatType = () : Promise<string> => {

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -444,9 +444,22 @@ class uProxyCore implements uProxy.CoreAPI {
     return network.getUser(path.userId);
   }
 
+  // TODO: make this return a promise, if it fails, the POST was not
+  // was not successful.
   public sendFeedback = (feedback :uProxy.UserFeedback) : void => {
     var sendXhr = (logs) : void => {
       var xhr = freedom["core.xhr"]();
+      xhr.on('onreadystatechange', () => {
+        Promise.all([xhr.getReadyState(), xhr.getStatus()])
+          .then((stateAndStatus) => {
+            log.info('getReadyState: ' + stateAndStatus[0]);
+            log.info('getStatus: ' + stateAndStatus[1]);
+
+            if (stateAndStatus[0] === 4 && stateAndStatus[1] != 200) {
+              // TODO: reject the promise.
+            }
+          });
+      });
       var params = JSON.stringify(
         {'email' : feedback.email,
          'feedback' : feedback.feedback,
@@ -484,7 +497,7 @@ class uProxyCore implements uProxy.CoreAPI {
       this.getNetworkInfo().then((networkInfo) => {
         sendXhr(networkInfo);
       });
-    } else (feedback.logs) {
+    } else {
       sendXhr('');
     }
     */

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -466,11 +466,13 @@ class uProxyCore implements uProxy.CoreAPI {
     if (this.natType_ === '') {
       return Diagnose.doNatProvoking().then((natType) => {
         this.natType_ = natType;
-        // Store NAT type for five minutes. This way, if the
-        // user previews their logs, and then submits them
-        // shortly after, we do not need to determine the NAT
-        // type once for the preview, and once for submission
-        // to our backend.
+        // Store NAT type for five minutes. This way, if the user previews
+        // their logs, and then submits them shortly after, we do not need
+        // to determine the NAT type once for the preview, and once for
+        // submission to our backend.
+        // If we expect users to check NAT type frequently (e.g. if they
+        // switch between networks while troubleshooting), then we might want
+        // to remove caching.
         setTimeout(() => {this.natType_ = '';}, 300000);
         return this.natType_;
       });

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -440,17 +440,22 @@ class uProxyCore implements uProxy.CoreAPI {
   public sendFeedback = (feedback :uProxy.UserFeedback) : void => {
     var sendXhr = (logs) : void => {
       var xhr = freedom["core.xhr"]();
+
+      /*
+      TODO: check if POST fails by registering onreadystatechange
+            callback.
       xhr.on('onreadystatechange', () => {
         Promise.all([xhr.getReadyState(), xhr.getStatus()])
           .then((stateAndStatus) => {
             log.info('getReadyState: ' + stateAndStatus[0]);
             log.info('getStatus: ' + stateAndStatus[1]);
-
             if (stateAndStatus[0] === 4 && stateAndStatus[1] != 200) {
-              // TODO: reject the promise.
+              // Reject the promise.
             }
           });
       });
+      */
+
       var params = JSON.stringify(
         {'email' : feedback.email,
          'feedback' : feedback.feedback,

--- a/src/generic_core/diagnose.ts
+++ b/src/generic_core/diagnose.ts
@@ -13,15 +13,6 @@ module Diagnose {
 
   var log :Logging.Log = new Logging.Log('Diagnose');
 
-  // Logging.setBufferedLogFilter(['*:I']);
-  // freedom().on('getLogs', function() {
-  //   var strs :string[] = Logging.getLogs();
-  //   for (var i = 0; i < strs.length; i++) {
-  //     freedom().emit('print', strs[i]);
-  //   }
-  //   Logging.clearLogs();
-  // });
-
   freedom().on('command', function(m :string) {
     log.debug('received command %1', [m]);
     if (m == 'send_udp') {

--- a/src/generic_core/diagnose.ts
+++ b/src/generic_core/diagnose.ts
@@ -1,0 +1,312 @@
+/// <reference path="../logging/logging.d.ts" />
+/// <reference path='../freedom/typings/freedom.d.ts' />
+/// <reference path='../freedom/typings/udp-socket.d.ts' />
+/// <reference path='../arraybuffers/arraybuffers.d.ts' />
+/// <reference path='messages.ts' />
+
+module Diagnose {
+  // Both Ping and NAT type detection need help from a server. The following
+  // ip/port is the instance we run on EC2.
+  var TEST_SERVER = '54.68.73.184';
+  var TEST_PORT = 6666;
+
+
+  var log :Logging.Log = new Logging.Log('Diagnose');
+
+  // Logging.setBufferedLogFilter(['*:I']);
+  // freedom().on('getLogs', function() {
+  //   var strs :string[] = Logging.getLogs();
+  //   for (var i = 0; i < strs.length; i++) {
+  //     freedom().emit('print', strs[i]);
+  //   }
+  //   Logging.clearLogs();
+  // });
+
+  freedom().on('command', function(m :string) {
+    log.debug('received command %1', [m]);
+    if (m == 'send_udp') {
+      doUdpTest();
+    } else if (m == 'stun_access') {
+      doStunAccessTest();
+    } else if (m == 'nat_provoking') {
+      doNatProvoking().then((natType: String) => {
+        log.debug('!!! natType =' + natType);
+        freedom().emit('print', 'NAT type is ' + natType);
+      });
+    }
+  });
+
+  function print(m: any) {
+    freedom().emit('print', m);
+  }
+
+  export function doUdpTest() {
+    log.info('perform udp test');
+    var socket: freedom_UdpSocket.Socket = freedom['core.udpsocket']();
+
+    function onUdpData(info: freedom_UdpSocket.RecvFromInfo) {
+      var rspStr = ArrayBuffers.arrayBufferToString(info.data);
+      log.debug(rspStr);
+
+      var rsp = JSON.parse(rspStr);
+      if (rsp['answer'] == 'Pong') {
+        print('Pong resonse received, latency=' +
+              (Date.now() - rsp['ping_time']) + 'ms')
+      }
+    }
+
+    socket.bind('0.0.0.0', 0)
+        .then((result: number) => {
+          if (result != 0) {
+            return Promise.reject(new Error('listen failed to bind :5758' +
+                ' with result code ' + result));
+          }
+          return Promise.resolve(result);
+        })
+        .then(socket.getInfo)
+        .then((socketInfo: freedom_UdpSocket.SocketInfo) => {
+          log.debug('listening on %1:%2',
+                    [socketInfo.localAddress, socketInfo.localPort]);
+        })
+        .then(() => {
+          socket.on('onData', onUdpData);
+          var pingReq = new Uint32Array(1);
+          var reqStr = JSON.stringify({
+            'ask': 'Ping',
+            'ping_time': Date.now()
+          });
+          var req = ArrayBuffers.stringToArrayBuffer(reqStr);
+          socket.sendTo(req, TEST_SERVER, TEST_PORT);
+        });
+  }
+
+  var stunServers = [
+    'stun:stun.l.google.com:19302',
+    'stun:stun1.l.google.com:19302',
+    'stun:stun2.l.google.com:19302',
+    'stun:stun3.l.google.com:19302',
+    'stun:stun4.l.google.com:19302',
+  ];
+
+  function doStunAccessTest() {
+    log.info('perform Stun access test');
+    for (var i = 0; i < stunServers.length; i++) {
+      var promises : Promise<number>[] = [];
+      for (var j = 0; j < 5; j++) {
+        promises.push(pingStunServer(stunServers[i]));
+      }
+      Promise.all(promises).then((laterncies: Array<number>) => {
+        var server = stunServers[i];
+        var total = 0;
+        for (var k = 0; k < laterncies.length; k++) {
+          total += laterncies[k];
+        }
+        print('Average laterncy for ' + stunServers[i] +
+              ' = ' + total / laterncies.length);
+      });
+    }
+  }
+
+  function pingStunServer(serverAddr: string) {
+    return new Promise<number>( (F, R) => {
+      var socket:freedom_UdpSocket.Socket = freedom['core.udpsocket']();
+      var parts = serverAddr.split(':');
+      var start = Date.now();
+
+      var bindRequest: Turn.StunMessage = {
+        method: Turn.MessageMethod.BIND,
+        clazz:  Turn.MessageClass.REQUEST,
+        transactionId: new Uint8Array(12),
+        attributes: []
+      };
+
+      var uint16View = new Uint16Array(bindRequest.transactionId);
+      for (var i = 0; i < 6; i++) {
+        uint16View[i] = Math.floor(Math.random() * 65535);
+      }
+
+      socket.on('onData', (info: freedom_UdpSocket.RecvFromInfo) => {
+        try {
+          var response = Turn.parseStunMessage(new Uint8Array(info.data));
+        } catch (e) {
+          log.error('Failed to parse bind request from %1', [serverAddr]);
+          R(e);
+          return;
+        }
+        var attribute = Turn.findFirstAttributeWithType(
+            Turn.MessageAttribute.XOR_MAPPED_ADDRESS, response.attributes);
+        var endPoint = Turn.parseXorMappedAddressAttribute(attribute.value);
+        var laterncy = Date.now() - start;
+        print(serverAddr + ' returned in ' + laterncy + 'ms. ' +
+              'report reflexive address: ' + JSON.stringify(endPoint));
+        F(laterncy);
+      });
+
+      var bytes = Turn.formatStunMessage(bindRequest);
+      socket.bind('0.0.0.0', 0)
+          .then((result: number) => {
+            if (result != 0) {
+              return Promise.reject(new Error('listen failed to bind :5758' +
+                  ' with result code ' + result));
+            }
+            return Promise.resolve(result);
+          }).then(() => {
+            return socket.sendTo(bytes.buffer, parts[1], parseInt(parts[2]));
+          }).then((written: number) => {
+              log.debug('%1 bytes sent correctly', [written]);
+          }).catch((e: Error) => {
+              log.debug(JSON.stringify(e));
+              R(e);
+          })
+    });
+  }
+
+  // The following code needs the help from a server to do its job. The server
+  // code can be found jsonserv.py in the same repository. One instance is
+  // running in EC2.
+  export function doNatProvoking() : Promise<String> {
+    return new Promise((F, R) => {
+      log.info('perform NAT provoking');
+      var socket: freedom_UdpSocket.Socket = freedom['core.udpsocket']();
+      var timerId: number = -1;
+
+      var rejectShortcut: (e: any) => void = null;
+
+      function onUdpData(info: freedom_UdpSocket.RecvFromInfo) {
+        var rspStr: string = ArrayBuffers.arrayBufferToString(info.data);
+        log.debug('receive response = ' + rspStr);
+
+        var rsp = JSON.parse(rspStr);
+
+        if (rsp['answer'] == 'FullCone') {
+          F('FullCone');
+        } else if (rsp['answer'] == 'RestrictedConePrepare') {
+          var peer_addr: string[] = rsp['prepare_peer'].split(':');
+          var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer('{"ask":""}');
+          log.debug('reply to RestrictedConePrepare');
+          socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
+          return;
+        } else if (rsp['answer'] == 'RestrictedCone') {
+          F('RestrictedCone');
+        } else if (rsp['answer'] == 'PortRestrictedConePrepare') {
+          var peer_addr: string[] = rsp['prepare_peer'].split(':');
+          var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer('{"ask":""}');
+          log.debug('reply to PortRestrictedConePrepare');
+          socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
+          return;
+        } else if (rsp['answer'] == 'PortRestrictedCone') {
+          F('PortRestrictedCone');
+        } else if (rsp['answer'] == 'SymmetricNATPrepare') {
+          var peer_addr: string[] = rsp['prepare_peer'].split(':');
+          var reqStr: string = JSON.stringify({ 'ask': 'AmISymmetricNAT' });
+          var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer(reqStr);
+          socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
+          return;
+        } else if (rsp['answer'] == 'SymmetricNAT') {
+          F('SymmetricNAT');
+        } else {
+          return;
+        }
+
+        if (timerId != -1) {
+          clearTimeout(timerId);
+          if (rejectShortcut) {
+            rejectShortcut(new Error('shortCircuit'));
+          }
+        }
+      }
+
+      socket.on('onData', onUdpData);
+
+      socket.bind('0.0.0.0', 0)
+          .then((result: number) => {
+            if (result != 0) {
+              return Promise.reject(new Error('failed to bind to a port: err=' + result));
+            }
+            return Promise.resolve(result);
+          })
+          .then(socket.getInfo)
+          .then((socketInfo: freedom_UdpSocket.SocketInfo) => {
+            log.debug('listening on %1:%2',
+                      [socketInfo.localAddress, socketInfo.localPort]);
+          })
+          .then(() => {
+            var reqStr: string = JSON.stringify({ 'ask': 'AmIFullCone' });
+            log.debug('send ' + reqStr);
+            var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer(reqStr);
+            for (var i = 0; i < 10; i++) {
+              socket.sendTo(req, TEST_SERVER, TEST_PORT);
+            }
+          })
+          .then(() => {
+            return new Promise<void>((F, R) => {
+              rejectShortcut = R;
+              timerId = setTimeout(() => {
+                timerId = -1;
+                F();
+              }, 2000);
+            });
+          })
+          .then(() => {
+            var reqStr: string = JSON.stringify({ 'ask': 'AmIRestrictedCone' });
+            log.debug(reqStr);
+            var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer(reqStr);
+            for (var i = 0; i < 3; i++) {
+              socket.sendTo(req, TEST_SERVER, TEST_PORT);
+            }
+          })
+          .then(() => {
+            return new Promise<void>((F, R) => {
+              rejectShortcut = R;
+              timerId = setTimeout(() => {
+                timerId = -1;
+                F();
+              }, 3000);
+            });
+          })
+          .then(() => {
+            var reqStr: string = JSON.stringify({ 'ask': 'AmIPortRestrictedCone' });
+            log.debug(reqStr);
+            var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer(reqStr);
+            for (var i = 0; i < 3; i++) {
+              socket.sendTo(req, TEST_SERVER, TEST_PORT);
+            }
+          })
+          .then(() => {
+            return new Promise<void>((F, R) => {
+              rejectShortcut = R;
+              timerId = setTimeout(() => {
+                timerId = -1;
+                F();
+              }, 10000);
+            });
+          })
+          .then(() => {
+            var reqStr: string = JSON.stringify({ 'ask': 'AmISymmetricNAT' });
+            log.debug(reqStr);
+            var req: ArrayBuffer = ArrayBuffers.stringToArrayBuffer(reqStr);
+            for (var i = 0; i < 3; i++) {
+              socket.sendTo(req, TEST_SERVER, TEST_PORT);
+            }
+          })
+          .then(() => {
+            return new Promise<void>((F, R) => {
+              rejectShortcut = R;
+              timerId = setTimeout(() => {
+                timerId = -1;
+                F();
+              }, 3000);
+            });
+          })
+          .catch((e: Error) => {
+            if (e.message != 'shortCircuit') {
+              log.error('something wrong: ' + e.message);
+              R(e);
+            } else {
+              log.debug('shortCircuit');
+            }
+          });
+    });
+  }
+}
+

--- a/src/generic_core/freedom-module.json
+++ b/src/generic_core/freedom-module.json
@@ -25,6 +25,8 @@
       "user.js",
       "social-enum.js",
       "social.js",
+      "messages.js",
+      "diagnose.js",
       "core.js"
     ]
   },

--- a/src/generic_core/messages.ts
+++ b/src/generic_core/messages.ts
@@ -1,0 +1,593 @@
+/// <reference path='../arraybuffers/arraybuffers.d.ts' />
+
+declare module sha1 {
+  /**
+   * Computes the HMAC-SHA1 of some data, with the specified key.
+   * Both key and data are interpreted as "binary strings" so to supply binary
+   * data or key you can construct a string with the help of
+   * String.fromCharCode(), e.g. [0x44, 0x5d, 0x75] -> 'D]u'.
+   * Ditto for return type.
+   */
+  function str_hmac_sha1(key:string, data:string) : string
+
+  /** As str_hmac_sha1 but returns a hex-formatted string. */
+  function hex_hmac_sha1(key:string, data:string) : string
+}
+
+/**
+ * Utilities for decoding and encoding STUN messages.
+ * TURN uses STUN messages, adding some methods and attributes.
+ *
+ * http://tools.ietf.org/html/rfc5389#section-6
+ */
+
+ module Turn {
+  /** A STUN/TURN message, used for requests and responses. */
+  export interface StunMessage {
+    method :MessageMethod;
+    clazz :MessageClass;
+    // Subarrays are much faster than encoding and decoding to a string.
+    transactionId :Uint8Array;
+    attributes :StunAttribute[];
+  }
+
+  /** A STUN/TURN attribute, which carries data in a message. */
+  export interface StunAttribute {
+    type :number;
+    value ?:Uint8Array;
+  }
+
+  /**
+   * Primary purpose of a request.
+   * The values here are a subset of what's defined for STUN and TURN.
+   * STUN only defines one method: BIND.
+   * TURN adds several more methods:
+   *   http://tools.ietf.org/html/rfc5766#section-13
+   */
+  export enum MessageMethod {
+    BIND = 1, // STUN's method; unsupported here, though Chrome tries it
+    ALLOCATE = 3,
+    REFRESH = 4,
+    SEND = 6,
+    DATA = 7,
+    CREATE_PERMISSION = 8,
+    CHANNEL_BIND = 9
+  }
+
+  /**
+   * This is orthogonal to method. Probably best to read:
+   *   http://tools.ietf.org/html/rfc5389#section-6
+   */
+  export enum MessageClass {
+    REQUEST = 1,
+    SUCCESS_RESPONSE = 2,
+    FAILURE_RESPONSE = 3,
+    INDICATION = 4
+  }
+
+  /**
+   * STUN/TURN attributes in which we are interested:
+   *   http://tools.ietf.org/html/rfc5389#section-15
+   *   http://tools.ietf.org/html/rfc5766#section-14
+   */
+  export enum MessageAttribute {
+    MAPPED_ADDRESS = 0x01,
+    USERNAME = 0x06,
+    MESSAGE_INTEGRITY = 0x08,
+    ERROR_CODE = 0x09,
+    XOR_PEER_ADDRESS = 0x12,
+    DATA = 0x13,
+    REALM = 0x14,
+    NONCE = 0x15,
+    XOR_RELAYED_ADDRESS = 0x16,
+    REQUESTED_TRANSPORT = 0x19,
+    XOR_MAPPED_ADDRESS = 0x20,
+    LIFETIME = 0x0d,
+    /**
+     * This attribute is appended to messages sent from one side of the
+     * TURN server to the other. For performance reasons we do not always
+     * strip this attribute before a message is relayed to a client; the
+     * value chosen lies within the "comprehension-optional" and undefined
+     * ranges which means that TURN clients should feel free to ignore it
+     * and the attribute should not interfere with ICE:
+     *   http://tools.ietf.org/html/rfc5389#section-18.2
+     *   http://www.iana.org/assignments/stun-parameters/stun-parameters.xhtml
+     */
+    IPC_TAG = 0xeeff
+  }
+
+  /** Represents a host:port combination. */
+  export interface Endpoint {
+    address:string;
+    port:number;
+  }
+
+  /**
+   * Username with which our HMAC_KEY was generated. Clients will need to use
+   * this to access the server.
+   */
+  export var USERNAME = 'test';
+
+  /**
+   * Password with which our HMAC_KEY was generated. Clients will need to use
+   * this to access the server.
+   */
+  export var PASSWORD = 'test';
+
+  /**
+   * Realm for this server. Has no real meaning -- but this is used as part of
+   * message signing (see HMAC_KEY).
+   */
+  export var REALM = 'myrealm';
+
+  /**
+   * Key for the HMAC algorithm with which we must sign STUN responses:
+   *   http://tools.ietf.org/html/rfc5389#section-15.4
+   *
+   * The key is defined as:
+   *   md5(username:realm:SASLprep(password))
+   *
+   * Currently, since the server has just one user (test), our key, pre-hashing,
+   * is effectively fixed as:
+   *   test:myrealm:test
+   *
+   * The hash can be easily generated on a Unix command-line:
+   *   echo -n 'test:myrealm:test'|md5sum
+   *   bd8adb317d5d542e5e2aba5bdb8f5ca2
+   *
+   * Wireshark-ing a TURN session with rfc5766-turn-server reveals that the key
+   * must be input to the HMAC algorithm as 16 bytes of *binary* data. So, we
+   * supply our crypto library with a UTF-8 string generated from the 16 bytes.
+   */
+   // TODO: dynamic username/password would be pretty easy to implement
+   // TODO: would be nice to run uint8array -> string on boot but the files
+   //       don't seem to load in the right order...might be a typescript bug
+   var HMAC_KEY = new Uint8Array([
+     0xbd, 0x8a, 0xdb, 0x31,
+     0x7d, 0x5d, 0x54, 0x2e,
+     0x5e, 0x2a, 0xba, 0x5b,
+     0xdb, 0x8f, 0x5c, 0xa2
+   ]);
+
+  /**
+   * Returns the "magic cookie" bytes:
+   *   http://tools.ietf.org/html/rfc5389#section-6
+   */
+  function getMagicCookieBytes() : Uint8Array {
+    return new Uint8Array([0x21, 0x12, 0xa4, 0x42]);
+  }
+
+  /**
+   * Parses a byte array, returning a StunMessage object.
+   * Throws an error if this is not a STUN request.
+   */
+  export function parseStunMessage(bytes:Uint8Array) : Turn.StunMessage {
+    // Fail if the request is too short to be valid.
+    if (bytes.length < 20) {
+      throw new Error('request too short');
+    }
+
+    // From:
+    //   http://tools.ietf.org/html/rfc5389#section-6
+    // The first two bytes of the header are pretty weird, as the bits for
+    // class and method are interleaved. Here's a breakdown:
+    //   0                 1
+    //   0 1 2  3  4 5 6 7 8 9 0 1 2 3 4 5
+    //   +-+-+--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+    //   | | |M |M |M|M|M|C|M|M|M|C|M|M|M|M|
+    //   | | |11|10|9|8|7|1|6|5|4|0|3|2|1|0|
+    //   +-+-+--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+
+    // Fail if the first two bits of the most significant byte are not zero.
+    if (bytes[0] & 0xc0) {
+      throw new Error('first two bits must be zero'); 
+    }
+
+    // Fail if the magic cookie is not present.
+    if (bytes[4] != 0x21 || bytes[5] != 0x12 ||
+        bytes[6] != 0xa4 || bytes[7] != 0x42) {
+      throw new Error('magic cookie not found'); 
+    }
+
+    // The class is determined by bits C1 and C0.
+    var c1 = bytes[0] & 0x01;
+    var c0 = bytes[1] & 0x10;
+    var clazz: Turn.MessageClass;
+    if (c1) {
+      if (c0) {
+        clazz = MessageClass.FAILURE_RESPONSE;
+      } else {
+        clazz = MessageClass.SUCCESS_RESPONSE;
+      }
+    } else if (c0) {
+      clazz = MessageClass.INDICATION;
+    } else {
+      clazz = MessageClass.REQUEST;
+    }
+
+    // The method is determined by bits M0 through M12.
+    // Though TURN's highest-numbered method is only 9, let's do all 12 bits
+    // for the sake of completeness.
+    // M0-M3.
+    var method:number = bytes[1] & 0x0f;
+    // M4-M6.
+    method |= (bytes[1] >> 1) & 0x70;
+    // M7-M12.
+    method |= (bytes[0] << 6) & 0x0f80;
+
+    // Transaction ID.
+    var transactionId = bytes.subarray(8, 20);
+
+    // Attributes.
+    var attributes: Turn.StunAttribute[] = [];
+    var attributeOffset = 20;
+    while (attributeOffset < bytes.length) {
+      var attribute = parseStunAttribute(bytes.subarray(attributeOffset));
+      attributes.push(attribute);
+      attributeOffset += 4 + calculatePadding((attribute.value ?
+          attribute.value.length : 0), 4);
+    }
+
+    return {
+      clazz : clazz,
+      method : method,
+      transactionId: transactionId,
+      attributes: attributes
+    }
+  }
+
+  /**
+   * Constructs a byte array from a StunMessage object.
+   */
+  export function formatStunMessage(message:Turn.StunMessage) : Uint8Array {
+    // Figure out how many bytes we'll need.
+    var length = 0;
+    for (var i = 0; i < message.attributes.length; i++) {
+      var declaredLength = message.attributes[i].value ?
+          message.attributes[i].value.length : 0;
+      var paddedLength = calculatePadding(declaredLength, 4);
+      length += (4 + paddedLength);
+    }
+
+    var buff = new ArrayBuffer(length + 20);
+    var bytes = new Uint8Array(buff);
+
+    // The first two bytes of the header are pretty weird, as the bits for
+    // class and method are interleaved. Here's a breakdown:
+    //   0                 1
+    //   0 1 2  3  4 5 6 7 8 9 0 1 2 3 4 5
+    //   +-+-+--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+    //   | | |M |M |M|M|M|C|M|M|M|C|M|M|M|M|
+    //   | | |11|10|9|8|7|1|6|5|4|0|3|2|1|0|
+    //   +-+-+--+--+-+-+-+-+-+-+-+-+-+-+-+-+
+
+    // Method (M0-M12).
+    // M0-M3.
+    bytes[1] = message.method & 0xff;
+    // M4-M6.
+    bytes[1] |= (message.method << 1) & 0xe0;
+    // M7-M12.
+    bytes[0] = (message.method << 2) & 0x3e00;
+
+    // Class (C1 and C0).
+    var c1 = bytes[0] & 0x01;
+    var c0 = bytes[1] & 0x10;
+    var clazz :Turn.MessageClass;
+    // C1.
+    if (message.clazz == MessageClass.SUCCESS_RESPONSE ||
+        message.clazz == MessageClass.FAILURE_RESPONSE) {
+      bytes[0] |= 0x01;
+    }
+    // C0.
+    if (message.clazz == MessageClass.INDICATION ||
+        message.clazz == MessageClass.FAILURE_RESPONSE) {
+      bytes[1] |= 0x10;
+    }
+
+    // Length.
+    bytes[2] = length >> 8;
+    bytes[3] = length & 0xff;
+
+    // Magic cookie.
+    bytes.set(getMagicCookieBytes(), 4);
+
+    // Transaction ID.
+    bytes.set(message.transactionId, 8);
+
+    // Attributes.
+    var attributeOffset = 20;
+    for (var i = 0; i < message.attributes.length; i++) {
+      var attribute = message.attributes[i];
+      attributeOffset += formatStunAttribute(attribute,
+          bytes.subarray(attributeOffset));
+    }
+
+    return bytes;
+  }
+
+  /**
+   * As formatStunMessage() but appends a MESSAGE-INTEGRITY attribute.
+   * Normally, this is the function you should call; the exceptions are tests
+   * and send/data indications (which do not require a checksum).
+   */
+  export function formatStunMessageWithIntegrity(message:Turn.StunMessage) : Uint8Array {
+    // Append the attribute and obtain the bytes...
+    message.attributes.push({
+      type: Turn.MessageAttribute.MESSAGE_INTEGRITY,
+      value: new Uint8Array(20)
+    });
+    var bytes = formatStunMessage(message);
+
+    // ...and compute the checksum, and copy it into the bytes.
+    // MESSAGE-INTEGRITY hashes are always 20 bytes in length.
+    var hashBytes = computeHash(bytes);
+    bytes.set(hashBytes, bytes.length - 20);
+
+    return bytes;
+  }
+
+  /**
+   * Computes the hash for the MESSAGE-INTEGRITY attribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15.4
+   *
+   * From the RFC:
+   *   "The text used as input to HMAC is the STUN message, including
+   *   the header, up to and including the attribute preceding the
+   *   MESSAGE-INTEGRITY attribute."
+   *
+   * The supplied bytes should be a STUN message, including a MESSAGE-INTEGRITY
+   * attribute (which must be the final attribute), with length including that
+   * attribute.
+   *
+   * Callers of this method should copy the computed hash into the
+   * supplied byte array.
+   */
+  export function computeHash(bytes:Uint8Array) : Uint8Array {
+    var keyAsString = ArrayBuffers.arrayBufferToString(HMAC_KEY.buffer);
+    // MESSAGE-INTEGRITY attributes are always 24 bytes long:
+    // 4 bytes header + 20 bytes hash
+    var bytesToBeHashed = bytes.subarray(0, bytes.byteLength - 24);
+    // Think of the next few lines as uint8ArrayToString().
+    // This is necessary because, depending on how b is constructed,
+    // b.buffer is not guaranteed to equal a, where b is a Uint8Array
+    // view on an ArrayBuffer a (in particular, views created with
+    // subarray will share the same parent ArrayBuffer).
+    // TODO: add uint8ArrayToString to uproxy-build-tools 
+    var a :string[] = [];
+    for (var i = 0; i < bytesToBeHashed.length; ++i) {
+      a.push(String.fromCharCode(bytes[i]));
+    }
+    var bytesToBeHashedAsString = a.join('');
+
+    var hashAsString = sha1.str_hmac_sha1(keyAsString,
+        bytesToBeHashedAsString);
+    return new Uint8Array(ArrayBuffers.stringToArrayBuffer(hashAsString));
+  }
+
+  /**
+   * Converts the supplied attribute to bytes, placing the result in the
+   * supplied byte array. Throws an error if the byte array is too small
+   * to contain the attribute but otherwise ignores any trailing bytes.
+   */
+  export function formatStunAttribute(
+      attr:Turn.StunAttribute,
+      bytes:Uint8Array) : number {
+    var paddedLength = calculatePadding(attr.value ? attr.value.length : 0, 4);
+    if (bytes.length < 4 + paddedLength) {
+      throw new Error('too few bytes');
+    }
+
+    // Type.
+    bytes[0] = attr.type >> 8;
+    bytes[1] = attr.type & 0xff;
+
+    // Length.
+    var length = attr.value ? attr.value.length : 0;
+    bytes[2] = length >> 8;
+    bytes[3] = length & 0xff;
+
+    // Value.
+    if (attr.value) {
+      bytes.set(attr.value, 4);
+      // Padding.
+      for (var i = attr.value.length; i < paddedLength; i++) {
+        bytes[4 + i] = 0;
+      }
+    }
+
+    return 4 + paddedLength;
+  }
+
+  /**
+   * Parses a STUN attribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15
+   */
+  export function parseStunAttribute(bytes:Uint8Array) : Turn.StunAttribute {
+    // Fail if the number of bytes is too small.
+    if (bytes.length < 4) {
+      throw new Error('too few bytes');
+    }
+
+    var type = bytes[0] << 8 | bytes[1];
+    var length = bytes[2] << 8 | bytes[3];
+    var value :Uint8Array;
+    if (length > 0) {
+      value = bytes.subarray(4, 4 + length);
+    }
+
+    return {
+      type : type,
+      value : value
+    };
+  }
+
+  /**
+   * Returns bytes suitable for use in a ERROR_CODE-typed StunAttribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15.6
+   */
+  export function formatErrorCodeAttribute(
+      code:number,
+      reason:string) : Uint8Array {
+    // TODO: check reason length is <128 characters
+    var length = 4 + reason.length;
+    var buffer = new ArrayBuffer(length);
+    var bytes = new Uint8Array(buffer);
+    // Reserved bits.
+    bytes[0] = bytes[1] = bytes[2] = 0;
+    // Class (hundreds digit of code).
+    var clazz = code / 100;
+    if (clazz < 3 || clazz > 6) {
+      throw new Error('class must be between 3 and 6');
+    }
+    bytes[2] = clazz;
+    // Number (code modulo 100).
+    bytes[3] = code % 100;
+    // Reason.
+    var reasonBuffer = ArrayBuffers.stringToArrayBuffer(reason);
+    bytes.set(new Uint8Array(reasonBuffer), 4);
+    return bytes;
+  }
+
+  /**
+   * Returns bytes suitable for use in a MAPPED-ADDRESS attribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15.1
+   * Although we never send MAPPED-ADDRESS attributes, this function is
+   * useful for testing and formatting XOR-MAPPED-ADDRESS attributes.
+   * TODO: support IPv6 (assumes IPv4)
+   */
+  export function formatMappedAddressAttribute(
+      address:string,
+      port:number) : Uint8Array {
+    var buffer = new ArrayBuffer(8);
+    var bytes = new Uint8Array(buffer);
+    
+    bytes[0] = 0; // reserved
+    bytes[1] = 0x01; // IPv4
+
+    // Port.
+    bytes[2] = port >> 8;
+    bytes[3] = port & 0xff;
+
+    // Address.
+    var s = address.split('.');
+    if (s.length != 4) {
+      throw new Error('cannot parse address ' + address);
+    }
+    for (var i = 0; i < 4; i++) {
+      bytes[4 + i] = parseInt(s[i]);
+    }
+
+    return bytes;
+  }
+
+  /**
+   * Parses a MAPPED-ADDRESS attribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15.1
+   * Again, although we never parse MAPPED-ADDRESS attributes, this function is
+   * useful for testing and for parsing XOR-MAPPED-ADDRESS attributes.
+   * TODO: support IPv6 (assumes IPv4)
+   */
+  export function parseMappedAddressAttribute(bytes:Uint8Array) : Turn.Endpoint {
+    if (bytes.length < 8) {
+      throw new Error('attribute too short');
+    }
+
+    if (bytes[0]) {
+      throw new Error('first byte must be zero');
+    }
+
+    if (bytes[1] != 0x01) {
+      throw new Error('only ipv4 supported'); 
+    }
+
+    // Port.
+    var port = (bytes[2] << 8) | bytes[3];
+
+    // Address.
+    var quadrants = [bytes[4], bytes[5], bytes[6], bytes[7]];
+    var address = quadrants.join('.');
+
+    return {
+      address: address,
+      port: port
+    };
+  }
+
+  /**
+   * Parses an XOR-MAPPED-ADDRESS attribute:
+   *   http://tools.ietf.org/html/rfc5389#section-15.2
+   * TODO: support IPv6 (assumes IPv4)
+   */
+  export function parseXorMappedAddressAttribute(bytes:Uint8Array) : Turn.Endpoint {
+    if (bytes.length < 8) {
+      throw new Error('attribute too short');
+    }
+
+    // Port.
+    var magicCookieBytes = getMagicCookieBytes();
+    bytes[2] ^= magicCookieBytes[0]; // most significant byte
+    bytes[3] ^= magicCookieBytes[1]; // least significant byte
+
+    // Address.
+    for (var i = 0; i < 4; i++) {
+      bytes[4 + i] ^= magicCookieBytes[i];
+    }
+    return parseMappedAddressAttribute(bytes);
+  }
+
+  /**
+   * Returns bytes suitable for use in XOR-MAPPED-ADDRESS and
+   * XOR-RELAYED-ADDRESS attributes:
+   *   http://tools.ietf.org/html/rfc5389#section-15.2
+   * TODO: support IPv6 (assumes IPv4)
+   */
+  export function formatXorMappedAddressAttribute(
+      address:string,
+      port:number) : Uint8Array {
+    var bytes = formatMappedAddressAttribute(address, port);
+
+    // From the RFC:
+    //   "X-Port is computed by taking the mapped port in host byte order,
+    //   XOR'ing it with the most significant 16 bits of the magic cookie,
+    //   and then the converting the result to network byte order."
+    // It's not clear why you would XOR the host byte ordered-representation
+    // so we just XOR the network byte representation. Examining the network
+    // traffic with Wireshark indicates that this is correct.
+
+    var magicCookie = getMagicCookieBytes();
+    bytes[2] ^= magicCookie[0];
+    bytes[3] ^= magicCookie[1];
+
+    // Address.
+    for (var i = 0; i < 4; i++) {
+      bytes[4 + i] ^= magicCookie[i];
+    }
+
+    return bytes;
+  }
+
+  /**
+   * Returns the first attribute in the supplied array having the
+   * specified type. Raises an error if the attribute is not found.
+   */
+  export function findFirstAttributeWithType(
+    type:Turn.MessageAttribute,
+    attributes:Turn.StunAttribute[]) : Turn.StunAttribute {
+    for (var i = 0; i < attributes.length; i++) {
+      var attribute = attributes[i];
+      if (attribute.type === type) {
+        return attribute;
+      }
+    }
+    throw new Error('attribute not found');
+  }
+
+  /** Rounds x up to the nearest b, e.g. calculatePadding(5, 4) == 8. */
+  export function calculatePadding(x:number, b:number) : number {
+    var t = Math.floor(x / b);
+    if ((x % b) > 0) {
+      t++;
+    }
+    return t * b;
+  }
+}

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -72,6 +72,11 @@
     core-icon[icon="launch"]:hover{
       opacity: 1;
     }
+    core-tooltip::shadow #tooltip {
+      /* Without this, the first time you view the
+         tooltip, it appears off center. */
+      left: -67.5px !important;
+    }
     paper-button {
       background-color: #009688; /* teal */
       color: white;
@@ -144,7 +149,7 @@
             <paper-checkbox id='logCheckbox' on-change='{{ logsToggled }}'></paper-checkbox>
             Include logs and network diagnostics
           </core-label>
-          <core-tooltip id='logsTooltip' label='View logs and network diagnostics' position='top'>
+          <core-tooltip unresolved id='logsTooltip' label='View logs & network diagnostics' position='top'>
             <uproxy-link on-tap='{{ confirmViewLogs }}'>
               <core-icon icon="launch"></core-icon>
             </uproxy-link>
@@ -152,7 +157,7 @@
         </div>
 
         <p id='moreInfo'>
-          Your feedback and email address will be sent to uProxy.org. Your logs, diagnostic network data and email may include personally identifiable information.
+          Your feedback and email address will be sent to uProxy.org. Your logs, network diagnostics and email may include personally identifiable information.
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -135,9 +135,9 @@
       <div id='logCheckboxContainer'>
         <core-label id='logCheckboxLabel' horizontal layout>
           <paper-checkbox for id='logCheckbox'></paper-checkbox>
-          Include logs
+          Include logs and diagnostic network data
         </core-label>
-        <core-tooltip id='logsTooltip' label='View your logs' position='right'>
+        <core-tooltip id='logsTooltip' label='Preview' position='right'>
           <uproxy-link on-tap='{{ viewLogs }}'>
             <core-icon icon="launch"></core-icon>
           </uproxy-link>
@@ -145,7 +145,7 @@
       </div>
 
       <p id='moreInfo'>
-        Your feedback and email address will be sent to uProxy.org. Your logs and email may include personally identifiable information.
+        Your feedback and email address will be sent to uProxy.org. Your logs, diagnostic network data and email may include personally identifiable information.
         <uproxy-faq-link anchor='doesUproxyLogData'>
           <core-icon icon="help"></core-icon>
         </uproxy-faq-link>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -5,7 +5,6 @@
 <link rel='import' href='../lib/paper-input/paper-autogrow-textarea.html'>
 <link rel='import' href='../lib/core-label/core-label.html'>
 <link rel='import' href='../lib/core-tooltip/core-tooltip.html'>
-<link rel="import" href="../lib/core-signals/core-signals.html">
 <link rel='import' href='faq-link.html'>
 
 <polymer-element name='uproxy-feedback' attributes=''>
@@ -148,7 +147,7 @@
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link>
-          <core-tooltip unresolved id='logsTooltip' label='Analyze network and view logs' position='top'>
+          <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
             <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
           </core-tooltip>
         </div>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -5,6 +5,7 @@
 <link rel='import' href='../lib/paper-input/paper-autogrow-textarea.html'>
 <link rel='import' href='../lib/core-label/core-label.html'>
 <link rel='import' href='../lib/core-tooltip/core-tooltip.html'>
+<link rel="import" href="../lib/core-signals/core-signals.html">
 <link rel='import' href='faq-link.html'>
 
 <polymer-element name='uproxy-feedback' attributes=''>
@@ -14,10 +15,14 @@
       text-align: center;
       font-color: #009688;  /* dark green */
     }
+    #container {
+      height: 100%;
+    }
     #formContainer {
-      margin: 30px;
+      padding: 30px;
       text-align: left;
       color: #009688;
+      overflow: auto;
     }
     .inputLabel {
       font-weight: bold;
@@ -42,9 +47,6 @@
       margin-top: 1em;
     }
     #sendFeedback {
-      position: absolute;
-      bottom: 0;
-      left: 0;
       width: 100%;
       padding-top: 1.5em;
       padding-bottom: 1.5em;
@@ -53,6 +55,7 @@
       font-weight: bold;
       cursor: pointer;
       text-align: center;
+      background-color: #ffffff;
     }
     core-icon[icon="help"]{
       height: 15px;
@@ -110,50 +113,53 @@
     }
     </style>
 
-    <uproxy-app-bar on-go-back='{{ backToSettings }}'>
-      Submit feedback
-    </uproxy-app-bar>
+    <core-signals on-core-signal-more-about-logging='{{ moreAboutLogging }}'></core-signals>
+    <core-signals on-core-signal-view-logs='{{ viewLogs }}'></core-signals>
 
-    <div id='formContainer'>
-      <p class='inputLabel'>Email (optional)</p>
-      <paper-input-decorator id='emailDecorator' label="Email address">
-        <input id="emailInput"
-               is="core-input"
-               value='{{ email }}'>
-      </paper-input-decorator>
+    <div id='container' vertical layout>
+      <uproxy-app-bar on-go-back='{{ backToSettings }}'>
+        Submit feedback
+      </uproxy-app-bar>
 
-      <p class='inputLabel'>Enter your feedback below</p>
-
-        <paper-input-decorator id='feedbackDecorator' label="Write your feedback">
-          <paper-autogrow-textarea id="feedbackPaperTextarea">
-            <textarea id="feedbackInput"
-                   value='{{ feedback }}'>
-            </textarea>
-          </paper-autogrow-textarea>
+      <div id='formContainer' flex>
+        <p class='inputLabel'>Email (optional)</p>
+        <paper-input-decorator id='emailDecorator' label="Email address">
+          <input id="emailInput"
+                 is="core-input"
+                 value='{{ email }}'>
         </paper-input-decorator>
 
-      <div id='logCheckboxContainer'>
-        <core-label id='logCheckboxLabel' horizontal layout>
-          <paper-checkbox for id='logCheckbox'></paper-checkbox>
-          Include logs and diagnostic network data
-        </core-label>
-        <core-tooltip id='logsTooltip' label='Preview' position='right'>
-          <uproxy-link on-tap='{{ viewLogs }}'>
-            <core-icon icon="launch"></core-icon>
-          </uproxy-link>
-        </core-tooltip>
+        <p class='inputLabel'>Enter your feedback below</p>
+
+          <paper-input-decorator id='feedbackDecorator' label="Write your feedback">
+            <paper-autogrow-textarea id="feedbackPaperTextarea">
+              <textarea id="feedbackInput"
+                     value='{{ feedback }}'>
+              </textarea>
+            </paper-autogrow-textarea>
+          </paper-input-decorator>
+
+        <div id='logCheckboxContainer'>
+          <core-label id='logCheckboxLabel' horizontal layout>
+            <paper-checkbox id='logCheckbox' on-change='{{ logsToggled }}'></paper-checkbox>
+            Include logs and diagnostic network data
+          </core-label>
+          <core-tooltip id='logsTooltip' label='Preview' position='top'>
+            <uproxy-link on-tap='{{ confirmViewLogs }}'>
+              <core-icon icon="launch"></core-icon>
+            </uproxy-link>
+          </core-tooltip>
+        </div>
+
+        <p id='moreInfo'>
+          Your feedback and email address will be sent to uProxy.org. Your logs, diagnostic network data and email may include personally identifiable information.
+          <uproxy-faq-link anchor='doesUproxyLogData'>
+            <core-icon icon="help"></core-icon>
+          </uproxy-faq-link>
+        </p>
       </div>
-
-      <p id='moreInfo'>
-        Your feedback and email address will be sent to uProxy.org. Your logs, diagnostic network data and email may include personally identifiable information.
-        <uproxy-faq-link anchor='doesUproxyLogData'>
-          <core-icon icon="help"></core-icon>
-        </uproxy-faq-link>
-      </p>
-
       <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SEND FEEDBACK</div>
     </div>
-
   </template>
   <script src='feedback.js'></script>
 </polymer-element>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -57,10 +57,8 @@
       text-align: center;
       background-color: #ffffff;
     }
+    core-icon[icon="launch"],
     core-icon[icon="help"]{
-      height: 15px;
-    }
-    core-icon[icon="launch"]{
       height: 15px;
       color: grey;
       opacity: 0.6;
@@ -69,13 +67,14 @@
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
     }
-    core-icon[icon="launch"]:hover{
+    core-icon[icon="launch"]:hover,
+    core-icon[icon="help"]:hover{
       opacity: 1;
     }
     core-tooltip::shadow #tooltip {
       /* Without this, the first time you view the
          tooltip, it appears off center. */
-      left: -67.5px !important;
+      left: -64px !important;
     }
     paper-button {
       background-color: #009688; /* teal */
@@ -118,9 +117,6 @@
     }
     </style>
 
-    <core-signals on-core-signal-more-about-logging='{{ moreAboutLogging }}'></core-signals>
-    <core-signals on-core-signal-view-logs='{{ viewLogs }}'></core-signals>
-
     <div id='container' vertical layout>
       <uproxy-app-bar on-go-back='{{ backToSettings }}'>
         Submit feedback
@@ -147,17 +143,18 @@
         <div id='logCheckboxContainer'>
           <core-label id='logCheckboxLabel' horizontal layout>
             <paper-checkbox id='logCheckbox' on-change='{{ logsToggled }}'></paper-checkbox>
-            Include logs and network diagnostics
+            Analyze network and include logs
           </core-label>
-          <core-tooltip unresolved id='logsTooltip' label='View logs & network diagnostics' position='top'>
-            <uproxy-link on-tap='{{ confirmViewLogs }}'>
-              <core-icon icon="launch"></core-icon>
-            </uproxy-link>
+          <uproxy-faq-link anchor='doesUproxyLogData'>
+            <core-icon icon="help"></core-icon>
+          </uproxy-faq-link>
+          <core-tooltip unresolved id='logsTooltip' label='Analyze network and view logs' position='top'>
+            <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
           </core-tooltip>
         </div>
 
         <p id='moreInfo'>
-          Your feedback and email address will be sent to uProxy.org. Your logs, network diagnostics and email may include personally identifiable information.
+          Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -142,9 +142,9 @@
         <div id='logCheckboxContainer'>
           <core-label id='logCheckboxLabel' horizontal layout>
             <paper-checkbox id='logCheckbox' on-change='{{ logsToggled }}'></paper-checkbox>
-            Include logs and diagnostic network data
+            Include logs and network diagnostics
           </core-label>
-          <core-tooltip id='logsTooltip' label='Preview' position='top'>
+          <core-tooltip id='logsTooltip' label='View logs and network diagnostics' position='top'>
             <uproxy-link on-tap='{{ confirmViewLogs }}'>
               <core-icon icon="launch"></core-icon>
             </uproxy-link>

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -7,7 +7,8 @@ Polymer({
     ui.view = uProxy.View.SETTINGS;
   },
   sendFeedback: function() {
-    // TODO: Get and send real logs.
+    // TODO: update sendFeedback to a promise, and deal
+    // with the error case appropriately.
     core.sendFeedback({
       email: this.email,
       feedback: this.feedback,

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -35,39 +35,6 @@ Polymer({
     });
     ui.view = uProxy.View.ROSTER;
   },
-  logsToggled: function() {
-    if (this.$.logCheckbox.checked) {
-      this.fire('open-dialog', {
-        message: 'uProxy will run network diagnostics when you submit your feedback, if you\'ve elected to include logs and network data. If you\'d like to preview your logs and network data, network diagnostics will be run before submission.',
-        buttons: [{
-          text: 'Got it'
-        }, {
-          text: 'More info',
-          signal: 'more-about-logging',
-          dismissive: true
-        }]
-      });
-    }
-  },
-  moreAboutLogging: function() {
-    this.ui.openTab('faq.html#doesUproxyLogData');
-  },
-  confirmViewLogs: function() {
-    this.fire('open-dialog', {
-      message: 'uProxy will run network diagnostics when you submit your feedback, if you\'ve elected to include logs and network data. If you\'d like to preview your logs and network data, network diagnostics will be run now. Would you like to preview logs and network data that will be sent to uProxy?',
-      buttons: [{
-        text: 'Yes',
-        signal: 'view-logs'
-      }, {
-        text: 'No',
-        dismissive: true
-      }, {
-        text: 'More info',
-        signal: 'more-about-logging',
-        dismissive: true
-      }]
-    });
-  },
   viewLogs: function() {
     this.ui.openTab('view-logs.html');
   },

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -71,5 +71,8 @@ Polymer({
   viewLogs: function() {
     this.ui.openTab('view-logs.html');
   },
-  ready: function() {}
+  ready: function() {
+    this.$.logsTooltip.setAttribute('resolved', '');
+    this.$.logsTooltip.removeAttribute('unresolved');
+  }
 });

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -34,13 +34,41 @@ Polymer({
     });
     ui.view = uProxy.View.ROSTER;
   },
+  logsToggled: function() {
+    if (this.$.logCheckbox.checked) {
+      this.fire('open-dialog', {
+        message: 'uProxy will run network diagnostics when you submit your feedback, if you\'ve elected to include logs and network data. If you\'d like to preview your logs and network data, network diagnostics will be run before submission.',
+        buttons: [{
+          text: 'Got it'
+        }, {
+          text: 'More info',
+          signal: 'more-about-logging',
+          dismissive: true
+        }]
+      });
+    }
+  },
+  moreAboutLogging: function() {
+    this.ui.openTab('faq.html#doesUproxyLogData');
+  },
+  confirmViewLogs: function() {
+    this.fire('open-dialog', {
+      message: 'uProxy will run network diagnostics when you submit your feedback, if you\'ve elected to include logs and network data. If you\'d like to preview your logs and network data, network diagnostics will be run now. Would you like to preview logs and network data that will be sent to uProxy?',
+      buttons: [{
+        text: 'Yes',
+        signal: 'view-logs'
+      }, {
+        text: 'No',
+        dismissive: true
+      }, {
+        text: 'More info',
+        signal: 'more-about-logging',
+        dismissive: true
+      }]
+    });
+  },
   viewLogs: function() {
     this.ui.openTab('view-logs.html');
-    // core.getLogs().then((logs) => {
-    //   logs = 'Browser Info: ' + navigator.userAgent + '\n' + logs;
-    //   var url = 'data:text/html;charset=UTF-8,'
-    //       + encodeURIComponent('<html><h2>Diagnostic Logs</h2><pre>' + logs + '</pre></html>');
-    // });
   },
   ready: function() {}
 });

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -3,7 +3,6 @@ Polymer({
   ui: ui,
   email: '',
   feedback: '',
-  logs: '',
   backToSettings: function() {
     ui.view = uProxy.View.SETTINGS;
   },
@@ -12,7 +11,8 @@ Polymer({
     core.sendFeedback({
       email: this.email,
       feedback: this.feedback,
-      logs: this.$.logCheckbox.checked
+      logs: this.$.logCheckbox.checked,
+      browserInfo: navigator.userAgent
     });
     // Reset the placeholders, which seem to be cleared after the
     // user types input in the input fields.
@@ -35,11 +35,12 @@ Polymer({
     ui.view = uProxy.View.ROSTER;
   },
   viewLogs: function() {
-    core.getLogs().then((logs) => {
-      var url = 'data:text/html;charset=UTF-8,'
-          + encodeURIComponent('<html><h2>Diagnostic Logs</h2><pre>' + logs + '</pre></html>');
-      this.ui.openTab(url);
-    });
+    this.ui.openTab('view-logs.html');
+    // core.getLogs().then((logs) => {
+    //   logs = 'Browser Info: ' + navigator.userAgent + '\n' + logs;
+    //   var url = 'data:text/html;charset=UTF-8,'
+    //       + encodeURIComponent('<html><h2>Diagnostic Logs</h2><pre>' + logs + '</pre></html>');
+    // });
   },
   ready: function() {}
 });

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -37,9 +37,5 @@ Polymer({
   },
   viewLogs: function() {
     this.ui.openTab('view-logs.html');
-  },
-  ready: function() {
-    this.$.logsTooltip.setAttribute('resolved', '');
-    this.$.logsTooltip.removeAttribute('unresolved');
   }
 });

--- a/src/generic_ui/polymer/logs.html
+++ b/src/generic_ui/polymer/logs.html
@@ -52,13 +52,6 @@
 
     <div id='container'>
       <h1>Logs & Network Analysis</h1>
-
-      <!--
-      <paper-button raised id='diagnose' on-tap='{{ getNetworkInfo }}'>
-        Diagnose Network
-      </paper-button>
-      -->
-
       <div id='logs'>
         <div id='loadingLogs' hidden?='{{ !loadingLogs }}'>
           <p>Retrieving logs and analyzing your network...</p>

--- a/src/generic_ui/polymer/logs.html
+++ b/src/generic_ui/polymer/logs.html
@@ -1,0 +1,72 @@
+<link rel="import" href="../lib/polymer/polymer.html">
+<link rel='import' href='../lib/paper-progress/paper-progress.html'>
+
+<polymer-element name='uproxy-logs'>
+  <template>
+    <style>
+      :host {
+        background-color: #FFFFFF;
+        font-family: Roboto, sans-serif;
+        font-size: 13px;
+      }
+      #container {
+        margin: 50px;
+      }
+      paper-button {
+        width: 100px;
+        background: #009688;  /* dark green */
+        color: white;
+      }
+      paper-button:disabled {
+        background: #f1f1f1;
+        color: rgb(112, 112, 112);
+      }
+      paper-progress::shadow #progressContainer {
+        background-color: #ffffff;
+        opacity: 0.5;
+      }
+      paper-progress::shadow #activeProgress {
+        background-color: #009688;
+      }
+      paper-progress {
+        margin-bottom: 1em;
+        width: 275px;
+      }
+      #loadingLogs {
+        font-family: Roboto, sans-serif;
+        text-align: center;
+      }
+      #logs {
+        font-family: monospace;
+        font-size: 14px;
+        word-wrap: break-word;
+        text-align: left;
+        padding: 10px;
+        background: lightgray;
+      }
+      h1 {
+        text-align: center;
+        margin-bottom: 1em;
+      }
+    </style>
+
+    <div id='container'>
+      <h1>Logs & Network Diagnostics</h1>
+
+      <!--
+      <paper-button raised id='diagnose' on-tap='{{ getNetworkInfo }}'>
+        Diagnose Network
+      </paper-button>
+      -->
+
+      <div id='logs'>
+        <div id='loadingLogs' hidden?='{{ !loadingLogs }}'>
+          <p>Retrieving logs and diagnosing your network...</p>
+          <paper-progress indeterminate='true'></paper-progress>
+        </div>
+        <pre>{{ logs }}</pre>
+      </div> <!-- end of errorText -->
+    </div>
+  </template>
+  <script src='logs.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/logs.html
+++ b/src/generic_ui/polymer/logs.html
@@ -51,7 +51,7 @@
     </style>
 
     <div id='container'>
-      <h1>Logs & Network Diagnostics</h1>
+      <h1>Logs & Network Analysis</h1>
 
       <!--
       <paper-button raised id='diagnose' on-tap='{{ getNetworkInfo }}'>
@@ -61,7 +61,7 @@
 
       <div id='logs'>
         <div id='loadingLogs' hidden?='{{ !loadingLogs }}'>
-          <p>Retrieving logs and diagnosing your network...</p>
+          <p>Retrieving logs and analyzing your network...</p>
           <paper-progress indeterminate='true'></paper-progress>
         </div>
         <pre>{{ logs }}</pre>

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -11,9 +11,8 @@ Polymer({
     this.ui = ui;
     core.getLogs().then((logs) => {
       this.loadingLogs = false;
-      this.logs = logs;
       // Add browser info to logs.
-      this.logs = 'Browser Info: ' + navigator.userAgent + '\n\n' + this.logs;
+      this.logs = 'Browser Info: ' + navigator.userAgent + '\n\n' + logs;
     });
   }
 });

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -12,6 +12,8 @@ Polymer({
     core.getLogs().then((logs) => {
       this.loadingLogs = false;
       this.logs = logs;
+      // Add browser info to logs.
+      this.logs = 'Browser Info: ' + navigator.userAgent + '\n\n' + this.logs;
     });
   }
 });

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -1,0 +1,17 @@
+/// <reference path='../scripts/ui.ts' />
+declare var ui :UI.UserInterface;
+
+Polymer({
+  logs: '',
+  loadingLogs: true,
+  getNetworkInfo: function() {
+  },
+  ready: function() {
+    // Expose global ui object in this context.
+    this.ui = ui;
+    core.getLogs().then((logs) => {
+      this.loadingLogs = false;
+      this.logs = logs;
+    });
+  }
+});

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -140,7 +140,7 @@
         margin-bottom: 3px;
       }
       #dialog {
-        top: 150px;
+        top: 20%;
         left: 0px;
       }
     </style>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -10,6 +10,7 @@
 <link rel="import" href='roster.html'>
 <link rel="import" href='settings.html'>
 <link rel="import" href='confirm.html'>
+<link rel="import" href='logs.html'>
 <link rel='import' href='copypaste.html'>
 <link rel='import' href='bubble.html'>
 <link rel='import' href='feedback.html'>

--- a/src/generic_ui/view-logs.html
+++ b/src/generic_ui/view-logs.html
@@ -3,8 +3,10 @@
 <head>
   <title>uProxy Logs</title>
 
-  <script src='scripts/dependencies.js'></script>
   <script src='scripts/uproxy.js'></script>
+  <script src='scripts/user.js'></script>
+  <script src='scripts/ui.js'></script>
+  <script src='scripts/dependencies.js'></script>
 
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
   <link rel='import' href='polymer/vulcanized.html'>

--- a/src/generic_ui/view-logs.html
+++ b/src/generic_ui/view-logs.html
@@ -1,0 +1,17 @@
+<html>
+
+<head>
+  <title>uProxy Logs</title>
+
+  <script src='scripts/dependencies.js'></script>
+  <script src='scripts/uproxy.js'></script>
+
+  <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
+  <link rel='import' href='polymer/vulcanized.html'>
+</head>
+
+<body>
+  <uproxy-logs></uproxy-logs>
+</body>
+
+</html>

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -154,6 +154,7 @@ module uProxy {
     email     :string;
     feedback  :string;
     logs      :string;
+    browserInfo :string;
   }
 
   // --- Core <--> UI Interfaces ---


### PR DESCRIPTION
Checking the checkbox opens this dialog:
Clicking More Info takes you to the "does uproxy log data about me" question in the FAQ.
![image](https://cloud.githubusercontent.com/assets/8723127/6875848/bc90201c-d498-11e4-9f42-d83787ce97ae.png)


I updated the hover text:
![image](https://cloud.githubusercontent.com/assets/8723127/6875326/f0244caa-d493-11e4-9337-a1db4fff4b88.png)

Clicking "Preview" opens this:
Clicking "No" just sends you back to the feedback page, more info goes to FAQ and yes will open the new view logs page (below):
![image](https://cloud.githubusercontent.com/assets/8723127/6875840/af1ad1fc-d498-11e4-83ad-9233b0751ccd.png)


View logs page, while loading:
![image](https://cloud.githubusercontent.com/assets/8723127/6875136/33832e40-d493-11e4-9bf4-a2525031ed96.png)

View logs page, loaded, with NAT data at the top:
![image](https://cloud.githubusercontent.com/assets/8723127/6878466/06c3de5a-d4b5-11e4-966b-eeedcedc2e98.png)







<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1173)
<!-- Reviewable:end -->
