### PR TITLE
Remove some PII from the logs

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -581,6 +581,8 @@ class uProxyCore implements uProxy.CoreAPI {
   private formatLogs_ = (logs :string[]) : string => {
     // replace the emails with consistent tags throughout the logs
     var emails :string[] = [];
+    var names :string[] = [];
+
     var emailReplacer = (email :string) :string => {
       var id = _.indexOf(emails, email);
       if (id === -1) {
@@ -591,12 +593,23 @@ class uProxyCore implements uProxy.CoreAPI {
       return 'EMAIL_' + id;
     }
 
+    var nameReplacer = (match :string, pre :string, name :string, post :string):string => {
+      var id = _.indexOf(names, name);
+      if (id === -1) {
+        id = names.length;
+        names.push(name);
+      }
+
+      return pre + 'NAME_' + id + post;
+    }
+
     var text = logs.join('\n');
 
     // email regex taken from regular-expressions.info
     text = text.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b/ig,
                         emailReplacer);
     text = text.replace(/data:image\/.+;base64,[A-Za-z0-9+\/=]+/g, 'IMAGE_DATA');
+    text = text.replace(/("name":")([^"]*)(")/g, nameReplacer);
     return text;
   }
 }  // class uProxyCore

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -578,12 +578,26 @@ class uProxyCore implements uProxy.CoreAPI {
       });
   }
 
-  private formatLogs_ = (rawLogs) : string => {
-    var formattedLogs = '';
-    for (var i = 0; i < rawLogs.length; i++) {
-      formattedLogs += rawLogs[i] + '\n';
+  private formatLogs_ = (logs :string[]) : string => {
+    // replace the emails with consistent tags throughout the logs
+    var emails :string[] = [];
+    var emailReplacer = (email :string) :string => {
+      var id = _.indexOf(emails, email);
+      if (id === -1) {
+        id = emails.length;
+        emails.push(email);
+      }
+
+      return 'EMAIL_' + id;
     }
-    return formattedLogs;
+
+    var text = logs.join('\n');
+
+    // email regex taken from regular-expressions.info
+    text = text.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b/ig,
+                        emailReplacer);
+    text = text.replace(/data:image\/.+;base64,[A-Za-z0-9+\/=]+/g, 'IMAGE_DATA');
+    return text;
   }
 }  // class uProxyCore
 


### PR DESCRIPTION
This removes the most dangerous (and easily-identified) PII from the
logs: emails and pictures.

For emails, we will replace any email address found with EMAIL_{ID}
where ID a numeric ID that will be consistent throughout that single
log.  The original proposal was to use a salted hash with a salt known
only to the reporter, however, that would end up being more difficult to
implement, less performant, and it would offer us a stronger chance of
determining what an email address was based on the logs.

For any base64-encoded image data we detect in the logs, we will replace
it with "IMAGE_DATA".  I cannot imagine any cases where the actual
content of an image would be useful in debugging.

Fixes #1164

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1228)
<!-- Reviewable:end -->
