### PR TITLE
Allow access to logging controller

### DIFF
--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -20,6 +20,7 @@ import version = require('../version/version');
 import browser_connector = require('../interfaces/browser_connector');
 import ui = require('./ui_connector');
 import uproxy_core = require('./uproxy_core');
+import logging_types = require('../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 
 import ui_connector = ui.connector;
 
@@ -36,7 +37,9 @@ var exported = {
   social_network: social_network,
   version: version,
   browser_connector: browser_connector,
-  ui_connector: ui_connector
+  ui_connector: ui_connector,
+  loggingController: uproxy_core.loggingController,
+  logging_types: logging_types,
 };
 export = exported;
 

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -27,7 +27,7 @@ var log :logging.Log = new logging.Log('core');
 log.info('Loading core', version.UPROXY_VERSION);
 
 // Note that the proxy runs extremely slowly in debug ('*:D') mode.
-var loggingController = freedom['loggingcontroller']();
+export var loggingController = freedom['loggingcontroller']();
 loggingController.setDefaultFilter(
     loggingTypes.Destination.console,
     loggingTypes.Level.warn);


### PR DESCRIPTION
TESTED: 
 * grunt
 * Loaded uProxy, and ran: 
```
var logging_types = browserified_exports.logging_types;
var loggingController = browserified_exports.loggingController;
loggingController.setDefaultFilter(
    logging_types.Destination.console,
    logging_types.Level.debug);
```
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1368)
<!-- Reviewable:end -->
