### PR TITLE
Add the ability to send feedback to alternate (hardcoded) urls

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -473,18 +473,18 @@ class uProxyCore implements uProxy.CoreAPI {
       maxAttempts = this.FeedbackUrls_.length;
     }
 
-    var logs :Promise<string>;
+    var logsPromise :Promise<string>;
 
     if (feedback.logs) {
-      logs = this.getLogsAndNetworkInfo().then((logs) => {
+      logsPromise = this.getLogsAndNetworkInfo().then((logs) => {
         var browserInfo = 'Browser Info: ' + feedback.browserInfo + '\n\n';
         return browserInfo + logs;
       });
     } else {
-      logs = Promise.resolve('');
+      logsPromise = Promise.resolve('');
     }
 
-    return logs.then((logs) => {
+    return logsPromise.then((logs) => {
       var attempts = 0;
 
       var payload = {


### PR DESCRIPTION
This separates the functionality for sending a post request from sending
the feedback-specific data and adds alternate urls to retry for the
feedback

Fixes #1191

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1215)
<!-- Reviewable:end -->
