### PR TITLE
Remove the dependency between chrome_core_connector and ui

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -90,7 +90,6 @@ function initUI() : user_interface.UserInterface {
   chromeCoreConnector = new ChromeCoreConnector({ name: 'uproxy-extension-to-app-port' });
   chromeCoreConnector.onUpdate(uproxy_core_api.Update.LAUNCH_UPROXY,
                            chromeBrowserApi.bringUproxyToFront);
-  chromeCoreConnector.connect();
 
   core = new CoreConnector(chromeCoreConnector);
   var oAuth = new ChromeTabAuth();

--- a/src/firefox/data/scripts/firefox_connector.ts
+++ b/src/firefox/data/scripts/firefox_connector.ts
@@ -28,6 +28,10 @@ class FirefoxConnector implements browser_connector.CoreBrowserConnector {
     this.send(ready);
   }
 
+  public connect = () :Promise<void> => {
+    this.emit('core_connect');
+    return Promise.resolve<void>();
+  }
 
   /**
    * Attach handlers for updates emitted from the uProxy Core.
@@ -47,6 +51,18 @@ class FirefoxConnector implements browser_connector.CoreBrowserConnector {
   public restart = () => {
     // TODO implement restart for firefox
     // https://github.com/uProxy/uproxy/issues/751
+  }
+
+  private events_ :{[name :string] :Function} = {};
+
+  public on = (name :string, callback :Function) => {
+    this.events_[name] = callback;
+  }
+
+  private emit = (name :string, ...args :Object[]) => {
+    if (name in this.events_) {
+      this.events_[name].apply(null, args);
+    }
   }
 
 }  // class FirefoxConnector

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -37,6 +37,14 @@ class CoreConnector implements uproxy_core_api.CoreApi {
                                     this.handleRequestRejected_);
   }
 
+  public on = (name :string, callback :Function) => {
+    this.browserConnector_.on(name, callback);
+  }
+
+  public connect = () :Promise<void> => {
+    return this.browserConnector_.connect();
+  }
+
   public connected = () => {
     return this.browserConnector_.status.connected;
   }

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -5,7 +5,7 @@ import browser_api = require('../../interfaces/browser_api');
 import BrowserAPI = browser_api.BrowserAPI;
 import browser_connector = require('../../interfaces/browser_connector');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import CoreApi = uproxy_core_api.CoreApi;
+import CoreConnector = require('./core_connector');
 import social = require('../../interfaces/social');
 import user = require('./user');
 import User = user.User;
@@ -15,13 +15,13 @@ describe('UI.UserInterface', () => {
   var ui :user_interface.UserInterface;
   var mockBrowserApi :BrowserAPI;
   var updateToHandlerMap :{[name :string] :Function} = {};
-  var mockCore :CoreApi;
+  var mockCore :CoreConnector;
 
   beforeEach(() => {
     // Create a fresh UI object before each test.
     mockCore = jasmine.createSpyObj(
         'core',
-        ['reset', 'onUpdate', 'sendCommand']);
+        ['reset', 'onUpdate', 'sendCommand', 'on', 'connect']);
 
     // Store all the handlers for Updates from core in a map.
     // These functions will be called directly from tests

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -7,6 +7,7 @@
 
 import ui_constants = require('../../interfaces/ui');
 import Persistent = require('../../interfaces/persistent');
+import CoreConnector = require('./core_connector');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 import browser_api = require('../../interfaces/browser_api');
 import BrowserAPI = browser_api.BrowserAPI;
@@ -190,10 +191,26 @@ module UI {
      * Upon construction, the UI installs update handlers on core.
      */
     constructor(
-        public core   :uproxy_core_api.CoreApi,
+        public core   :CoreConnector,
         public browserApi :BrowserAPI) {
       // TODO: Determine the best way to describe view transitions.
       this.view = ui_constants.View.SPLASH;  // Begin at the splash intro.
+
+      core.on('core_connect', () => {
+        this.view = ui_constants.View.SPLASH;
+      });
+
+      core.on('core_disconnect', () => {
+        // When disconnected from the app, we should show the browser specific page
+        // that shows the "app missing" message.
+        this.view = ui_constants.View.BROWSER_ERROR;
+
+        if (this.isGettingAccess()) {
+          this.stopGettingInUiAndConfig(true);
+        }
+      });
+
+      core.connect();
 
       // Attach handlers for UPDATES received from core.
       // TODO: Implement the rest of the fine-grained state updates.

--- a/src/interfaces/browser_connector.ts
+++ b/src/interfaces/browser_connector.ts
@@ -42,5 +42,11 @@ export interface CoreBrowserConnector {
 
   restart() : void;
 
+  connect() :Promise<void>;
+
+  on(name :string, callback :Function) :void;
+  on(name :'core_connect', callback :() => void) :void;
+  on(name :'core_disconnect', callback :() => void) :void;
+
   status :StatusObject;
 }


### PR DESCRIPTION
The chrome core connector previously required access to the ui object in
order to change state when disconnect or connect events occurred.  This
modifies the functionality of the core connector so that it will trigger
an event when those events occur.

For firefox, we add a connect function that does nothing except for
triggering the event.

Tested by opening chrome with and without the app installed (and installing the app after opening chrome)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1323)
<!-- Reviewable:end -->
