### PR TITLE
Do not attempt to proxy with an offline instance

### DIFF
--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -17,6 +17,16 @@ Polymer({
     this.model = model;
   },
   start: function() {
+    if (!this.instance.isOnline) {
+      this.fire('core-signal', {
+        name: 'show-toast',
+        data: {
+          text: this.user.name + ' is offline'
+        }
+      });
+      return;
+    }
+
     console.log('[polymer] calling core.start(', this.path, ')');
 
     this.aborted = false;

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../lib/core-icon-button/core-icon-button.html">
 <link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
 <link rel="import" href="../lib/paper-tabs/paper-tabs.html">
+<link rel="import" href="../lib/paper-toast/paper-toast.html">
 <link rel="import" href="../lib/core-tooltip/core-tooltip.html">
 <link rel="import" href='splash.html'>
 <link rel="import" href='roster.html'>
@@ -144,6 +145,7 @@
     </style>
 
     <core-signals on-core-signal-close-settings="{{ closeSettings }}"></core-signals>
+    <core-signals on-core-signal-show-toast="{{ showToast }}"></core-signals>
 
     <div id='browserElementContainer' hidden?='{{uProxy.View.BROWSER_ERROR !== ui.view}}'></div>
 
@@ -249,6 +251,8 @@
     </paper-action-dialog>
 
     <uproxy-troubleshoot></uproxy-troubleshoot>
+
+    <paper-toast id="toast"></paper-toast>
 
   </template>
 

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -90,6 +90,10 @@ Polymer({
     // to sync the value to core
     core.updateGlobalSettings(model.globalSettings);
   },
+  showToast: function(e, data) {
+    this.$.toast.setAttribute('text', data.text);
+    this.$.toast.show();
+  },
   signalToFireChanged: function() {
     if (this.ui.signalToFire != '') {
       this.fire('core-signal', {name: this.ui.signalToFire});


### PR DESCRIPTION
When a user attempts to proxy with an offline instance, do not attempt
to connect to that instance.  Instead, we now display a toast
notification reminding the user that their friend is offline.

This also adds the ability to display a toast notification

Fixes #1224

![is-offline-toast](https://cloud.githubusercontent.com/assets/902894/7049971/cdf6757a-ddeb-11e4-8d2c-e16cbfed79ea.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1231)
<!-- Reviewable:end -->
