### PR TITLE
Switch styling for user image in settings to cover

### DIFF
--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -44,8 +44,9 @@
       height: 54px;
       border-radius: 50%;
       margin-left: -6px;
-      background-size: 100%;
+      background-size: cover;
       background-repeat: no-repeat;
+      background-position: center;
     }
     #settingsLinks {
       padding: 24px 28px;


### PR DESCRIPTION
This updates the styling for the user image in settings to be cover,
that should look a bit better for cases where the picture is extra-wide.
Still waiting on getting back user-decided pictures to make this a solid
fix.

This will center the picture which may be undesirable in some cases, any
other positioning also has that possibility though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1243)
<!-- Reviewable:end -->
