### PR TITLE
Fix issues with copy+paste app bar

### DIFF
--- a/src/generic_ui/polymer/app-bar.html
+++ b/src/generic_ui/polymer/app-bar.html
@@ -32,6 +32,8 @@
     }
     #title {
       margin-left: 36px;
+      white-space: nowrap;
+      overflow: hidden;
     }
     </style>
 

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -30,9 +30,9 @@
     <core-signals on-core-signal-copypaste-init='{{ init }}'></core-signals>
 
     <uproxy-app-bar disableback='{{ ui.copyPasteGettingState === GettingState.GETTING_ACCESS || ui.copyPasteSharingState === SharingState.SHARING_ACCESS }}' on-go-back='{{ handleBackClick }}'>
-      <span hidden?='{{ GettingState.NONE === ui.copyPasteGettingState || SharingState.TRYING_TO_SHARE_ACCESS == ui.copyPasteSharingState }}'>Request a one time connection</span>
-      <span hidden?='{{ SharingState.NONE === ui.copyPasteSharingState }}'>Share a one time connection</span>
-      <span hidden?='{{ ui.copyPasteSharingState !== SharingState.NONE || ui.copyPasteGettingState !== GettingState.NONE }}'>Manual Connection</span>
+      <span hidden?='{{ SharingState.NONE === ui.copyPasteSharingState }}'>Share a </span>
+      <span hidden?='{{ SharingState.NONE !== ui.copyPasteSharingState || GettingState.NONE === ui.copyPasteGettingState }}'>Request a </span>
+      <span>One Time Connection</span>
     </uproxy-app-bar>
 
     <uproxy-bubble active='{{ ui.copyPasteError === UI.CopyPasteError.BAD_URL }}' on-closed='{{ dismissError }}' class='error'>


### PR DESCRIPTION
This fixes two issues with the app bar on the copy+paste page

First of all, there were some cases where two headings were displayed at
the same time, this removes that.

Second, this removes text wrapping from the app-bar heading.

Fixes #1183

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1188)
<!-- Reviewable:end -->
