### PR TITLE
Name Specfiles SpecRunner.html to avoid breaking app/extension loading

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -477,6 +477,7 @@ module.exports = (grunt) ->
             ]
         options:
           specs: 'build/compile-src/chrome/extension/**/*.spec.js'
+          outfile: 'build/compile-src/chrome/extension/SpecRunner.html'
           template: require('grunt-template-jasmine-istanbul')
           templateOptions:
             coverage: 'build/coverage/chrome_extension/coverage.json'
@@ -495,6 +496,7 @@ module.exports = (grunt) ->
             ]
         options:
           specs: 'build/compile-src/chrome/app/**/*.spec.js'
+          outfile: 'build/compile-src/chrome/app/SpecRunner.html'
           template: require('grunt-template-jasmine-istanbul')
           templateOptions:
             coverage: 'build/coverage/chrome_app/coverage.json'
@@ -555,6 +557,7 @@ module.exports = (grunt) ->
         options:
           specs: 'build/compile-src/generic_ui/scripts/**/*.spec.js'
           template: require('grunt-template-jasmine-istanbul')
+          outfile: 'build/compile-src/generic_ui/SpecRunner.html'
           templateOptions:
             coverage: 'build/coverage/generic_ui/coverage.json'
             report:


### PR DESCRIPTION
Chrome apps and chrome extensions cannot be loaded if there are files starting with '_'. This pull request renames the output files for SpecRunners to just be named 'SpecRunner.html' so that or a development build, if the SpecRunners are in the location of the extension or app, this doesn't require their manual removal. 

(see https://github.com/uProxy/uproxy/issues/474)

TESTED: 
grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1235)
<!-- Reviewable:end -->
