### PR TITLE
Show troubleshoot dialog on sharer's side. Keep error flow within popup dialog.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "core-header-panel": "Polymer/core-header-panel#~0.5.5",
     "core-drawer-panel": "Polymer/core-drawer-panel#~0.5.5",
     "core-overlay": "Polymer/core-overlay#~0.5.5",
-    "lodash": "~3.6.0"
+    "lodash": "~3.6.0",
+    "paper-toast": "Polymer/paper-toast#~0.5.5"
   }
 }

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -127,10 +127,9 @@ module Core {
 
     public stopShare = () :Promise<void> => {
       if (this.localSharingWithRemote === SharingState.NONE) {
-        log.warn('Cannot stop sharing when not sharing');
+        log.warn('Cannot stop sharing when neither sharing nor trying to share.');
         return Promise.resolve<void>();
       }
-
       this.localSharingWithRemote = SharingState.NONE;
       this.stateRefresh_();
       this.rtcToNet_.close();

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -101,7 +101,7 @@ module Core {
         this.bytesSent_ = 0;
         this.bytesReceived_ = 0;
         this.stateRefresh_();
-        return new Promise<void>((F, R) => {F();});
+        return Promise.resolve<void>();
       });
 
       this.localSharingWithRemote = SharingState.TRYING_TO_SHARE_ACCESS;
@@ -126,9 +126,9 @@ module Core {
     }
 
     public stopShare = () :Promise<void> => {
-      if (this.localSharingWithRemote !== SharingState.NONE) {
+      if (this.localSharingWithRemote === SharingState.NONE) {
         log.warn('Cannot stop sharing when not sharing');
-        return new Promise<void>((F, R) => {F();});
+        return Promise.resolve<void>();
       }
 
       this.localSharingWithRemote = SharingState.NONE;

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -119,6 +119,9 @@ module Core {
       return this.rtcToNet_.onceReady;
     }
 
+    // This must be called as soon as you receive an OFFER signal from your peer.
+    // Otherwise, CANDIDATE signals can be dropped or handled by old rtcToNet_
+    // instances.
     public resetRtcToNetCreated = () :void => {
       this.rtcToNetCreated = new Promise<void>((F, R) => {
         this.fulfillRtcToNetCreated_ = F;

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -26,9 +26,9 @@ module Core {
     // Resolve this promise when rtcToNet is created and therefore not null.
     // Used to help determine when to call handleSignal (which relies
     // on rtcToNet or socksToRtc being not null).
-    // The promise is reset in resetRtcToNetCreated().
-    public onceRtcToNetCreated :Promise<void> = null;
-    // Helper function used to fulfill onceRtcToNetCreated.
+    // The promise is reset in resetSharerCreated().
+    public onceSharerCreated :Promise<void> = null;
+    // Helper function used to fulfill onceSharerCreated.
     private fulfillRtcToNetCreated_ :Function;
     private sharingReset_ :Promise<void> = null;
 
@@ -39,7 +39,7 @@ module Core {
       sendUpdate :(x :uProxy.Update, data?:Object) => void
     ) {
       this.sendUpdate_ = sendUpdate;
-      this.resetRtcToNetCreated();
+      this.resetSharerCreated();
     }
 
     private createSender_ = (type :uProxy.MessageType) => {
@@ -124,8 +124,8 @@ module Core {
     // this function so that CANDIDATEs received after the new OFFER will know to wait
     // for a new rtcToNet_ instance to be created. Otherwise, CANDIDATE signals can be
     // dropped or handled by old rtcToNet_ instances.
-    public resetRtcToNetCreated = () :void => {
-      this.onceRtcToNetCreated = new Promise<void>((F, R) => {
+    public resetSharerCreated = () :void => {
+      this.onceSharerCreated = new Promise<void>((F, R) => {
         this.fulfillRtcToNetCreated_ = F;
       });
     }

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -27,8 +27,8 @@ module Core {
     // Used to help determine when to call handleSignal (which relies
     // on rtcToNet or socksToRtc being not null).
     // The promise is reset in resetRtcToNetCreated().
-    public rtcToNetCreated :Promise<void> = null;
-    // Helper function used to fulfill rtcToNetCreated.
+    public onceRtcToNetCreated :Promise<void> = null;
+    // Helper function used to fulfill onceRtcToNetCreated.
     private fulfillRtcToNetCreated_ :Function;
     private sharingReset_ :Promise<void> = null;
 
@@ -125,7 +125,7 @@ module Core {
     // for a new rtcToNet_ instance to be created. Otherwise, CANDIDATE signals can be
     // dropped or handled by old rtcToNet_ instances.
     public resetRtcToNetCreated = () :void => {
-      this.rtcToNetCreated = new Promise<void>((F, R) => {
+      this.onceRtcToNetCreated = new Promise<void>((F, R) => {
         this.fulfillRtcToNetCreated_ = F;
       });
     }

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -67,7 +67,7 @@ module Core {
       target.handleSignalFromPeer(msg);
     };
 
-    public startShare = () => {
+    public startShare = () :Promise<void> => {
       this.rtcToNet_ = new RtcToNet.RtcToNet(
         <freedom_RTCPeerConnection.RTCConfiguration> {
           iceServers: core.globalSettings.stunServers
@@ -102,6 +102,7 @@ module Core {
         this.stateRefresh_();
         this.rtcToNet_ = null;
       });
+      return this.rtcToNet_.onceReady;
     }
 
     public stopShare = () :Promise<void> => {

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -26,8 +26,10 @@ module Core {
     // Resolve this promise when rtcToNet is created and therefore not null.
     // Used to help determine when to call handleSignal (which relies
     // on rtcToNet or socksToRtc being not null).
-    // The promise is defined in resetRtcToNetCreated().
-    public rtcToNetCreated :Promise<void> = null;
+    // The promise is reset in resetRtcToNetCreated().
+    public rtcToNetCreated :Promise<void> = new Promise<void>((F, R) => {
+      this.fulfillRtcToNetCreated_ = F;
+    });
     // Helper function used to fulfill rtcToNetCreated.
     private fulfillRtcToNetCreated_ :Function;
     private sharingReseted_ :Promise<void> = null;

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -233,39 +233,48 @@ describe('Core.RemoteInstance', () => {
       spyOn(RtcToNet, 'RtcToNet').and.returnValue(fakeRtcToNet);
     });
 
-    it('ignores CANDIDATE signal from client peer as server without OFFER', () => {
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate);
-      expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+    it('ignores CANDIDATE signal from client peer as server without OFFER', (done) => {
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate).then(() => {
+        expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
+        expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('handles OFFER signal from client peer as server', () => {
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeOffer);
-      expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(fakeRtcToNet.handleSignalFromPeer).toHaveBeenCalledWith(fakeOffer);
+    it('handles OFFER signal from client peer as server', (done) => {
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeOffer).then(() => {
+        expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
+        expect(fakeRtcToNet.handleSignalFromPeer).toHaveBeenCalledWith(fakeOffer);
+        done();
+      });
     });
 
     it('handles signal from server peer as client', (done) => {
       alice.wireConsentFromRemote.isOffering = true;
       alice.start().then(() => {
-        alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate);
-        expect(fakeSocksToRtc.handleSignalFromPeer).toHaveBeenCalledWith(fakeCandidate);
-        expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
-        done();
+        alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate).then(() => {
+          expect(fakeSocksToRtc.handleSignalFromPeer).toHaveBeenCalledWith(fakeCandidate);
+          expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+          done();
+        });
       }).catch((e) => console.error('error calling start: ' + e));
     });
 
-    it('rejects invalid signals', () => {
-      alice.handleSignal(uProxy.MessageType.INSTANCE, fakeCandidate);
-      expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
+    it('rejects invalid signals', (done) => {
+      alice.handleSignal(uProxy.MessageType.INSTANCE, fakeCandidate).then(() => {
+        expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+        expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
+        done();
+      });
     });
 
-    it('rejects message from client if consent has not been granted', () => {
+    it('rejects message from client if consent has not been granted', (done) => {
       alice.user.consent.localGrantsAccessToRemote = false;
-      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate);
-      expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
-      expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+      alice.handleSignal(uProxy.MessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate).then(() => {
+        expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
+        expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
+        done();
+      });
     });
   });
 });

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -170,7 +170,7 @@ module Core {
         // If the remote peer sent signal as the client, we act as server.
         if (!this.user.consent.localGrantsAccessToRemote) {
           log.warn('Remote side attempted access without permission');
-          return;
+          return Promise.resolve<void>();
         }
 
         // Create a new rtcToNet object everytime there is an OFFER signal.

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -162,19 +162,20 @@ module Core {
           return;
         }
 
-        // Create a new rtcToNet object everytime there is an OFFER signal
+        // Create a new rtcToNet object everytime there is an OFFER signal.
         if (signalFromRemote['type'] == WebRtc.SignalType.OFFER) {
           this.connection_.resetRtcToNetCreated();
           this.startShare_();
         }
-
-          this.connection_.rtcToNetCreated.then(() => {
-            this.connection_.handleSignal({
-              type: type,
-              data: signalFromRemote
-            });
+        // Wait for the new rtcToNet instance to be created before you handle
+        // additional messages from a client peer.
+        this.connection_.rtcToNetCreated.then(() => {
+          this.connection_.handleSignal({
+            type: type,
+            data: signalFromRemote
           });
-          return;
+        });
+        return;
 
         /*
         TODO: Uncomment when getter sends a cancel signal if socksToRtc closes while
@@ -184,7 +185,8 @@ module Core {
         } else if (signalFromRemote['type'] == WebRtc.SignalType.CANCEL_OFFER) {
           this.stopShare();
           return;
-        }*/
+        }
+        */
       }
 
       this.connection_.handleSignal({

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -182,7 +182,7 @@ module Core {
       this.startupTimeout_ = setTimeout(() => {
         log.warn('Timing out rtcToNet_ connection');
         this.connection_.stopShare();
-        ui.update(uProxy.Update.FRIEND_FAILED_TO_GET);
+        ui.update(uProxy.Update.FRIEND_FAILED_TO_GET, this.user.name);
       }, this.RTC_TO_NET_TIMEOUT);
       this.connection_.startShare().then(() => {
         this.clearTimeout_();

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -177,6 +177,9 @@ module Core {
       * we should try to start sharing.
       */
     private startShare_ = () => {
+      // Clear pending timeout, if one exists, so that we are only concerned
+      // with the most recent click to startShare.
+      this.clearTimeout_();
       // Cancel rtcToNet_ connection if start hasn't completed in 45 seconds.
       this.startupTimeout_ = setTimeout(() => {
         log.warn('Timing out rtcToNet_ connection');

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -78,6 +78,9 @@ module Core {
     // reject to indicate the remote connection is not ready to accept signals.
     // Only if the peer sent an OFFER signal and an rtcToNet instance is created
     // will this fulfill.
+    // TODO: to make it clearer what this promise is waiting for, change to
+    // something like:
+    // Promise.all([this.receivedOffer_, this.connection_.onceRtcToNetCreated])
     private onceSharerReadyForOffer_ :Promise<void>;
 
     /**
@@ -172,10 +175,10 @@ module Core {
 
         // Create a new rtcToNet object everytime there is an OFFER signal.
         if (signalFromRemote['type'] == WebRtc.SignalType.OFFER) {
-          // TODO: Move the logic for resetting the rtcToNetCreated promise inside
+          // TODO: Move the logic for resetting the onceRtcToNetCreated promise inside
           // remote-connection.ts.
           this.connection_.resetRtcToNetCreated();
-          this.onceSharerReadyForOffer_ = this.connection_.rtcToNetCreated;
+          this.onceSharerReadyForOffer_ = this.connection_.onceRtcToNetCreated;
           this.startShare_();
         }
         // Wait for the new rtcToNet instance to be created before you handle

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -193,6 +193,7 @@ module Core {
         TODO: Uncomment when getter sends a cancel signal if socksToRtc closes while
         trying to connect. Something like:
         https://github.com/uProxy/uproxy-lib/tree/lucyhe-emitcancelsignal
+        Issue: https://github.com/uProxy/uproxy/issues/1256
 
         } else if (signalFromRemote['type'] == WebRtc.SignalType.CANCEL_OFFER) {
           this.stopShare();

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -80,7 +80,7 @@ module Core {
     // will this fulfill.
     // TODO: to make it clearer what this promise is waiting for, change to
     // something like:
-    // Promise.all([this.receivedOffer_, this.connection_.onceRtcToNetCreated])
+    // Promise.all([this.receivedOffer_, this.connection_.onceSharerCreated])
     private onceSharerReadyForOffer_ :Promise<void>;
 
     /**
@@ -175,10 +175,10 @@ module Core {
 
         // Create a new rtcToNet object everytime there is an OFFER signal.
         if (signalFromRemote['type'] == WebRtc.SignalType.OFFER) {
-          // TODO: Move the logic for resetting the onceRtcToNetCreated promise inside
+          // TODO: Move the logic for resetting the onceSharerCreated promise inside
           // remote-connection.ts.
-          this.connection_.resetRtcToNetCreated();
-          this.onceSharerReadyForOffer_ = this.connection_.onceRtcToNetCreated;
+          this.connection_.resetSharerCreated();
+          this.onceSharerReadyForOffer_ = this.connection_.onceSharerCreated;
           this.startShare_();
         }
         // Wait for the new rtcToNet instance to be created before you handle

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -172,6 +172,8 @@ module Core {
 
         // Create a new rtcToNet object everytime there is an OFFER signal.
         if (signalFromRemote['type'] == WebRtc.SignalType.OFFER) {
+          // TODO: Move the logic for resetting the rtcToNetCreated promise inside
+          // remote-connection.ts.
           this.connection_.resetRtcToNetCreated();
           this.onceSharerReadyForOffer_ = this.connection_.rtcToNetCreated;
           this.startShare_();

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -22,12 +22,13 @@
     paper-button {
       background: #009688;  /* dark green */
       color: white;
+      margin-bottom: 24px;
     }
     paper-button.stop {
       background: rgb(221, 221, 221);
       color: rgb(112, 112, 112);
     }
-    #getting, #sharing {
+    #getting, #sharing, #nothing {
       margin: 24px;
     }
     a {
@@ -45,6 +46,7 @@
     <uproxy-app-bar disableback='{{ ui.copyPasteGettingState === GettingState.GETTING_ACCESS || ui.copyPasteSharingState === SharingState.SHARING_ACCESS }}' on-go-back='{{ handleBackClick }}'>
       <span hidden?='{{ SharingState.NONE === ui.copyPasteSharingState }}'>Share a </span>
       <span hidden?='{{ SharingState.NONE !== ui.copyPasteSharingState || GettingState.NONE === ui.copyPasteGettingState }}'>Request a </span>
+      <span hidden?='{{ SharingState.NONE !== ui.copyPasteSharingState || !(SharingState.NONE !== ui.copyPasteSharingState || GettingState.NONE === ui.copyPasteGettingState) }}'>Start a </span>
       <span>one-time connection</span>
     </uproxy-app-bar>
 

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -12,6 +12,7 @@ Polymer({
     // Expose global ui object and UI module in this context. This allows the
     // hidden? watch for the get/give toggle to actually update.
     this.ui = ui;
+    this.UI = UI;
     this.uProxy = uProxy;
     this.GettingState = GettingState;
     this.model = model;
@@ -39,14 +40,7 @@ Polymer({
         // if the failure is because of a user action, do nothing
         return;
       }
-      ui.failedToGet = true;
-      this.fire('core-signal', {
-        name: 'show-toast',
-        data: {
-          text: 'Unable to get access from ' + this.user.name
-        }
-      });
-
+      ui.toastMessage = UI.GET_FAILED_MSG + this.user.name;
       ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
     });

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -31,6 +31,9 @@ Polymer({
       }
 
       this.fire('core-signal', {name: 'open-troubleshoot'});
+      this.fire('core-signal', {name: 'show-toast',
+                                data: {text: 'Unable to get access from ' + this.user.name}});
+
       ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
     });

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -19,12 +19,7 @@ Polymer({
   },
   start: function() {
     if (!this.instance.isOnline) {
-      this.fire('core-signal', {
-        name: 'show-toast',
-        data: {
-          text: this.user.name + ' is offline'
-        }
-      });
+      this.ui.toastMessage = this.user.name + ' is offline';
       return;
     }
 

--- a/src/generic_ui/polymer/link.html
+++ b/src/generic_ui/polymer/link.html
@@ -16,7 +16,7 @@ Usage: <uproxy-link role='(button|link)' on-tap='{{ EVENT }}'>CONTENT</uproxy-li
       }
     </style>
 
-    <span tabindex='0'>
+    <span tabindex='0' id='linkText'>
       <content></content>
     </span>
 

--- a/src/generic_ui/polymer/link.html
+++ b/src/generic_ui/polymer/link.html
@@ -16,7 +16,7 @@ Usage: <uproxy-link role='(button|link)' on-tap='{{ EVENT }}'>CONTENT</uproxy-li
       }
     </style>
 
-    <span tabindex='0' id='linkText'>
+    <span tabindex='0'>
       <content></content>
     </span>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -140,11 +140,12 @@
         z-index: 1002; /* Must be greater than core-overlay-backdrop */
       }
       paper-toast {
+        position: fixed;
         left: 12px;
         right: 12px;
         background-color: #283230;
         padding: 16px 16px 12px 20px;
-        position: fixed;
+        font-size: 12px;
       }
       .toastHelpLink {
         color: #47B5AA;
@@ -277,9 +278,9 @@
         text='{{ ui.toastMessage }}'
         responsiveWidth='320px'>
       <div class='toastHelpLink' on-tap="{{ troubleshootForGetter }}"
-          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) }}'>HELP</div>
+          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) }}'>GET HELP</div>
       <div class='toastHelpLink' on-tap="{{ troubleshootForSharer }}"
-          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>HELP</div>
+          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>GET HELP</div>
     </paper-toast>
 
   </template>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -144,6 +144,10 @@
         right: 12px;
         background-color: #283230;
         padding: 16px 16px 12px 20px;
+        position: fixed;
+      }
+      .toastHelpLink {
+        color: #47B5AA;
       }
       core-icon[icon="launch"] {
         margin-bottom: 6px;
@@ -267,9 +271,15 @@
 
     <uproxy-troubleshoot></uproxy-troubleshoot>
 
-    <paper-toast id='toast' style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;' responsiveWidth='320px' duration='30000'>
-      <core-icon icon='launch' on-tap='{{ troubleshootForGetter }}' hidden?='{{ !ui.failedToGet }}'></core-icon>
-      <core-icon icon='launch' on-tap='{{ troubleshootForSharer }}' hidden?='{{ !ui.failedToShare }}'></core-icon>
+    <paper-toast id='toast'
+        opened='{{ messageNotNull(ui.toastMessage) }}'
+        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'
+        text='{{ ui.toastMessage }}'
+        responsiveWidth='320px'>
+      <div class='toastHelpLink' on-tap="{{ troubleshootForGetter }}"
+          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) }}'>HELP</div>
+      <div class='toastHelpLink' on-tap="{{ troubleshootForSharer }}"
+          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>HELP</div>
     </paper-toast>
 
   </template>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../lib/core-icon-button/core-icon-button.html">
 <link rel='import' href='../lib/paper-dialog/paper-action-dialog.html'>
 <link rel="import" href="../lib/paper-tabs/paper-tabs.html">
+<link rel="import" href="../lib/paper-toast/paper-toast.html">
 <link rel="import" href="../lib/core-tooltip/core-tooltip.html">
 <link rel="import" href='splash.html'>
 <link rel="import" href='roster.html'>
@@ -138,12 +139,28 @@
         top: 20%;
         z-index: 1002; /* Must be greater than core-overlay-backdrop */
       }
+      paper-toast {
+        left: 12px;
+        right: 12px;
+        background-color: #283230;
+        padding: 16px 16px 12px 20px;
+      }
+      core-icon[icon="launch"] {
+        margin-bottom: 6px;
+        height: 18px;
+        width: 18px;
+        color: #47B5AA;
+        -webkit-transition: all 0.23s !important;
+        -moz-transition: all 0.23s !important;
+        transition: all 0.23s !important;
+      }
       .core-overlay-backdrop {
         z-index: 1001;
       }
     </style>
 
     <core-signals on-core-signal-close-settings="{{ closeSettings }}"></core-signals>
+    <core-signals on-core-signal-show-toast="{{ showToast }}"></core-signals>
 
     <div id='browserElementContainer' hidden?='{{uProxy.View.BROWSER_ERROR !== ui.view}}'></div>
 
@@ -249,6 +266,10 @@
     </paper-action-dialog>
 
     <uproxy-troubleshoot></uproxy-troubleshoot>
+
+    <paper-toast id='toast' style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;' responsiveWidth='320px' duration='30000'>
+      <core-icon icon='launch' style='color: #009688;' on-tap='{{ setGetMode }}'>
+    </paper-toast>
 
   </template>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -270,13 +270,12 @@
       </template>
     </paper-action-dialog>
 
-    <uproxy-troubleshoot></uproxy-troubleshoot>
+    <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>
 
     <paper-toast id='toast'
         opened='{{ messageNotNull(ui.toastMessage) }}'
-        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'
-        text='{{ ui.toastMessage }}'
-        responsiveWidth='320px'>
+        text='{{ ui.toastMessage }}' responsiveWidth='320px'
+        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'>
       <div class='toastHelpLink' on-tap="{{ troubleshootForGetter }}"
           hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) }}'>GET HELP</div>
       <div class='toastHelpLink' on-tap="{{ troubleshootForSharer }}"

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -278,7 +278,7 @@
         text='{{ ui.toastMessage }}' responsiveWidth='320px'
         style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'>
       <div id='toastHelpLink' on-tap="{{ openTroubleshoot }}"
-          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) && !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>GET HELP
+          hidden?='{{ !stringMatches(ui.toastMessage, UI.GET_FAILED_MSG) && !stringMatches(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>GET HELP
       </div>
     </paper-toast>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -151,22 +151,12 @@
       #toastHelpLink {
         color: #47B5AA;
       }
-      core-icon[icon="launch"] {
-        margin-bottom: 6px;
-        height: 18px;
-        width: 18px;
-        color: #47B5AA;
-        -webkit-transition: all 0.23s !important;
-        -moz-transition: all 0.23s !important;
-        transition: all 0.23s !important;
-      }
       .core-overlay-backdrop {
         z-index: 1001;
       }
     </style>
 
     <core-signals on-core-signal-close-settings="{{ closeSettings }}"></core-signals>
-    <core-signals on-core-signal-show-toast="{{ showToast }}"></core-signals>
 
     <div id='browserElementContainer' hidden?='{{uProxy.View.BROWSER_ERROR !== ui.view}}'></div>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -147,7 +147,7 @@
         padding: 16px 16px 12px 20px;
         font-size: 12px;
       }
-      .toastHelpLink {
+      #toastHelpLink {
         color: #47B5AA;
       }
       core-icon[icon="launch"] {
@@ -276,10 +276,9 @@
         opened='{{ messageNotNull(ui.toastMessage) }}'
         text='{{ ui.toastMessage }}' responsiveWidth='320px'
         style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'>
-      <div class='toastHelpLink' on-tap="{{ troubleshootForGetter }}"
-          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) }}'>GET HELP</div>
-      <div class='toastHelpLink' on-tap="{{ troubleshootForSharer }}"
-          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>GET HELP</div>
+      <div id='toastHelpLink' on-tap="{{ openTroubleshoot }}"
+          hidden?='{{ !messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG) && !messageMatchesFailure(ui.toastMessage, UI.SHARE_FAILED_MSG) }}'>GET HELP
+      </div>
     </paper-toast>
 
   </template>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -116,14 +116,13 @@ Polymer({
     }
     return false;
   },
-  troubleshootForGetter: function() {
+  openTroubleshoot: function() {
+    if (this.messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG)) {
+      this.troubleshootTitle = "Unable to get access";
+    } else {
+      this.troubleshootTitle = "Unable to share access";
+    }
     this.closeToast();
-    this.troubleshootTitle = "Unable to get access";
-    this.fire('core-signal', {name: 'open-troubleshoot'});
-  },
-  troubleshootForSharer: function() {
-    this.closeToast();
-    this.troubleshootTitle = "Unable to share access";
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   messageMatchesFailure: function(toastMessage, failureMsgConstant) {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -75,14 +75,24 @@ Polymer({
       this.fire('core-signal', { name: signal });
     }
   },
+  closeToast: function() {
+    this.ui.toastMessage = null;
+  },
+  messageNotNull: function(toastMessage) {
+    if (toastMessage) {
+      clearTimeout(this.clearToastTimeout);
+      this.clearToastTimeout = setTimeout(this.closeToast, 10000);
+      return true;
+    }
+    return false;
+  }
   ready: function() {
     // Expose global ui object and UI module in this context.
     this.ui = ui;
+    this.UI = UI;
     this.uProxy = uProxy;
     this.model = model;
-    this.failedToShare = false;
-    this.failedToGet = false;
-    this.
+    this.closeToastTimeout = null;
     if(ui.browserApi.browserSpecificElement){
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
@@ -94,18 +104,21 @@ Polymer({
     core.updateGlobalSettings(model.globalSettings);
   },
   troubleshootForGetter: function() {
+    this.closeToast();
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   troubleshootForSharer: function() {
+    this.closeToast();
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   showToast: function(e, data) {
-    this.$.toast.setAttribute('text', data.text);
-    this.$.toast.show();
-    this.$.toast.addEventListener('core-overlay-close-completed', () => {
-      this.ui.failedToGet = false;
-      this.ui.failedToShare = false;
-    });
+    this.ui.toastMessage = data.text;
+  },
+  messageMatchesFailure: function(toastMessage, failureMsgConstant) {
+    if (toastMessage) {
+      return toastMessage.indexOf(failureMsgConstant) > -1;
+    }
+    return false;
   },
   signalToFireChanged: function() {
     if (this.ui.signalToFire != '') {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -90,13 +90,21 @@ Polymer({
     // to sync the value to core
     core.updateGlobalSettings(model.globalSettings);
   },
-  signalToFireChanged: function() {
-    if (this.ui.signalToFire != '') {
-      this.fire('core-signal', {name: this.ui.signalToFire});
-      this.ui.signalToFire = '';
+  showToast: function(e, data) {
+    this.$.toast.setAttribute('text', data.text);
+    if (data.sharingError) {
+      this.sharingError = true;
+    } else if (data.gettingError) {
+      this.gettingError = true;
     }
+    this.$.toast.show();
   },
-  observe: {
-    'ui.signalToFire' : 'signalToFireChanged'
+  topOfStatuses: function(gettingStatus, sharingStatus) {
+    if (gettingStatus && sharingStatus) {
+      return 126;
+    } else if (gettingStatus || sharingStatus) {
+      return 68;
+    }
+    return 10;
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -75,17 +75,6 @@ Polymer({
       this.fire('core-signal', { name: signal });
     }
   },
-  closeToast: function() {
-    this.ui.toastMessage = null;
-  },
-  messageNotNull: function(toastMessage) {
-    if (toastMessage) {
-      clearTimeout(this.clearToastTimeout);
-      this.clearToastTimeout = setTimeout(this.closeToast, 10000);
-      return true;
-    }
-    return false;
-  }
   ready: function() {
     // Expose global ui object and UI module in this context.
     this.ui = ui;
@@ -103,6 +92,30 @@ Polymer({
     // to sync the value to core
     core.updateGlobalSettings(model.globalSettings);
   },
+  signalToFireChanged: function() {
+    if (this.ui.signalToFire != '') {
+      this.fire('core-signal', {name: this.ui.signalToFire});
+      this.ui.signalToFire = '';
+    }
+  },
+  /* All functions below help manage paper-toast behaviour. */
+  showToast: function(e, data) {
+    this.ui.toastMessage = data.text;
+  },
+  closeToast: function() {
+    this.ui.toastMessage = null;
+  },
+  messageNotNull: function(toastMessage) {
+    // Whether the toast is shown is controlled by if ui.toastMessage
+    // is null. This function returns whether ui.toastMessage == null,
+    // and also sets a timeout to close the toast.
+    if (toastMessage) {
+      clearTimeout(this.clearToastTimeout);
+      this.clearToastTimeout = setTimeout(this.closeToast, 10000);
+      return true;
+    }
+    return false;
+  },
   troubleshootForGetter: function() {
     this.closeToast();
     this.troubleshootTitle = "Unable to get access";
@@ -113,27 +126,27 @@ Polymer({
     this.troubleshootTitle = "Unable to share access";
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
-  showToast: function(e, data) {
-    this.ui.toastMessage = data.text;
-  },
   messageMatchesFailure: function(toastMessage, failureMsgConstant) {
+    // Determine if the error in the toast is a getter or sharer error
+    // by comparing the error string to getter/sharer error constants.
     if (toastMessage) {
       return toastMessage.indexOf(failureMsgConstant) > -1;
     }
     return false;
   },
-  signalToFireChanged: function() {
-    if (this.ui.signalToFire != '') {
-      this.fire('core-signal', {name: this.ui.signalToFire});
-      this.ui.signalToFire = '';
-    }
-  },
   topOfStatuses: function(gettingStatus, sharingStatus) {
+    // Returns number of pixels from the bottom of the window a toast
+    // can be positioned without interfering with the getting or sharing
+    // status bars.
+    var padding = 10;
+    var statusRowHeight = 58; // From style of the statusRow divs.
     if (gettingStatus && sharingStatus) {
-      return 126;
+      return 2 * statusRowHeight + padding;
     } else if (gettingStatus || sharingStatus) {
-      return 68;
+      return statusRowHeight + padding;
     }
-    return 10;
+    // If there are no status bars, toasts should still 'float' a little
+    // above the bottom of the window.
+    return padding;
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -99,9 +99,6 @@ Polymer({
     }
   },
   /* All functions below help manage paper-toast behaviour. */
-  showToast: function(e, data) {
-    this.ui.toastMessage = data.text;
-  },
   closeToast: function() {
     this.ui.toastMessage = null;
   },

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -117,7 +117,7 @@ Polymer({
     return false;
   },
   openTroubleshoot: function() {
-    if (this.messageMatchesFailure(ui.toastMessage, UI.GET_FAILED_MSG)) {
+    if (this.stringMatches(ui.toastMessage, UI.GET_FAILED_MSG)) {
       this.troubleshootTitle = "Unable to get access";
     } else {
       this.troubleshootTitle = "Unable to share access";
@@ -125,7 +125,7 @@ Polymer({
     this.closeToast();
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
-  messageMatchesFailure: function(toastMessage, failureMsgConstant) {
+  stringMatches: function(toastMessage, failureMsgConstant) {
     // Determine if the error in the toast is a getter or sharer error
     // by comparing the error string to getter/sharer error constants.
     if (toastMessage) {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -134,6 +134,10 @@ Polymer({
     // Returns number of pixels from the bottom of the window a toast
     // can be positioned without interfering with the getting or sharing
     // status bars.
+    // Since the toast always looks for the bottom of the window, not the
+    // bottom of its parent element, this function is needed to control toast
+    // placement rather than a simpler solution such as moving the toast
+    // inside the roster element.
     var padding = 10;
     var statusRowHeight = 58; // From style of the statusRow divs.
     if (gettingStatus && sharingStatus) {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -105,10 +105,12 @@ Polymer({
   },
   troubleshootForGetter: function() {
     this.closeToast();
+    this.troubleshootTitle = "Unable to get access";
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   troubleshootForSharer: function() {
     this.closeToast();
+    this.troubleshootTitle = "Unable to share access";
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   showToast: function(e, data) {

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -70,7 +70,7 @@
     paper-progress::shadow #activeProgress {
       background-color: #009688;
     }
-    uproxy-faq-link /deep/ #linkText {
+    uproxy-faq-link .linkText {
       text-decoration: underline;
       color: rgba(0,0,0,0.40);
     }
@@ -107,10 +107,14 @@
 
       <!-- Third screen in dialog shows NAT type and asks user if they want to submit feedback. -->
       <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
-        It looks like you are on a <b>{{ natType }}</b>, which is <b>{{ natDescription }}</b> interfering with your ability to connect to friends.
-        <uproxy-faq-link anchor='doesUproxyLogData'>More info</uproxy-faq-link><br><br>
+        It looks like you are on a <strong>{{ natType }}</strong>, which is <strong>{{ natImpact }}</strong> interfering with your ability to connect to friends.
+        <uproxy-faq-link anchor='doesUproxyLogData'>
+          <span class='linkText'>More info</span>
+        </uproxy-faq-link><br><br>
         Would you like to submit your NAT type to the uProxy team, to help us better understand the networks our users are on?
-        <uproxy-faq-link anchor='doesUproxyLogData'>Privacy policy</uproxy-faq-link>
+        <uproxy-faq-link anchor='doesUproxyLogData'>
+          <span class='linkText'>Privacy policy</span>
+        </uproxy-faq-link>
         <br>
         <div id='analyzedNetworkButtons'>
           <paper-button on-tap='{{ submitFeedback }}'>
@@ -127,4 +131,3 @@
   </template>
   <script src='troubleshoot.js'></script>
 </polymer-element>
-

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -6,7 +6,7 @@
 <link rel='import' href='../lib/core-signals/core-signals.html'>
 <link rel='import' href='faq-link.html'>
 
-<polymer-element name='uproxy-troubleshoot'>
+<polymer-element name='uproxy-troubleshoot' attributes='titleText'>
   <template>
     <style>
     :host {
@@ -51,8 +51,29 @@
       min-width: 305px;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
     }
-    paper-action-dialog::shadow #scroller {
-      padding: 18px 20px 0px 20px;
+    paper-dialog::shadow #scroller {
+      padding: 12px;
+    }
+    #askToAnalyze, #analyzeNetwork, #analyzedNetwork {
+      padding: 0px 15px 15px;
+      color: rgba(0,0,0,0.55);
+    }
+    #analyzeNetwork {
+      text-align: center;
+      font-size: 14px;
+    }
+    #analyzedNetwork {
+      text-align: left;
+    }
+    #analyzedNetworkButtons {
+      text-align: center;
+    }
+    paper-progress::shadow #activeProgress {
+      background-color: #009688;
+    }
+    uproxy-faq-link /deep/ #linkText {
+      text-decoration: underline;
+      color: rgba(0,0,0,0.40);
     }
     </style>
 
@@ -61,23 +82,46 @@
 
     <paper-dialog backdrop layered='false' id='troubleshootDialog'>
       <core-icon class="button" icon="clear" on-tap='{{ close }}'></core-icon>
-      <h1>Unable to proxy</h1>
-      <div>
+      <h1>{{ titleText }}</h1>
+      <div id='askToAnalyze' hidden?='{{ analyzingNetwork || analyzedNetwork }}'>
         <p>
-          Something went wrong. Would you like uProxy to diagnose your network?
+          It could be that your network's NAT type is incompatible with uProxy. Would you like to uProxy to analyze your network?
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link><br>
         </p>
-        <paper-button on-tap='{{ analyzeNetworkAndViewLogs }}'>
-          Analyze Network
-        </paper-button><br>
-        <paper-button on-tap='{{ submitFeedback }}'>
-          Submit Feedback
+        <paper-button on-tap='{{ getNatType }}'>
+          Yes
+        </paper-button>
+        <paper-button on-tap='{{ close }}'>
+          No
         </paper-button>
       </div>
+
+      <div id='analyzeNetwork' hidden?='{{ !analyzingNetwork }}'>
+        Analyzing network<br>
+        <paper-progress indeterminate='true'></paper-progress>
+      </div>
+      <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
+        It looks like you are on a <b>{{ natType }}</b>, which is <b>{{ natDescription }}</b> interfering with your ability to connect to friends.
+        <uproxy-faq-link anchor='doesUproxyLogData'>More info</uproxy-faq-link><br><br>
+          <!-- <core-icon icon="help"></core-icon> -->
+        Would you like to submit your NAT type to the uProxy team, to help us better understand the networks our users are on?
+        <uproxy-faq-link anchor='doesUproxyLogData'>Privacy policy</uproxy-faq-link>
+        <br>
+        <div id='analyzedNetworkButtons'>
+          <paper-button on-tap='{{ submitFeedback }}'>
+            Yes
+          </paper-button>
+          <paper-button on-tap='{{ close }}'>
+            No
+          </paper-button>
+        </div>
+      </div>
+
     </paper-dialog>
 
   </template>
   <script src='troubleshoot.js'></script>
 </polymer-element>
+

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -11,7 +11,6 @@
     <style>
     :host {
       text-align: center;
-      font-color: #009688;  /* dark green */
     }
     h1 {
       font-size: 1.5em;
@@ -83,6 +82,8 @@
     <paper-dialog backdrop layered='false' id='troubleshootDialog'>
       <core-icon class="button" icon="clear" on-tap='{{ close }}'></core-icon>
       <h1>{{ titleText }}</h1>
+
+      <!-- First screen in the dialog asks user if they want to diagnose their network. -->
       <div id='askToAnalyze' hidden?='{{ analyzingNetwork || analyzedNetwork }}'>
         <p>
           It could be that your network's NAT type is incompatible with uProxy. Would you like to uProxy to analyze your network?
@@ -98,14 +99,16 @@
         </paper-button>
       </div>
 
+      <!-- Second screen in dialog shows a loading bar as we get NAT type. -->
       <div id='analyzeNetwork' hidden?='{{ !analyzingNetwork }}'>
         Analyzing network<br>
         <paper-progress indeterminate='true'></paper-progress>
       </div>
+
+      <!-- Third screen in dialog shows NAT type and asks user if they want to submit feedback. -->
       <div id='analyzedNetwork' hidden?='{{ !analyzedNetwork }}'>
         It looks like you are on a <b>{{ natType }}</b>, which is <b>{{ natDescription }}</b> interfering with your ability to connect to friends.
         <uproxy-faq-link anchor='doesUproxyLogData'>More info</uproxy-faq-link><br><br>
-          <!-- <core-icon icon="help"></core-icon> -->
         Would you like to submit your NAT type to the uProxy team, to help us better understand the networks our users are on?
         <uproxy-faq-link anchor='doesUproxyLogData'>Privacy policy</uproxy-faq-link>
         <br>

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -16,11 +16,11 @@ Polymer({
     core.getNatType().then((natType) => {
       this.natType = natType;
       if (natType === 'SymmetricNAT') {
-        this.natDescription = 'very likely';
+        this.natImpact = 'very likely';
       } else if (natType === 'PortRestrictedCone') {
-        this.natDescription = 'possibly'
+        this.natImpact = 'possibly'
       } else {
-        this.natDescription = 'unlikely'
+        this.natImpact = 'unlikely'
       }
       this.analyzingNetwork = false;
       this.analyzedNetwork = true;
@@ -31,5 +31,7 @@ Polymer({
     this.model = model;
     this.analyzingNetwork = false;
     this.analyzedNetwork = false;
+    this.natType = '';
+    this.natImpact = '';
   }
 });

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -4,19 +4,15 @@ Polymer({
   },
   open: function() {
     this.analyzedNetwork = false;
+    this.analyzingNetwork = false;
     this.$.troubleshootDialog.open();
   },
   submitFeedback: function() {
     this.fire('core-signal', {name: 'open-feedback', data: {includeLogs: this.analyzedNetwork}});
     this.close();
   },
-  analyzeNetworkAndViewLogs: function() {
-    this.ui.openTab('view-logs.html');
-    this.analyzedNetwork = true;
-  },
   getNatType: function() {
     this.analyzingNetwork = true;
-
     core.getNatType().then((natType) => {
       this.natType = natType;
       if (natType === 'SymmetricNAT') {

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -14,9 +14,26 @@ Polymer({
     this.ui.openTab('view-logs.html');
     this.analyzedNetwork = true;
   },
+  getNatType: function() {
+    this.analyzingNetwork = true;
+
+    core.getNatType().then((natType) => {
+      this.natType = natType;
+      if (natType === 'SymmetricNAT') {
+        this.natDescription = 'very likely';
+      } else if (natType === 'PortRestrictedCone') {
+        this.natDescription = 'possibly'
+      } else {
+        this.natDescription = 'unlikely'
+      }
+      this.analyzingNetwork = false;
+      this.analyzedNetwork = true;
+    });
+  },
   ready: function() {
     this.ui = ui;
     this.model = model;
+    this.analyzingNetwork = false;
     this.analyzedNetwork = false;
   }
 });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -67,6 +67,9 @@ module UI {
 
   export var DEFAULT_USER_IMG = '../icons/contact-default.png';
 
+  export var SHARE_FAILED_MSG :string = 'Unable to share access with ';
+  export var GET_FAILED_MSG :string = 'Unable to get access from ';
+
   export interface Contacts {
     getAccessContacts : {
       onlinePending :UI.User[];
@@ -168,8 +171,7 @@ module UI {
     // with the new value.
     public signalToFire :string = '';
 
-    public failedToShare :boolean = false;
-    public failedToGet :boolean = false;
+    public toastMessage :string = null;
 
     /*
      * This is used to store the information for setting up a copy+paste
@@ -349,10 +351,10 @@ module UI {
         this.updateSharingStatusBar_();
       });
 
-      core.onUpdate(uProxy.Update.FRIEND_FAILED_TO_GET, () => {
+      core.onUpdate(uProxy.Update.FRIEND_FAILED_TO_GET, (nameOfFriend) => {
         // Setting this variable will toggle a paper-toast (in root.html)
         // to open.
-        this.failedToShare = true;
+        this.toastMessage = UI.SHARE_FAILED_MSG + nameOfFriend;
       });
     }
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -345,6 +345,10 @@ module UI {
 
         this.updateSharingStatusBar_();
       });
+
+      core.onUpdate(uProxy.Update.FRIEND_FAILED_TO_GET, () => {
+        this.fireSignal('open-troubleshoot');
+      });
     }
 
     // Because of an observer (in root.ts) watching the value of

--- a/src/uproxy.ts
+++ b/src/uproxy.ts
@@ -74,7 +74,8 @@ module uProxy {
     STOP_GETTING,
     START_GIVING,
     STOP_GIVING,
-    STATE
+    STATE,
+    FRIEND_FAILED_TO_GET
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/uProxy/uproxy/issues/1203

Toasts now float appropriately relative to getting/status bars, e.g.
No statuses:
![image](https://cloud.githubusercontent.com/assets/8723127/7082227/86067cf4-df1e-11e4-851c-7c685040e6d7.png)
One status:
![image](https://cloud.githubusercontent.com/assets/8723127/7082232/92a1c2ac-df1e-11e4-9e87-0bae57a4e98d.png)
If width is <320px the toast sticks to the sides:
![image](https://cloud.githubusercontent.com/assets/8723127/7082239/a901c088-df1e-11e4-977e-f680b0f33d71.png)
I can take this out if it looks weird.

Updated error flow
If getting fails:
![image](https://cloud.githubusercontent.com/assets/8723127/7082246/d1588e18-df1e-11e4-9fe1-4c51eccefe13.png)
![image](https://cloud.githubusercontent.com/assets/8723127/7090763/604379e0-df73-11e4-94c9-d67ac25bd048.png)
Clicking No or the X will dismiss the dialog. Clicking Yes opens:
![image](https://cloud.githubusercontent.com/assets/8723127/7082248/e479bd78-df1e-11e4-872a-163d509a457b.png)
![image](https://cloud.githubusercontent.com/assets/8723127/7082250/ea1ac132-df1e-11e4-9888-1d3bb5ff30e9.png)
Clicking Yes opens feedback, with the logs option pre-checked:
![image](https://cloud.githubusercontent.com/assets/8723127/7082252/f752a78e-df1e-11e4-9280-7eaa3fd79061.png)

Please let me know how copy/style can be improved!

Right now the question icon, "More info" and "Privacy policy" all link to the FAQ about logs. @gwpenn is writing up new content!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1246)
<!-- Reviewable:end -->
