### PR TITLE
Stop specifying multiple urls per stun server

### DIFF
--- a/src/generic_core/diagnose-nat.ts
+++ b/src/generic_core/diagnose-nat.ts
@@ -1,9 +1,12 @@
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/udp-socket.d.ts' />
 /// <reference path='../../../third_party/sha1/sha1.d.ts' />
+/// <reference path='../../../third_party/typings/lodash/lodash.d.ts' />
 
 import arraybuffers = require('../../../third_party/uproxy-lib/arraybuffers/arraybuffers');
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
+import _ = require('lodash');
+import globals = require('./globals');
 
 // Both Ping and NAT type detection need help from a server. The following
 // ip/port is the instance we run on EC2.
@@ -629,17 +632,8 @@ export function doUdpTest() {
       });
 }
 
-var stunServers = [
-  'stun:stun.services.mozilla.com',
-  'stun:stun.stunprotocol.org',
-  'stun:stun.l.google.com:19302',
-  'stun:stun1.l.google.com:19302',
-  'stun:stun2.l.google.com:19302',
-  'stun:stun3.l.google.com:19302',
-  'stun:stun4.l.google.com:19302'
-];
-
 function doStunAccessTest() {
+  var stunServers = <string[]>_(globals.settings.stunServers).map('urls').flatten().value();
   log.info('perform Stun access test');
   for (var i = 0; i < stunServers.length; i++) {
     var promises : Promise<number>[] = [];

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -10,26 +10,22 @@ export var storage = new local_storage.Storage();
 export var STORAGE_VERSION = 1;
 export var MESSAGE_VERSION = 1;
 
-export var DEFAULT_STUN_SERVERS_ = [
+export var DEFAULT_STUN_SERVERS = [
   {urls: ['stun:stun.services.mozilla.com']},
   {urls: ['stun:stun.stunprotocol.org']},
-  {
-    urls: [
-      'stun:stun.l.google.com:19302',
-      'stun:stun1.l.google.com:19302',
-      'stun:stun2.l.google.com:19302',
-      'stun:stun3.l.google.com:19302',
-      'stun:stun4.l.google.com:19302'
-    ]
-  }
+  {urls: ['stun:stun.l.google.com:19302']},
+  {urls: ['stun:stun1.l.google.com:19302']},
+  {urls: ['stun:stun2.l.google.com:19302']},
+  {urls: ['stun:stun3.l.google.com:19302']},
+  {urls: ['stun:stun4.l.google.com:19302']},
 ];
 
   // Initially, the STUN servers are a copy of the default.
   // We need to use slice to copy the values, otherwise modifying this
-  // variable can modify DEFAULT_STUN_SERVERS_ as well.
+  // variable can modify DEFAULT_STUN_SERVERS as well.
 export var settings :uproxy_core_api.GlobalSettings = {
   description: '',
-  stunServers: DEFAULT_STUN_SERVERS_.slice(0),
+  stunServers: DEFAULT_STUN_SERVERS.slice(0),
   hasSeenSharingEnabledScreen: false,
   hasSeenWelcome: false,
   allowNonUnicast: false,
@@ -48,7 +44,7 @@ export var loadSettings :Promise<void> =
       // servers.
       if (!settings.stunServers
           || settings.stunServers.length == 0) {
-        settings.stunServers = DEFAULT_STUN_SERVERS_.slice(0);
+        settings.stunServers = DEFAULT_STUN_SERVERS.slice(0);
       }
       // If storage does not know if this user has seen a specific overlay
       // yet, assume the user has not seen it so that they will not miss any

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -137,6 +137,9 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
    */
   public updateGlobalSettings = (newSettings :uproxy_core_api.GlobalSettings) => {
     newSettings.version = globals.STORAGE_VERSION;
+    if (newSettings.stunServers.length === 0) {
+      newSettings.stunServers = globals.DEFAULT_STUN_SERVERS;
+    }
     globals.storage.save<uproxy_core_api.GlobalSettings>('globalSettings', newSettings)
       .catch((e) => {
         log.error('Could not save globalSettings to storage', e.stack);

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -1,19 +1,6 @@
 /// <reference path='./context.d.ts' />
 
 Polymer({
-  DEFAULT_STUN_SERVERS: [
-    {urls: ['stun:stun.services.mozilla.com']},
-    {urls: ['stun:stun.stunprotocol.org']},
-    {
-      urls: [
-        'stun:stun.l.google.com:19302',
-        'stun:stun1.l.google.com:19302',
-        'stun:stun2.l.google.com:19302',
-        'stun:stun3.l.google.com:19302',
-        'stun:stun4.l.google.com:19302'
-      ]
-    }
-  ],
   displayAdvancedSettings: false,
   logOut: function() {
     browserified_exports.ui.logout({name: browserified_exports.model.onlineNetwork.name,
@@ -46,7 +33,7 @@ Polymer({
     this.$.confirmNewServer.hidden = false;
   },
   resetStunServers: function() {
-    browserified_exports.model.globalSettings.stunServers = this.DEFAULT_STUN_SERVERS;
+    browserified_exports.model.globalSettings.stunServers = [];
     browserified_exports.core.updateGlobalSettings(browserified_exports.model.globalSettings);
     if(!this.$.confirmNewServer.hidden) {
       this.$.confirmNewServer.hidden = true;


### PR DESCRIPTION
Due to an upstream bug (willscott/webrtc-adapter#5), we are unable to
specify multiple urls for a single stun server.  To get around this, we
now specify each URL individually.

At the same time, this removes the many different locations where we
have constants for the stun servers; that is now only done in
globals.ts.

Fixes #1332
Fixes #1326

Tested by starting a copy+paste connection as well as viewing network info/logs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1349)
<!-- Reviewable:end -->
