### PR TITLE
change monitoring interval from 5s to 1 minute

### DIFF
--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -126,7 +126,7 @@ describe('Social.FreedomNetwork', () => {
           expect(friend).toBeDefined();
           spyOn(friend, 'monitor');
           // Advance clock 5 seconds and make sure monitoring was called.
-          jasmine.clock().tick(5000);
+          jasmine.clock().tick(60000);
           expect(friend.monitor).toHaveBeenCalled();
           done();
         });
@@ -155,12 +155,12 @@ describe('Social.FreedomNetwork', () => {
       expect(friend).toBeDefined();
       spyOn(friend, 'monitor');
       // Monitoring is still running.
-      jasmine.clock().tick(5000);
+      jasmine.clock().tick(60000);
       expect(friend.monitor).toHaveBeenCalled();
 
       network.logout().then(() => {
         (<any>friend.monitor).calls.reset();
-        jasmine.clock().tick(5000);
+        jasmine.clock().tick(60000);
         expect(friend.monitor).not.toHaveBeenCalled();
         jasmine.clock().uninstall();
       }).then(done);

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -585,7 +585,7 @@ module Social {
           this.getUser(userId).monitor();
         }
       };
-      this.monitorIntervalId_ = setInterval(monitorCallback, 5000);
+      this.monitorIntervalId_ = setInterval(monitorCallback, 60000);
     }
 
     private stopMonitor_ = () : void => {


### PR DESCRIPTION
We believe this monitoring doesn't really give us much, We should have instances for all clientIds that are ONLINE. ONLINE means user is online with uproxy.

But for some weird case that we saw from user log I see that uproxy keeps sending instance_request for some client ids. These are all jabber... user ids.

I believe user is not really online with uproxy, but for some reason social provider gives us ONLINE, We'd like to investigate this, but for now to avoid xmpp throttling us we'll increase the monitoring interval to 1 minute.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1244)
<!-- Reviewable:end -->
