### PR TITLE
The profile picture in settings should never be stretched

### DIFF
--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -44,6 +44,8 @@
       height: 54px;
       border-radius: 50%;
       margin-left: -6px;
+      background-size: 100%;
+      background-repeat: no-repeat;
     }
     #settingsLinks {
       padding: 24px 28px;
@@ -101,8 +103,9 @@
 
     <div hidden?='{{model.onlineNetwork==null}}' vertical layout>
       <div class='userInfo'>
-        <img class='userImage' hidden?='{{model.onlineNetwork.imageData==null}}'
-            src='{{model.onlineNetwork.imageData}}'>
+        <div class='userImage' hidden?='{{model.onlineNetwork.imageData==null}}'
+          style='background-image: url({{model.onlineNetwork.imageData}});'
+          ></div>
         <div class='networkName'>Connected with {{model.onlineNetwork.name}}</div>
         <!-- show userName and userId if both are available -->
         <div hidden?='{{!model.onlineNetwork.userName}}'>


### PR DESCRIPTION
Even if we are sent a non-square profile picture, we should be sure not
to stretch the image.  This provides a temporary fix for
freedom-firebase sending down non-square facebook profile pictures and a
general fix to make sure that images will never be distorted horribly.

Fixes #1171

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1195)
<!-- Reviewable:end -->
