### PR TITLE
Remove the type errors we see every time we build

### DIFF
--- a/src/chrome/app/scripts/background.ts
+++ b/src/chrome/app/scripts/background.ts
@@ -14,7 +14,7 @@
 var connector :ChromeUIConnector;
 var uProxyAppChannel : OnAndEmit<any,any>;
 
-var uproxyModule = new freedom('scripts/freedom-module.json', {
+freedom('scripts/freedom-module.json', {
   'logger': 'scripts/uproxy-lib/loggingprovider/loggingprovider.json',
   'debug': 'debug',
   oauth: [Chrome_oauth]

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -35,7 +35,7 @@ var storage = new Core.Storage();
 // This is the channel to speak to the UI component of uProxy.
 // The UI is running from the privileged part of freedom, so we can just set
 // this to be freedom, and communicate using 'emit's and 'on's.
-var bgAppPageChannel = new freedom();
+var bgAppPageChannel = freedom();
 
 // Keep track of the current remote instance who is acting as a proxy server
 // for us.

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -87,7 +87,6 @@ class MockStorage implements freedom_Storage {
 }  // class MockStorage
 
 class MockChannel {
-
   public on = (eventTypeString, callback) => {
     return null;
   }
@@ -108,7 +107,9 @@ class MockLoggingProvider {
   public setBufferedLogFilter = (filter:string) : void => {}
 }  // class MockLoggingProvider
 
-var freedom = MockChannel;
+var freedom = () => {
+  return new MockChannel();
+}
 freedom['storage'] = () => { return new MockStorage({}); };
 var mockSocial = () => { return new MockSocial(); };
 mockSocial['api'] = 'social';


### PR DESCRIPTION
The type errors we are seeing when we build actually turn out to be
because freedom should not be called with the new operator, this removes
that.

Initially, we never touch the return value from calling it in
`chrome/app/background.ts`, so don't bother saving it in a variable.

This also fixes the description of freedom in our mock.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1205)
<!-- Reviewable:end -->
