### PR TITLE
Fix the target page for firefox content proxy

### DIFF
--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -138,7 +138,7 @@ function setUpConnection(freedom, panel, button) {
 
   /* Allow any pages in the addon to send messages to the UI or the core */
   pagemod.PageMod({
-    include: self.data.url('very-much-not-index.html'),
+    include: self.data.url('*'),
     contentScriptFile: self.data.url('scripts/content-proxy.js'),
     onAttach: function(worker) {
       worker.port.on('update', function(data) {

--- a/src/generic_core/freedom-module.json
+++ b/src/generic_core/freedom-module.json
@@ -3,7 +3,6 @@
   "description": "The uProxy backend provides a mesh web proxy. Access the web through your social connections.",
   "app": {
     "script": [
-      "../bower/lodash/lodash.min.js",
       "freedom-module.static.js"
     ]
   },


### PR DESCRIPTION
This moves the Firefox content proxy from never being included to being
included on every local page.

Yeah, this is embarrassing.

Tested by opening the logs page

Fixes #1329

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1331)
<!-- Reviewable:end -->
