### PR TITLE
Remove url and imageData from logs

### DIFF
--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -618,8 +618,10 @@ class uProxyCore implements uProxy.CoreAPI {
     // email regex taken from regular-expressions.info
     text = text.replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}\b/ig,
                         emailReplacer);
-    text = text.replace(/data:image\/.+;base64,[A-Za-z0-9+\/=]+/g, 'IMAGE_DATA');
     text = text.replace(/("name":")([^"]*)(")/g, nameReplacer);
+    text = text.replace(/data:image\/.+;base64,[A-Za-z0-9+\/=]+/g, 'IMAGE_DATA');
+    text = text.replace(/("imageData":")([^"]*)(")/g, '"imageData":"IMAGE_DATA"');
+    text = text.replace(/("url":")([^"]*)(")/g, '"url":"URL"');
     return text;
   }
 }  // class uProxyCore

--- a/src/generic_core/core.ts
+++ b/src/generic_core/core.ts
@@ -620,8 +620,8 @@ class uProxyCore implements uProxy.CoreAPI {
                         emailReplacer);
     text = text.replace(/("name":")([^"]*)(")/g, nameReplacer);
     text = text.replace(/data:image\/.+;base64,[A-Za-z0-9+\/=]+/g, 'IMAGE_DATA');
-    text = text.replace(/("imageData":")([^"]*)(")/g, '"imageData":"IMAGE_DATA"');
-    text = text.replace(/("url":")([^"]*)(")/g, '"url":"URL"');
+    text = text.replace(/"imageData":"[^"]*"/g, '"imageData":"IMAGE_DATA"');
+    text = text.replace(/"url":"[^"]*"/g, '"url":"URL"');
     return text;
   }
 }  // class uProxyCore


### PR DESCRIPTION
Remove url and imageData from logs

Before:
```
{"userId":"100006963823986","lastUpdated":1429297992786,"name":"NAME_1","url":"https://www.facebook.com/profile.php?id=100006963823986","imageData":"https://fbcdn-profile-a.akamaihd.net/hprofile-ak-xfa1/v/t1.0-1/p100x100/10487395_1411734449068669_3657311256448408178_n.jpg?oh=83937bad852014fb7ef2be4d4afb8164&oe=55D62430&__gda__=1436094844_4462a8cf349f4d8de49587fccc877a9f"}
```

After:
```
Received own XMPP profile {"userId":"6706848","lastUpdated":1429297950079,"name":"NAME_1","url":"URL","imageData":"IMAGE_DATA"}
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1301)
<!-- Reviewable:end -->
