### PR TITLE
Fix to open troubleshoot dialog when proxying fails.

### DIFF
--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -22,17 +22,14 @@ Polymer({
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
     }).catch((e) => {
-      this.openTroubleshoot();
+      // TODO: the querySelector should be replaced with the line below, which
+      // for some reason does not work. GitHub issue:
+      // https://github.com/uProxy/uproxy/issues/1199
+      // this.fire('core-signal', {name: 'open-troubleshoot'});
+      document.querySelector('html /deep/ #troubleshootDialog').open();
       ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
     });
-  },
-  openTroubleshoot: function() {
-    document.querySelector('html /deep/ #troubleshootDialog').open();
-    // TODO: this function should really contain the line below, which
-    // for some reason does not work. GitHub issue:
-    // https://github.com/uProxy/uproxy/issues/1199
-    // this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   stop: function() {
     console.log('[polymer] calling core.stop()');

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -15,7 +15,6 @@ Polymer({
     this.GettingState = GettingState;
     this.model = model;
   },
-
   start: function() {
     console.log('[polymer] calling core.start(', this.path, ')');
     core.start(this.path).then((endpoint) => {
@@ -23,10 +22,17 @@ Polymer({
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
     }).catch((e) => {
-      this.fire('core-signal', {name: 'open-troubleshoot'});
+      this.openTroubleshoot();
       ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
     });
+  },
+  openTroubleshoot: function() {
+    document.querySelector('html /deep/ #troubleshootDialog').open();
+    // TODO: this function should really contain the line below, which
+    // for some reason does not work. GitHub issue:
+    // https://github.com/uProxy/uproxy/issues/1199
+    // this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   stop: function() {
     console.log('[polymer] calling core.stop()');


### PR DESCRIPTION
I thought this was the fix: https://github.com/uProxy/uproxy/pull/1193
I originally tested by firing a core-signal, but I didn't realize that firing from inside a promise then() or catch() block doesn't work. I tested this by trying a proxy I knew would fail. Should be working correctly now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1200)
<!-- Reviewable:end -->
