### PR TITLE
Fallback if Feedback submission fails. Help user classify NAT if proxying fails.

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -612,7 +612,6 @@ core.onCommand(uProxy.Command.HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE,
 core.onCommand(uProxy.Command.UPDATE_GLOBAL_SETTINGS, core.updateGlobalSettings);
 core.onPromiseCommand(uProxy.Command.SEND_FEEDBACK, core.sendFeedback);
 core.onPromiseCommand(uProxy.Command.GET_LOGS, core.getLogsAndNetworkInfo);
-//core.onPromiseCommand(uProxy.Command.GET_NAT, core.getNatType);
 
 // Now that this module has got itself setup, it sends a 'ready' message to the
 // freedom background page.

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -436,7 +436,7 @@ class uProxyCore implements uProxy.CoreAPI {
   }
 
   public sendFeedback = (feedback :uProxy.UserFeedback) : Promise<void> => {
-    return new Promise<void>((F, R) => {
+    return new Promise<void>((fulfill, reject) => {
       var sendXhr = (logs) : void => {
         var xhr = freedom["core.xhr"]();
         xhr.on('onreadystatechange', () => {
@@ -444,12 +444,12 @@ class uProxyCore implements uProxy.CoreAPI {
             .then((stateAndStatus) => {
               // 200 is the HTTP result code for a successful request.
               if (stateAndStatus[0] === XMLHttpRequest.DONE && stateAndStatus[1] === 200) {
-                F();
+                fulfill();
               } else if (stateAndStatus[0] === XMLHttpRequest.DONE && stateAndStatus[1] != 200) {
                 // TODO: Once we have non-AppEngine links we can send feedback to, try
                 // multiple URLs before rejecting the sendFeedback promise.
                 // https://github.com/uProxy/uproxy/issues/1191
-                R('POST to uproxy.org failed.');
+                reject('POST to uproxy.org failed.');
               }
             });
         });

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -450,6 +450,8 @@ class uProxyCore implements uProxy.CoreAPI {
             if (stateAndStatus[0] === 4 && stateAndStatus[1] === 200) {
               this.fulfillFeedbackSent_();
             } else if (stateAndStatus[0] === 4 && stateAndStatus[1] != 200) {
+              // TODO: Once we have non-AppEngine links we can send feedback to, try
+              // multiple URLs before rejecting the sendFeedback promise.
               this.rejectFeedbackSent_('POST to uproxy.org failed.');
             }
           });
@@ -612,6 +614,7 @@ core.onCommand(uProxy.Command.HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE,
 core.onCommand(uProxy.Command.UPDATE_GLOBAL_SETTINGS, core.updateGlobalSettings);
 core.onPromiseCommand(uProxy.Command.SEND_FEEDBACK, core.sendFeedback);
 core.onPromiseCommand(uProxy.Command.GET_LOGS, core.getLogsAndNetworkInfo);
+core.onPromiseCommand(uProxy.Command.GET_NAT, core.getNatType);
 
 // Now that this module has got itself setup, it sends a 'ready' message to the
 // freedom background page.

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -469,9 +469,13 @@ class uProxyCore implements uProxy.CoreAPI {
 
     var browserInfo = 'Browser Info: ' + feedback.browserInfo + '\n\n';
 
-    if (feedback.logs) {
+    if (feedback.logs && feedback.networkInfo) {
       this.getLogsAndNetworkInfo().then((logsWithNetworkInfo) => {
         sendXhr(browserInfo + logsWithNetworkInfo);
+      });
+    } else if (feedback.networkInfo) {
+      this.getNetworkInfo().then((networkInfo) => {
+        sendXhr(networkInfo);
       });
     } else {
       sendXhr('');
@@ -482,27 +486,6 @@ class uProxyCore implements uProxy.CoreAPI {
       this.rejectFeedbackSent_ = R;
     });
     return this.feedbackSent_;
-
-    /*
-    TODO: Allow users to submit just network info or just logs.
-    The new logic should be like below.
-
-    if (feedback.logs && feedback.networkInfo) {
-      this.getLogsAndNetworkInfo().then((logsWithNetworkInfo) => {
-        sendXhr(browserInfo + logsWithNetworkInfo);
-      });
-    } else if (feedback.logs) {
-      this.getLogs().then((logs) => {
-        sendXhr(browserInfo + logs);
-      });
-    } else if (feedback.networkInfo) {
-      this.getNetworkInfo().then((networkInfo) => {
-        sendXhr(networkInfo);
-      });
-    } else {
-      sendXhr('');
-    }
-    */
   }
 
   public getNatType = () : Promise<string> => {
@@ -614,7 +597,7 @@ core.onCommand(uProxy.Command.HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE,
 core.onCommand(uProxy.Command.UPDATE_GLOBAL_SETTINGS, core.updateGlobalSettings);
 core.onPromiseCommand(uProxy.Command.SEND_FEEDBACK, core.sendFeedback);
 core.onPromiseCommand(uProxy.Command.GET_LOGS, core.getLogsAndNetworkInfo);
-core.onPromiseCommand(uProxy.Command.GET_NAT, core.getNatType);
+core.onPromiseCommand(uProxy.Command.GET_NAT_TYPE, core.getNatType);
 
 // Now that this module has got itself setup, it sends a 'ready' message to the
 // freedom background page.

--- a/src/generic_core/diagnose.ts
+++ b/src/generic_core/diagnose.ts
@@ -20,7 +20,7 @@ module Diagnose {
     } else if (m == 'stun_access') {
       doStunAccessTest();
     } else if (m == 'nat_provoking') {
-      doNatProvoking().then((natType: String) => {
+      doNatProvoking().then((natType: string) => {
         log.debug('!!! natType =' + natType);
         freedom().emit('print', 'NAT type is ' + natType);
       });
@@ -155,7 +155,7 @@ module Diagnose {
   // The following code needs the help from a server to do its job. The server
   // code can be found jsonserv.py in the same repository. One instance is
   // running in EC2.
-  export function doNatProvoking() : Promise<String> {
+  export function doNatProvoking() : Promise<string> {
     return new Promise((F, R) => {
       log.info('perform NAT provoking');
       var socket: freedom_UdpSocket.Socket = freedom['core.udpsocket']();

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -4,6 +4,7 @@
 <link rel='import' href='../lib/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../lib/paper-input/paper-autogrow-textarea.html'>
 <link rel='import' href='../lib/core-label/core-label.html'>
+<link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
 <link rel='import' href='../lib/core-tooltip/core-tooltip.html'>
 <link rel='import' href='../lib/core-overlay/core-overlay.html'>
 <link rel='import' href='../lib/core-signals/core-signals.html'>
@@ -114,6 +115,20 @@
     paper-checkbox::shadow #checkbox {
       border-color: grey;
     }
+    paper-action-dialog {
+      top: 30%;
+      z-index: 1002; /* Must be greater than core-overlay-backdrop */
+    }
+    .core-overlay-backdrop {
+      z-index: 1001;
+    }
+    #sendingFeedback {
+      text-align: center;
+      font-size: 16px;
+    }
+    paper-progress::shadow #activeProgress {
+      background-color: #009688;
+    }
     #feedbackDecorator {
       height: 190px;
     }
@@ -131,17 +146,15 @@
         <uproxy-app-bar on-go-back='{{ close }}'>
           Submit feedback
         </uproxy-app-bar>
-
         <div id='formContainer' flex>
-          <p class='inputLabel'>Email (optional)</p>
-          <paper-input-decorator id='emailDecorator' label="Email address">
-            <input id="emailInput"
-                   is="core-input"
-                   value='{{ email }}'>
-          </paper-input-decorator>
-
-          <p class='inputLabel'>Enter your feedback below</p>
-
+          <div>
+            <p class='inputLabel'>Email (optional)</p>
+            <paper-input-decorator id='emailDecorator' label="Email address">
+              <input id="emailInput"
+                     is="core-input"
+                     value='{{ email }}'>
+            </paper-input-decorator>
+            <p class='inputLabel'>Enter your feedback below</p>
             <paper-input-decorator id='feedbackDecorator' label="Write your feedback">
               <paper-autogrow-textarea id="feedbackPaperTextarea">
                 <textarea id="feedbackInput"
@@ -149,30 +162,35 @@
                 </textarea>
               </paper-autogrow-textarea>
             </paper-input-decorator>
-
-          <div id='logCheckboxContainer'>
-            <core-label id='logCheckboxLabel' horizontal layout>
-              <paper-checkbox id='logCheckbox'></paper-checkbox>
-              Analyze network and include logs
-            </core-label>
-            <uproxy-faq-link anchor='doesUproxyLogData'>
-              <core-icon icon="help"></core-icon>
-            </uproxy-faq-link>
-            <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
-              <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
-            </core-tooltip>
-          </div>
-
-          <p id='moreInfo'>
-            Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.
-            <uproxy-faq-link anchor='doesUproxyLogData'>
-              <core-icon icon="help"></core-icon>
-            </uproxy-faq-link>
-          </p>
-        </div>
+            <div id='logCheckboxContainer'>
+              <core-label id='logCheckboxLabel' horizontal layout>
+                <paper-checkbox id='logCheckbox'></paper-checkbox>
+                Analyze network and include logs
+              </core-label>
+              <uproxy-faq-link anchor='doesUproxyLogData'>
+                <core-icon icon="help"></core-icon>
+              </uproxy-faq-link>
+              <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
+                <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
+              </core-tooltip>
+            </div>
+            <p id='moreInfo'>
+              Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.
+              <uproxy-faq-link anchor='doesUproxyLogData'>
+                <core-icon icon="help"></core-icon>
+              </uproxy-faq-link>
+            </p>
+          </div> <!-- end of feedback form -->
+        </div> <!-- end of form container -->
         <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SEND FEEDBACK</div>
       </div>
     </core-overlay>
+    <paper-action-dialog backdrop layered="false" id='sendingFeedbackDialog' autoCloseDisabled='true'>
+      <div id='sendingFeedback'>
+        Sending feedback<br>
+        <paper-progress indeterminate='true'></paper-progress>
+      </div>
+    </paper-action-dialog>
   </template>
   <script src='feedback.js'></script>
 </polymer-element>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -143,40 +143,35 @@
           Submit feedback
         </uproxy-app-bar>
         <div id='formContainer' flex>
-          <div>
-            <p class='inputLabel'>Email (optional)</p>
-            <paper-input-decorator id='emailDecorator' label="Email address">
-              <input id="emailInput"
-                     is="core-input"
-                     value='{{ email }}'>
-            </paper-input-decorator>
-            <p class='inputLabel'>Enter your feedback below</p>
-            <paper-input-decorator id='feedbackDecorator' label="Write your feedback">
-              <paper-autogrow-textarea id="feedbackPaperTextarea">
-                <textarea id="feedbackInput"
-                       value='{{ feedback }}'>
-                </textarea>
-              </paper-autogrow-textarea>
-            </paper-input-decorator>
-            <div id='logCheckboxContainer'>
-              <paper-checkbox for id='logCheckbox'></paper-checkbox>
-              <span id='logCheckboxLabel' on-tap='{{ viewLogs }}'>
-                Analyze network and include logs
-              </span>
-              <uproxy-faq-link anchor='doesUproxyLogData'>
-                <core-icon icon="help"></core-icon>
-              </uproxy-faq-link>
-<!--               <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
-                <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
-              </core-tooltip> -->
-            </div>
-            <p id='moreInfo'>
-              Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.
-              <uproxy-faq-link anchor='doesUproxyLogData'>
-                <core-icon icon="help"></core-icon>
-              </uproxy-faq-link>
-            </p>
-          </div> <!-- end of feedback form -->
+          <p class='inputLabel'>Email (optional)</p>
+          <paper-input-decorator id='emailDecorator' label="Email address">
+            <input id="emailInput"
+                   is="core-input"
+                   value='{{ email }}'>
+          </paper-input-decorator>
+          <p class='inputLabel'>Enter your feedback below</p>
+          <paper-input-decorator id='feedbackDecorator' label="Write your feedback">
+            <paper-autogrow-textarea id="feedbackPaperTextarea">
+              <textarea id="feedbackInput"
+                     value='{{ feedback }}'>
+              </textarea>
+            </paper-autogrow-textarea>
+          </paper-input-decorator>
+          <div id='logCheckboxContainer'>
+            <paper-checkbox for id='logCheckbox'></paper-checkbox>
+            <span id='logCheckboxLabel' on-tap='{{ viewLogs }}'>
+              Analyze network and include logs
+            </span>
+            <uproxy-faq-link anchor='doesUproxyLogData'>
+              <core-icon icon="help"></core-icon>
+            </uproxy-faq-link>
+          </div>
+          <p id='moreInfo'>
+            Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.
+            <uproxy-faq-link anchor='doesUproxyLogData'>
+              <core-icon icon="help"></core-icon>
+            </uproxy-faq-link>
+          </p>
         </div> <!-- end of form container -->
         <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SUBMIT FEEDBACK</div>
       </div>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -119,9 +119,6 @@
       top: 30%;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
     }
-    .core-overlay-backdrop {
-      z-index: 1001;
-    }
     #sendingFeedback {
       text-align: center;
       font-size: 16px;

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -178,7 +178,7 @@
             </p>
           </div> <!-- end of feedback form -->
         </div> <!-- end of form container -->
-        <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SEND FEEDBACK</div>
+        <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SUBMIT FEEDBACK</div>
       </div>
     </core-overlay>
     <paper-action-dialog backdrop layered="false" id='sendingFeedbackDialog' autoCloseDisabled='true'>

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -42,10 +42,9 @@
       margin: 0.5em 0em;
     }
     #logCheckboxLabel {
-      display: inline-table;
+      cursor: pointer;
     }
     #logCheckbox {
-      display: table-cell;
       padding-right:10px;
       vertical-align: middle;
     }
@@ -160,16 +159,16 @@
               </paper-autogrow-textarea>
             </paper-input-decorator>
             <div id='logCheckboxContainer'>
-              <core-label id='logCheckboxLabel' horizontal layout>
-                <paper-checkbox id='logCheckbox'></paper-checkbox>
+              <paper-checkbox for id='logCheckbox'></paper-checkbox>
+              <span id='logCheckboxLabel' on-tap='{{ viewLogs }}'>
                 Analyze network and include logs
-              </core-label>
+              </span>
               <uproxy-faq-link anchor='doesUproxyLogData'>
                 <core-icon icon="help"></core-icon>
               </uproxy-faq-link>
-              <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
+<!--               <core-tooltip id='logsTooltip' label='Analyze network and view logs' position='top'>
                 <core-icon icon='launch' on-tap='{{ viewLogs }}'></core-icon>
-              </core-tooltip>
+              </core-tooltip> -->
             </div>
             <p id='moreInfo'>
               Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information.

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -17,8 +17,7 @@ Polymer({
       email: this.email,
       feedback: this.feedback,
       logs: this.$.logCheckbox.checked,
-      browserInfo: navigator.userAgent,
-      networkInfo: this.$.logCheckbox.checked
+      browserInfo: navigator.userAgent
     }).then(() => {
       // Reset the placeholders, which seem to be cleared after the
       // user types input in the input fields.

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -15,7 +15,7 @@ Polymer({
       feedback: this.feedback,
       logs: this.$.logCheckbox.checked,
       browserInfo: navigator.userAgent,
-      networkInfo: true
+      networkInfo: this.$.logCheckbox.checked
     }).then(() => {
       // Reset the placeholders, which seem to be cleared after the
       // user types input in the input fields.

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -14,7 +14,8 @@ Polymer({
       email: this.email,
       feedback: this.feedback,
       logs: this.$.logCheckbox.checked,
-      browserInfo: navigator.userAgent
+      browserInfo: navigator.userAgent,
+      networkInfo: true
     }).then(() => {
       // Reset the placeholders, which seem to be cleared after the
       // user types input in the input fields.

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -5,7 +5,10 @@ Polymer({
   close: function() {
     this.$.feedbackPanel.close();
   },
-  open: function() {
+  open: function(e, detail, signal) {
+    if (detail && detail.includeLogs) {
+      this.$.logCheckbox.checked = true;
+    }
     this.$.feedbackPanel.open();
   },
   sendFeedback: function() {

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -9,34 +9,44 @@ Polymer({
     this.$.feedbackPanel.open();
   },
   sendFeedback: function() {
-    // TODO: update sendFeedback to a promise, and deal
-    // with the error case appropriately.
+    this.$.sendingFeedbackDialog.open();
     core.sendFeedback({
       email: this.email,
       feedback: this.feedback,
       logs: this.$.logCheckbox.checked,
       browserInfo: navigator.userAgent
-    });
-    // Reset the placeholders, which seem to be cleared after the
-    // user types input in the input fields.
-    this.$.emailInput.placeholder = 'Email address';
-    this.$.feedbackInput.placeholder = 'Write your feedback';
-    // Clear the form.
-    this.email = '';
-    this.feedback = '';
-    this.$.logCheckbox.checked = false;
+    }).then(() => {
+      // Reset the placeholders, which seem to be cleared after the
+      // user types input in the input fields.
+      this.$.emailInput.placeholder = 'Email address';
+      this.$.feedbackInput.placeholder = 'Write your feedback';
+      // Clear the form.
+      this.email = '';
+      this.feedback = '';
+      this.$.logCheckbox.checked = false;
 
-    // root.ts listens for open-dialog signals and shows a popup
-    // when it receives these events.
-    this.fire('open-dialog', {
-      heading: 'Thank you!',
-      message: 'Your feedback has been submitted to the uProxy development team.',
-      buttons: [{
-        text: 'Done',
-        signal: 'close-settings'
-      }]
+      // root.ts listens for open-dialog signals and shows a popup
+      // when it receives these events.
+      this.fire('open-dialog', {
+        heading: 'Thank you!',
+        message: 'Your feedback has been submitted to the uProxy development team.',
+        buttons: [{
+          text: 'Done',
+          signal: 'close-settings'
+        }]
+      });
+      this.close();
+      this.$.sendingFeedbackDialog.close();
+    }).catch((e) => {
+      this.fire('open-dialog', {
+        heading: 'Email feedback instead?',
+        message: 'Oops! We were unable to submit your feedback to uproxy.org. Please copy and paste your feedback in an email to info@uproxy.org.',
+        buttons: [{
+          text: 'OK'
+        }]
+      });
+      this.$.sendingFeedbackDialog.close();
     });
-    this.close();
   },
   viewLogs: function() {
     this.ui.openTab('view-logs.html');

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -23,8 +23,16 @@ Polymer({
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
     }).catch((e) => {
-      ui.showNotification('Unable to get access from ' + this.user.name,
-                          { mode: 'get', user: this.user.userId });
+      this.fire('open-dialog', {
+        heading: 'Oh no!',
+        message: 'Unable to get access from ' + this.user.name + '. Would you like uProxy to diagnose your network?',
+        buttons: [{
+          text: 'Yes',
+          signal: 'analyze-network'
+        }]
+      });
+      // ui.showNotification('Unable to get access from ' + this.user.name,
+      //                    { mode: 'get', user: this.user.userId });
       console.error('Unable to start proxying ', e);
     });
   },

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -24,8 +24,7 @@ Polymer({
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
     }).catch((e) => {
       this.fire('core-signal', {name: 'open-troubleshoot'});
-      ui.showNotification('Unable to get access from ' + this.user.name,
-                         { mode: 'get', user: this.user.userId });
+      ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
     });
   },

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -23,16 +23,9 @@ Polymer({
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
     }).catch((e) => {
-      this.fire('open-dialog', {
-        heading: 'Oh no!',
-        message: 'Unable to get access from ' + this.user.name + '. Would you like uProxy to diagnose your network?',
-        buttons: [{
-          text: 'Yes',
-          signal: 'analyze-network'
-        }]
-      });
-      // ui.showNotification('Unable to get access from ' + this.user.name,
-      //                    { mode: 'get', user: this.user.userId });
+      this.fire('core-signal', {name: 'open-troubleshoot'});
+      ui.showNotification('Unable to get access from ' + this.user.name,
+                         { mode: 'get', user: this.user.userId });
       console.error('Unable to start proxying ', e);
     });
   },

--- a/src/generic_ui/polymer/logs.html
+++ b/src/generic_ui/polymer/logs.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../lib/polymer/polymer.html">
+<link rel="import" href="../lib/core-signals/core-signals.html">
 <link rel='import' href='../lib/paper-progress/paper-progress.html'>
 
 <polymer-element name='uproxy-logs'>
@@ -10,16 +11,13 @@
         font-size: 13px;
       }
       #container {
+        text-align: center;
         margin: 50px;
       }
-      paper-button {
-        width: 100px;
-        background: #009688;  /* dark green */
-        color: white;
-      }
-      paper-button:disabled {
-        background: #f1f1f1;
-        color: rgb(112, 112, 112);
+      #openUproxy {
+        color: #009688;
+        cursor: pointer;
+        text-decoration: underline;
       }
       paper-progress::shadow #progressContainer {
         background-color: #ffffff;
@@ -45,13 +43,13 @@
         background: lightgray;
       }
       h1 {
-        text-align: center;
         margin-bottom: 1em;
       }
     </style>
 
     <div id='container'>
       <h1>Logs & Network Analysis</h1>
+      <p>To send your logs to the uProxy team for help, <span id='openUproxy' on-tap='{{ openUproxy }}'>open uProxy</span> and click 'Submit Feedback'</p>
       <div id='logs'>
         <div id='loadingLogs' hidden?='{{ !loadingLogs }}'>
           <p>Retrieving logs and analyzing your network...</p>

--- a/src/generic_ui/polymer/logs.html
+++ b/src/generic_ui/polymer/logs.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../lib/polymer/polymer.html">
-<link rel="import" href="../lib/core-signals/core-signals.html">
 <link rel='import' href='../lib/paper-progress/paper-progress.html'>
 
 <polymer-element name='uproxy-logs'>

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -4,7 +4,8 @@ declare var ui :UI.UserInterface;
 Polymer({
   logs: '',
   loadingLogs: true,
-  getNetworkInfo: function() {
+  openUproxy: function() {
+    ui.bringUproxyToFront();
   },
   ready: function() {
     // Expose global ui object in this context.

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -15,6 +15,7 @@
 <link rel='import' href='copypaste.html'>
 <link rel='import' href='bubble.html'>
 <link rel='import' href='feedback.html'>
+<link rel='import' href='troubleshoot.html'>
 <link rel='import' href='browser-elements.html'>
 
 <polymer-element name='uproxy-root' attributes='model' on-update-view='{{ updateView }}' on-open-dialog='{{ openDialog }}'>
@@ -246,6 +247,8 @@
         </paper-button>
       </template>
     </paper-action-dialog>
+
+    <uproxy-troubleshoot></uproxy-troubleshoot>
 
   </template>
 

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -60,6 +60,8 @@
     #submitFeedback {
       text-decoration: underline;
       cursor: pointer;
+      display: inline-block;
+      margin-top: 50px;
     }
     uproxy-faq-link {
       width: 100%;
@@ -118,9 +120,9 @@
         <p>
           We won't share your data or post publicly without your consent
         </p>
-        <p id='submitFeedback' on-tap='{{ openFeedbackForm }}'>
+        <span id='submitFeedback' on-tap='{{ openFeedbackForm }}'>
           Submit Feedback
-        </p>
+        </span>
       </div>
       <uproxy-faq-link anchor='whyDoesUproxyConnect'>
         Learn more about social networks

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -2,6 +2,7 @@
 <link rel='import' href='../lib/paper-button/paper-button.html'>
 <link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
 <link rel='import' href='../lib/core-tooltip/core-tooltip.html'>
+<link rel='import' href='../lib/core-icons/core-icons.html'>
 <link rel='import' href='../lib/core-signals/core-signals.html'>
 <link rel='import' href='faq-link.html'>
 
@@ -14,9 +15,21 @@
     }
     h1 {
       font-size: 1.5em;
+      margin-top: 1.4em;
+    }
+    core-icon[icon="check"] {
+      height: 15px;
+      width: 15px;
+    }
+    core-icon[icon="clear"] {
+      float: right;
+    }
+    core-icon[icon="help"] {
+      height: 15px;
+      width: 15px;
     }
     core-icon[icon="help"],
-    core-icon[icon="close"] {
+    core-icon[icon="clear"] {
       color: grey;
       opacity: 0.6;
       margin-bottom: 2px;
@@ -25,39 +38,22 @@
       transition: all 0.23s !important;
     }
     core-icon[icon="help"]:hover,
-    core-icon[icon="close"]:hover {
+    core-icon[icon="clear"]:hover {
       opacity: 1;
-    }
-    core-icon[icon="help"] {
-      height: 15px;
-      width: 15px;
-    }
-    core-icon[icon="close"] {
-      float: right;
     }
     paper-button {
       background-color: #009688; /* teal */
       color: white;
-      margin-bottom: 3px;
-      margin-top: 10px;
+      margin: 10px 2px 3px 2px;
+      font-size: 12px;
     }
     paper-action-dialog {
       top: 20%;
       min-width: 305px;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
     }
-    #analyzeNetwork {
-      text-align: center;
-      font-size: 14px;
-    }
-    #analyzedNetwork {
-      text-align: left;
-    }
-    paper-progress::shadow #activeProgress {
-      background-color: #009688;
-    }
-    #confirmSendButton {
-      float: right;
+    paper-action-dialog::shadow #scroller {
+      padding: 18px 20px 0px 20px;
     }
     </style>
 
@@ -65,37 +61,23 @@
     <core-signals on-core-signal-open-troubleshoot='{{ open }}'></core-signals>
 
     <paper-action-dialog backdrop layered="false" id='troubleshootDialog'>
-      <h1>
-        Unable to proxy <core-icon icon="close" on-tap='{{ close }}'></core-icon>
-      </h1>
-      <div hidden?='{{ analyzingNetwork || analyzedNetwork }}'>
+      <core-icon icon="clear" on-tap='{{ close }}'></core-icon>
+      <h1>Unable to proxy</h1>
+      <div>
         <p>
           Something went wrong. Would you like uProxy to diagnose your network?
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link><br>
         </p>
-        <paper-button on-tap='{{ getNatType }}'>
+        <paper-button on-tap='{{ analyzeNetworkAndViewLogs }}' hidden?='{{ analyzedNetwork }}'>
           Analyze Network
         </paper-button>
-      </div>
-      <div id='analyzeNetwork' hidden?='{{ !analyzingNetwork }}'>
-        Analyzing network<br>
-        <paper-progress indeterminate='true'></paper-progress>
-      </div>
-      <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
-        NAT type detected: <b>{{ natType }}</b> <br>
-        This NAT type is <b>{{ natDescription }}</b> restricting your ability to use uProxy.
-        <uproxy-faq-link anchor='doesUproxyLogData'>
-          <core-icon icon="help"></core-icon>
-        </uproxy-faq-link><br><br>
-        Would you like to report your NAT type to uProxy developers?
-        <br>
-        <paper-button dismissive>
-          No
-        </paper-button>
-        <paper-button affirmative on-tap='{{ sendNetworkInfo }}' id='confirmSendButton'>
-          Yes
+        <paper-button id='analyzedButton' disabled hidden?='{{ !analyzedNetwork }}'>
+          <core-icon icon='check'></core-icon> Analyzed
+        </paper-button><br>
+        <paper-button on-tap='{{ submitFeedback }}'>
+          Submit Feedback
         </paper-button>
       </div>
     </paper-action-dialog>

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -12,8 +12,7 @@
       text-align: center;
       font-color: #009688;  /* dark green */
     }
-    core-icon[icon="launch"],
-    core-icon[icon="help"]{
+    core-icon[icon="help"] {
       height: 15px;
       color: grey;
       opacity: 0.6;
@@ -22,36 +21,32 @@
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
     }
-    core-icon[icon="launch"]:hover,
-    core-icon[icon="help"]:hover{
+    core-icon[icon="help"]:hover {
       opacity: 1;
-    }
-    core-tooltip::shadow #tooltip {
-      /* Without this, the first time you view the
-         tooltip, it appears off center. */
-      left: -64px !important;
     }
     paper-button {
       background-color: #009688; /* teal */
       color: white;
       margin-bottom: 3px;
+      margin-top: 10px;
     }
     paper-action-dialog {
       top: 20%;
+      min-width: 305px;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
-    }
-    .core-overlay-backdrop {
-      z-index: 1001;
     }
     #analyzeNetwork {
       text-align: center;
       font-size: 14px;
     }
+    #analyzedNetwork {
+      text-align: left;
+    }
     paper-progress::shadow #activeProgress {
       background-color: #009688;
     }
-    #dontSendButton {
-      float: left;
+    #confirmSendButton {
+      float: right;
     }
     </style>
 
@@ -75,16 +70,17 @@
         <paper-progress indeterminate='true'></paper-progress>
       </div>
       <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
-        NAT type detected: {{ natType }} <br>
-        This NAT type is {{ natDescription }} restricting your ability to use uProxy.
+        NAT type detected: <b>{{ natType }}</b> <br>
+        This NAT type is <b>{{ natDescription }}</b> restricting your ability to use uProxy.
         <uproxy-faq-link anchor='doesUproxyLogData'>
           <core-icon icon="help"></core-icon>
-        </uproxy-faq-link><br>
+        </uproxy-faq-link><br><br>
         Would you like to report your NAT type to uProxy developers?
-        <paper-button dismissive id='dontSendButton'>
+        <br>
+        <paper-button dismissive>
           No
         </paper-button>
-        <paper-button affirmative on-tap='{{ sendNetworkInfo }}'>
+        <paper-button affirmative on-tap='{{ sendNetworkInfo }}' id='confirmSendButton'>
           Yes
         </paper-button>
       </div>

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -12,8 +12,11 @@
       text-align: center;
       font-color: #009688;  /* dark green */
     }
-    core-icon[icon="help"] {
-      height: 15px;
+    h1 {
+      font-size: 1.5em;
+    }
+    core-icon[icon="help"],
+    core-icon[icon="close"] {
       color: grey;
       opacity: 0.6;
       margin-bottom: 2px;
@@ -21,8 +24,16 @@
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
     }
-    core-icon[icon="help"]:hover {
+    core-icon[icon="help"]:hover,
+    core-icon[icon="close"]:hover {
       opacity: 1;
+    }
+    core-icon[icon="help"] {
+      height: 15px;
+      width: 15px;
+    }
+    core-icon[icon="close"] {
+      float: right;
     }
     paper-button {
       background-color: #009688; /* teal */
@@ -51,9 +62,12 @@
     </style>
 
     <!-- Listen for the 'open-troubleshoot' event, which the user can trigger after proxying fails. -->
-    <core-signals on-core-signal-open-troubleshoot="{{ open }}"></core-signals>
+    <core-signals on-core-signal-open-troubleshoot='{{ open }}'></core-signals>
 
-    <paper-action-dialog backdrop layered="false" id='troubleshootDialog' heading='Unable to proxy'>
+    <paper-action-dialog backdrop layered="false" id='troubleshootDialog'>
+      <h1>
+        Unable to proxy <core-icon icon="close" on-tap='{{ close }}'></core-icon>
+      </h1>
       <div hidden?='{{ analyzingNetwork || analyzedNetwork }}'>
         <p>
           Something went wrong. Would you like uProxy to diagnose your network?

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -1,0 +1,95 @@
+<link rel='import' href='../lib/polymer/polymer.html'>
+<link rel='import' href='../lib/paper-button/paper-button.html'>
+<link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
+<link rel='import' href='../lib/core-tooltip/core-tooltip.html'>
+<link rel='import' href='../lib/core-signals/core-signals.html'>
+<link rel='import' href='faq-link.html'>
+
+<polymer-element name='uproxy-troubleshoot'>
+  <template>
+    <style>
+    :host {
+      text-align: center;
+      font-color: #009688;  /* dark green */
+    }
+    core-icon[icon="launch"],
+    core-icon[icon="help"]{
+      height: 15px;
+      color: grey;
+      opacity: 0.6;
+      margin-bottom: 2px;
+      -webkit-transition: all 0.23s !important;
+      -moz-transition: all 0.23s !important;
+      transition: all 0.23s !important;
+    }
+    core-icon[icon="launch"]:hover,
+    core-icon[icon="help"]:hover{
+      opacity: 1;
+    }
+    core-tooltip::shadow #tooltip {
+      /* Without this, the first time you view the
+         tooltip, it appears off center. */
+      left: -64px !important;
+    }
+    paper-button {
+      background-color: #009688; /* teal */
+      color: white;
+      margin-bottom: 3px;
+    }
+    paper-action-dialog {
+      top: 20%;
+      z-index: 1002; /* Must be greater than core-overlay-backdrop */
+    }
+    .core-overlay-backdrop {
+      z-index: 1001;
+    }
+    #analyzeNetwork {
+      text-align: center;
+      font-size: 14px;
+    }
+    paper-progress::shadow #activeProgress {
+      background-color: #009688;
+    }
+    #dontSendButton {
+      float: left;
+    }
+    </style>
+
+    <!-- Listen for the 'open-troubleshoot' event, which the user can trigger after proxying fails. -->
+    <core-signals on-core-signal-open-troubleshoot="{{ open }}"></core-signals>
+
+    <paper-action-dialog backdrop layered="false" id='troubleshootDialog' heading='Unable to proxy'>
+      <div hidden?='{{ analyzingNetwork || analyzedNetwork }}'>
+        <p>
+          Something went wrong. Would you like uProxy to diagnose your network?
+          <uproxy-faq-link anchor='doesUproxyLogData'>
+            <core-icon icon="help"></core-icon>
+          </uproxy-faq-link><br>
+        </p>
+        <paper-button on-tap='{{ getNatType }}'>
+          Analyze Network
+        </paper-button>
+      </div>
+      <div id='analyzeNetwork' hidden?='{{ !analyzingNetwork }}'>
+        Analyzing network<br>
+        <paper-progress indeterminate='true'></paper-progress>
+      </div>
+      <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
+        NAT type detected: {{ natType }} <br>
+        This NAT type is {{ natDescription }} restricting your ability to use uProxy.
+        <uproxy-faq-link anchor='doesUproxyLogData'>
+          <core-icon icon="help"></core-icon>
+        </uproxy-faq-link><br>
+        Would you like to report your NAT type to uProxy developers?
+        <paper-button dismissive id='dontSendButton'>
+          No
+        </paper-button>
+        <paper-button affirmative on-tap='{{ sendNetworkInfo }}'>
+          Yes
+        </paper-button>
+      </div>
+    </paper-action-dialog>
+
+  </template>
+  <script src='troubleshoot.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -17,10 +17,6 @@
       font-size: 1.5em;
       margin-top: 1.4em;
     }
-    core-icon[icon="check"] {
-      height: 15px;
-      width: 15px;
-    }
     core-icon[icon="clear"] {
       float: right;
     }
@@ -70,11 +66,8 @@
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link><br>
         </p>
-        <paper-button on-tap='{{ analyzeNetworkAndViewLogs }}' hidden?='{{ analyzedNetwork }}'>
+        <paper-button on-tap='{{ analyzeNetworkAndViewLogs }}'>
           Analyze Network
-        </paper-button>
-        <paper-button id='analyzedButton' disabled hidden?='{{ !analyzedNetwork }}'>
-          <core-icon icon='check'></core-icon> Analyzed
         </paper-button><br>
         <paper-button on-tap='{{ submitFeedback }}'>
           Submit Feedback

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -3,61 +3,20 @@ Polymer({
     this.$.troubleshootDialog.close();
   },
   open: function() {
+    this.analyzedNetwork = false;
     this.$.troubleshootDialog.open();
   },
-  sendNetworkInfo: function() {
-    core.sendFeedback({
-      email: '',
-      feedback: '',
-      logs: false,
-      browserInfo: '',
-      networkInfo: true
-    }).then(() => {
-      this.close();
-      // root.ts listens for open-dialog signals and shows a popup
-      // when it receives these events.
-      this.fire('open-dialog', {
-        heading: 'Thank you!',
-        message: 'Your NAT type has been submitted to the uProxy development team.',
-        buttons: [{
-          text: 'Done',
-          signal: 'close-settings'
-        }]
-      });
-    }).catch((e) => {
-      this.close();
-      this.fire('open-dialog', {
-        heading: 'Email instead?',
-        message:
-          'Oops! We were unable to submit your NAT type to uproxy.org. Please send your NAT type ('
-          + this.natType
-          + ') in an email to info@uproxy.org.',
-        buttons: [{
-          text: 'OK'
-        }]
-      });
-    });
+  submitFeedback: function() {
+    this.fire('core-signal', {name: 'open-feedback', data: {includeLogs: this.analyzedNetwork}});
+    this.close();
   },
-  getNatType: function() {
-    this.analyzingNetwork = true;
-
-    core.getNatType().then((natType) => {
-      this.natType = natType;
-      if (natType === 'SymmetricNAT') {
-        this.natDescription = 'very likely';
-      } else if (natType === 'PortRestrictedCone') {
-        this.natDescription = 'possibly'
-      } else {
-        this.natDescription = 'unlikely'
-      }
-      this.analyzingNetwork = false;
-      this.analyzedNetwork = true;
-    });
+  analyzeNetworkAndViewLogs: function() {
+    this.ui.openTab('view-logs.html');
+    this.analyzedNetwork = true;
   },
   ready: function() {
     this.ui = ui;
     this.model = model;
-    this.analyzingNetwork = false;
     this.analyzedNetwork = false;
   }
 });

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -18,7 +18,7 @@ Polymer({
       // when it receives these events.
       this.fire('open-dialog', {
         heading: 'Thank you!',
-        message: 'Your feedback has been submitted to the uProxy development team.',
+        message: 'Your NAT type has been submitted to the uProxy development team.',
         buttons: [{
           text: 'Done',
           signal: 'close-settings'
@@ -27,8 +27,11 @@ Polymer({
     }).catch((e) => {
       this.close();
       this.fire('open-dialog', {
-        heading: 'Email info instead?',
-        message: 'Oops! We were unable to submit your info to uproxy.org. Please copy and paste your NAT type in an email to info@uproxy.org.',
+        heading: 'Email instead?',
+        message:
+          'Oops! We were unable to submit your NAT type to uproxy.org. Please send your NAT type ('
+          + this.natType
+          + ') in an email to info@uproxy.org.',
         buttons: [{
           text: 'OK'
         }]

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -1,0 +1,60 @@
+Polymer({
+  close: function() {
+    this.$.troubleshootDialog.close();
+  },
+  open: function() {
+    this.$.troubleshootDialog.open();
+  },
+  sendNetworkInfo: function() {
+    core.sendFeedback({
+      email: '',
+      feedback: '',
+      logs: false,
+      browserInfo: '',
+      networkInfo: true
+    }).then(() => {
+      this.close();
+      // root.ts listens for open-dialog signals and shows a popup
+      // when it receives these events.
+      this.fire('open-dialog', {
+        heading: 'Thank you!',
+        message: 'Your feedback has been submitted to the uProxy development team.',
+        buttons: [{
+          text: 'Done',
+          signal: 'close-settings'
+        }]
+      });
+    }).catch((e) => {
+      this.close();
+      this.fire('open-dialog', {
+        heading: 'Email info instead?',
+        message: 'Oops! We were unable to submit your info to uproxy.org. Please copy and paste your NAT type in an email to info@uproxy.org.',
+        buttons: [{
+          text: 'OK'
+        }]
+      });
+    });
+  },
+  getNatType: function() {
+    this.analyzingNetwork = true;
+
+    core.getNatType().then((natType) => {
+      this.natType = natType;
+      if (natType === 'SymmetricNAT') {
+        this.natDescription = 'very likely';
+      } else if (natType === 'PortRestrictedCone') {
+        this.natDescription = 'possibly'
+      } else {
+        this.natDescription = 'unlikely'
+      }
+      this.analyzingNetwork = false;
+      this.analyzedNetwork = true;
+    });
+  },
+  ready: function() {
+    this.ui = ui;
+    this.model = model;
+    this.analyzingNetwork = false;
+    this.analyzedNetwork = false;
+  }
+});

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -17,6 +17,5 @@ Polymer({
   ready: function() {
     this.ui = ui;
     this.model = model;
-    this.analyzedNetwork = false;
   }
 });

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -184,7 +184,7 @@ class CoreConnector implements uProxy.CoreAPI {
     return this.promiseCommand(uProxy.Command.LOGOUT, networkInfo);
   }
 
-  sendFeedback = (feedback :uProxy.UserFeedback) : void => {
+  sendFeedback = (feedback :uProxy.UserFeedback) : Promise<void> => {
     return this.promiseCommand(uProxy.Command.SEND_FEEDBACK, feedback);
   }
 

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -185,7 +185,7 @@ class CoreConnector implements uProxy.CoreAPI {
   }
 
   sendFeedback = (feedback :uProxy.UserFeedback) : void => {
-    return this.sendCommand(uProxy.Command.SEND_FEEDBACK, feedback);
+    return this.promiseCommand(uProxy.Command.SEND_FEEDBACK, feedback);
   }
 
   restart = () => {

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -196,7 +196,7 @@ class CoreConnector implements uProxy.CoreAPI {
     return this.promiseCommand(uProxy.Command.GET_LOGS);
   }
 
-  getNat = () : Promise<string> => {
-    return this.promiseCommand(uProxy.Command.GET_NAT);
+  getNatType = () : Promise<string> => {
+    return this.promiseCommand(uProxy.Command.GET_NAT_TYPE);
   }
 }  // class CoreConnector

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -195,4 +195,8 @@ class CoreConnector implements uProxy.CoreAPI {
   getLogs = () : Promise<string> => {
     return this.promiseCommand(uProxy.Command.GET_LOGS);
   }
+
+  getNat = () : Promise<string> => {
+    return this.promiseCommand(uProxy.Command.GET_NAT);
+  }
 }  // class CoreConnector

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -42,7 +42,8 @@ module uProxy {
     SEND_CREDENTIALS,
     UPDATE_GLOBAL_SETTINGS,
     SEND_FEEDBACK,
-    GET_LOGS
+    GET_LOGS,
+    GET_NAT
   }
 
   // Updates are sent from the Core to the UI, to update state that the UI must

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -154,7 +154,6 @@ module uProxy {
     feedback  :string;
     logs      :boolean;
     browserInfo :string;
-    networkInfo :boolean;
   }
 
   // --- Core <--> UI Interfaces ---

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -43,7 +43,7 @@ module uProxy {
     UPDATE_GLOBAL_SETTINGS,
     SEND_FEEDBACK,
     GET_LOGS,
-    GET_NAT
+    GET_NAT_TYPE
   }
 
   // Updates are sent from the Core to the UI, to update state that the UI must
@@ -152,8 +152,9 @@ module uProxy {
   export interface UserFeedback {
     email     :string;
     feedback  :string;
-    logs      :string;
+    logs      :boolean;
     browserInfo :string;
+    networkInfo :boolean;
   }
 
   // --- Core <--> UI Interfaces ---


### PR DESCRIPTION
To do in this pull request:
- Add 'X' button to close Unable to Proxy dialog (or add 'Try Again' option beside the 'Analyze Network' button)
- Add padding on top of 'Submit Feedback' on the Splash page
- Make the checkbox label on the feedback page link to the View Logs page, and remove the pop-out icon that currently opens that page
- Add a timeout to getNatType when feedback is being sent -- if it takes longer than 30s (?) we will submit all feedback except the NAT type. This will guarantee that the 'Submitting Feedback' dialog will be closed.

To do in future pull request: the new uproxy-troubleshoot element should be added to the Advanced Settings page when that is created (the contents of uproxy-troubleshoot should be taken out of the paper-dialog and added to a core-overlay)

![image](https://cloud.githubusercontent.com/assets/8723127/6914091/0bc64b34-d755-11e4-8c5b-13c96e5048b6.png)

![image](https://cloud.githubusercontent.com/assets/8723127/6914122/5a720016-d755-11e4-879f-762838c2e2bd.png)

![image](https://cloud.githubusercontent.com/assets/8723127/6913330/b947d182-d74c-11e4-81b0-06765abb10b8.png)

![image](https://cloud.githubusercontent.com/assets/8723127/6913589/45c06644-d750-11e4-87a4-7defb4b34c05.png)

![image](https://cloud.githubusercontent.com/assets/8723127/6913592/49e9b518-d750-11e4-9e23-c32267eb535d.png)

![image](https://cloud.githubusercontent.com/assets/8723127/6913596/51b76434-d750-11e4-8d82-5f43699ac7ad.png)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1180)
<!-- Reviewable:end -->
