### PR TITLE
core: Wait to clean up old connection before starting a new one

### DIFF
--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -201,8 +201,8 @@ module Core {
     /**
      * Stop using this remote instance as a proxy server.
      */
-    public stop = () : void => {
-      this.connection_.stopGet();
+    public stop = () : Promise<void> => {
+      return this.connection_.stopGet();
     }
 
     /**


### PR DESCRIPTION
The previous behaviour we had when attempting to start a new connection
was that we would try to terminate any existing connection and would
immediately start trying to connect.  This sometimes caused a race
condition when the state was not completely cleaned up.

To get around that issue, we now wait for the old connections to finish
cleaning up before we try to start a new one.

Fixes #1234

Tested by manually switching who I am proxying with multiple times without clicking stop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1237)
<!-- Reviewable:end -->
