### PR TITLE
Explicitly update global settings when changing mode

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -193,7 +193,7 @@
           </uproxy-bubble>
 
           <div class='bottom fit'>
-            <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}'>
+            <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}' on-core-activate='{{ tabSelected }}'>
               <paper-tab>Get Access</paper-tab>
               <paper-tab>Share Access</paper-tab>
             </paper-tabs>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -187,7 +187,7 @@
               on-tap='{{ setShareMode }}'></img>
           </core-tooltip>
 
-            <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && (model.contacts.shareAccessContacts.onlineTrustedUproxy.length > 0 || model.contacts.shareAccessContacts.offlineTrustedUproxy.length > 0) }}'>
+          <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && (model.contacts.shareAccessContacts.onlineTrustedUproxy.length > 0 || model.contacts.shareAccessContacts.offlineTrustedUproxy.length > 0) }}'>
             <h3>Sharing Enabled</h3>
             <p>This icon means you're available for sharing access with friends you've offered access to.</p>
           </uproxy-bubble>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -30,9 +30,11 @@ Polymer({
   },
   setGetMode: function() {
     model.globalSettings.mode = uProxy.Mode.GET;
+    core.updateGlobalSettings(model.globalSettings);
   },
   setShareMode: function() {
     model.globalSettings.mode = uProxy.Mode.SHARE;
+    core.updateGlobalSettings(model.globalSettings);
   },
   closedWelcome: function() {
     model.globalSettings.hasSeenWelcome = true;
@@ -82,12 +84,5 @@ Polymer({
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
-  },
-
-  observe: {
-    'model.globalSettings.mode': 'modeChange'
-  },
-  modeChange: function() {
-    core.updateGlobalSettings(model.globalSettings);
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -84,5 +84,10 @@ Polymer({
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
+  },
+  tabSelected: function(e) {
+    // setting the value is taken care of in the polymer binding, we just need
+    // to sync the value to core
+    core.updateGlobalSettings(model.globalSettings);
   }
 });


### PR DESCRIPTION
Previously, we had a polymer watcher on model.globalSettings.mode which
would trigger `modeChange` which would update the globalSettings state
in core whenever mode was changed.  This caused `updateGlobalSettings`
to be called multiple times in some cases (except for the two instances
in `root.ts` that relied on the watcher, all other cases still
explicitly updated settings themselves) and resulted in it being called
in error at other points (initialization caused it to be called, even if
globalSettings itself was not fully populated).

We now manually call `updateGlobalSettings` when the user clicks the get
or share tabs.

Fixes #1190

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1201)
<!-- Reviewable:end -->
