### PR TITLE
Clear old endpoints before setting a new one

### DIFF
--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -84,8 +84,7 @@ Polymer({
       return;
     }
 
-    ui.startGettingInUi();
-    ui.browserApi.startUsingProxy(ui.copyPastePendingEndpoint);
+    ui.startGettingInUiAndConfig(null, ui.copyPastePendingEndpoint);
     ui.copyPastePendingEndpoint = null;
   },
   switchToGetting: function() {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -176,6 +176,9 @@ module UI {
     private isLogoutExpected_ :boolean = false;
     private reconnectInterval_ :number;
 
+    // is a proxy currently set
+    private proxySet_ :boolean = false;
+
     /*
      * This is used to store the information for setting up a copy+paste
      * connection between establishing the connection and the user confirming
@@ -529,6 +532,7 @@ module UI {
         return;
       }
 
+      this.proxySet_ = false;
       this.browserApi.stopUsingProxy();
     }
 
@@ -545,14 +549,22 @@ module UI {
       */
     public startGettingInUiAndConfig =
         (instanceId :string, endpoint :Net.Endpoint) => {
-      this.instanceGettingAccessFrom_ = instanceId;
+      if (instanceId) {
+        this.instanceGettingAccessFrom_ = instanceId;
+        this.mapInstanceIdToUser_[instanceId].isSharingWithMe = true;
+      }
 
       this.startGettingInUi();
 
       this.updateGettingStatusBar_();
 
-      this.mapInstanceIdToUser_[instanceId].isSharingWithMe = true;
+      if (this.proxySet_) {
+        // this handles the case where the user starts proxying again before
+        // confirming the disconnect
+        this.stopGettingInUiAndConfig(false);
+      }
 
+      this.proxySet_ = true;
       this.browserApi.startUsingProxy(endpoint);
     }
 


### PR DESCRIPTION
Currently, if a user gets disconnected and then tries to reconnect, we
will not clear any old proxying settings on the browser before trying to
set the new ones.  On Chrome, this results in new settings not getting
set and us getting stuck in a state where we are not proxying.

Fixes #1238

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1251)
<!-- Reviewable:end -->
