### PR TITLE
Use Quicksand font for uProxy splash page

### DIFF
--- a/src/generic_ui/index.html
+++ b/src/generic_ui/index.html
@@ -16,6 +16,15 @@
     @font-face {
       font-family: Roboto, sans-serif;
     }
+    @font-face {
+      font-family: Quicksand;
+      src: url(fonts/Quicksand-Regular.ttf);
+    }
+    @font-face {
+      font-family: Quicksand;
+      src: url(fonts/Quicksand-Bold.ttf);
+      font-weight: 700;
+    }
     html {
       height: 100%;
       position: relative;

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -22,6 +22,16 @@
       color: #009688;  /* dark green */
       margin-bottom: 1.5em;
     }
+    h1.uproxyTitle {
+      font-family: "Quicksand", sans-serif;
+      font-weight: 700;
+      font-size: 40px;
+      letter-spacing: -1px;
+      margin-bottom: 1em;
+    }
+    h1.uproxyTitle .first-u {
+      color: #10c9b1;
+    }
     h1.sub {
       font-weight: normal;
     }
@@ -91,7 +101,7 @@
     <div vertical layout id='intro1' hidden?='{{SPLASH_STATES.INTRO!==ui.splashState}}'>
       <div class='view' flex>
         <img class='uproxy-logo' src='../icons/smiley.png'>
-        <h1>uProxy</h1>
+        <h1 class='uproxyTitle'><span class='first-u'>u</span>Proxy</h1>
         <p>
           uProxy helps you share your access to the internet or get internet
           access from friends


### PR DESCRIPTION
Use Quicksand font for uProxy splash page, to match website, FAQ, etc

Screenshot:
![screen shot 2015-04-09 at 11 08 12 am](https://cloud.githubusercontent.com/assets/6494307/7069825/034e469a-dea9-11e4-9920-358fafcbb3b5.png)

Tested on Chrome and Firefox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1236)
<!-- Reviewable:end -->
