### PR TITLE
Create and use uproxy-action-dialog

### DIFF
--- a/src/generic_ui/polymer/action-dialog.html
+++ b/src/generic_ui/polymer/action-dialog.html
@@ -1,0 +1,5 @@
+<link rel='import' href='../../bower/paper-dialog/paper-action-dialog.html'>
+
+<polymer-element name='uproxy-action-dialog' extends='paper-action-dialog' role='dialog'>
+  <script src='action-dialog.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/action-dialog.ts
+++ b/src/generic_ui/polymer/action-dialog.ts
@@ -1,0 +1,17 @@
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+
+// we never want to set a position for the dialog that is off the screen, this
+// ensures that the minimum values for left and top will always be >= 0
+Polymer({
+  repositionTarget: function() {
+    this.super();
+
+    if (parseFloat(this.target.style.left) < 0) {
+      this.target.style.left = '0px';
+    }
+
+    if (parseFloat(this.target.style.top) < 0) {
+      this.target.style.top = '0px';
+    }
+  }
+});

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -4,11 +4,11 @@
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/paper-input/paper-autogrow-textarea.html'>
 <link rel='import' href='../../bower/core-label/core-label.html'>
-<link rel='import' href='../../bower/paper-dialog/paper-action-dialog.html'>
 <link rel='import' href='../../bower/core-tooltip/core-tooltip.html'>
 <link rel='import' href='../../bower/core-overlay/core-overlay.html'>
 <link rel='import' href='../../bower/core-signals/core-signals.html'>
 <link rel='import' href='faq-link.html'>
+<link rel='import' href='action-dialog.html'>
 
 <polymer-element name='uproxy-feedback' attributes=''>
   <template>
@@ -117,7 +117,7 @@
     paper-checkbox::shadow #checkbox {
       border-color: grey;
     }
-    paper-action-dialog {
+    uproxy-action-dialog {
       top: 30%;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
     }
@@ -179,12 +179,12 @@
         <div id='sendFeedback' on-tap='{{ sendFeedback }}'>SUBMIT FEEDBACK</div>
       </div>
     </core-overlay>
-    <paper-action-dialog backdrop layered="false" id='sendingFeedbackDialog' autoCloseDisabled='true'>
+    <uproxy-action-dialog backdrop layered="false" id='sendingFeedbackDialog' autoCloseDisabled='true'>
       <div id='sendingFeedback'>
         Sending feedback<br>
         <paper-progress indeterminate='true'></paper-progress>
       </div>
-    </paper-action-dialog>
+    </uproxy-action-dialog>
   </template>
   <script src='feedback.js'></script>
 </polymer-element>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -4,7 +4,6 @@
 <link rel="import" href="../../bower/core-drawer-panel/core-drawer-panel.html">
 <link rel="import" href="../../bower/core-toolbar/core-toolbar.html">
 <link rel="import" href="../../bower/core-icon-button/core-icon-button.html">
-<link rel='import' href='../../bower/paper-dialog/paper-action-dialog.html'>
 <link rel="import" href="../../bower/paper-tabs/paper-tabs.html">
 <link rel="import" href="../../bower/paper-toast/paper-toast.html">
 <link rel="import" href="../../bower/core-tooltip/core-tooltip.html">
@@ -18,6 +17,7 @@
 <link rel='import' href='feedback.html'>
 <link rel='import' href='reconnect.html'>
 <link rel='import' href='troubleshoot.html'>
+<link rel='import' href='action-dialog.html'>
 <link rel='import' href='browser-elements.html'>
 
 <polymer-element name='uproxy-root' attributes='model' on-update-view='{{ updateView }}' on-open-dialog='{{ openDialog }}'>
@@ -144,7 +144,7 @@
         color: white;
         margin-bottom: 3px;
       }
-      paper-action-dialog {
+      uproxy-action-dialog {
         top: 20%;
         z-index: 1002; /* Must be greater than core-overlay-backdrop */
       }
@@ -271,7 +271,7 @@
 
     <!-- Dialog is opened when .toggle() is called in openDialog -->
     <!-- Without layered="false", styling needs to be prefixed with 'html /deep/' in order to have effect on the dialog contents.'  -->
-    <paper-action-dialog backdrop layered="false" heading="{{ dialog.heading }}" id="dialog">
+    <uproxy-action-dialog backdrop layered="false" heading="{{ dialog.heading }}" id="dialog">
       <p>{{ dialog.message }}</p>
       <template repeat='{{ button in dialog.buttons }}'>
         <paper-button
@@ -280,9 +280,9 @@
           {{button.text}}
         </paper-button>
       </template>
-    </paper-action-dialog>
+    </uproxy-action-dialog>
 
-    <paper-action-dialog id='statsDialog' backdrop layered="false" heading="Welcome to uProxy" id="dialog">
+    <uproxy-action-dialog id='statsDialog' backdrop layered="false" heading="Welcome to uProxy" id="dialog">
       <p>
         This is a beta release of uProxy. You can help us improve uProxy by sharing anonymous metrics with the development team. Data reported is anonymized by the client and transmitted securely.
         <uproxy-faq-link anchor='doesUproxyLogData'>
@@ -292,7 +292,7 @@
       <p>Would you like to enable anonymous metrics collection?</p>
       <paper-button affirmative class='dialogButton' on-tap='{{ enableStats }}'>I'm in</paper-button>
       <paper-button dismissive class='dialogButton' on-tap='{{ disableStats }}'>No thanks</paper-button>
-    </paper-action-dialog>
+    </uproxy-action-dialog>
 
     <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>
 


### PR DESCRIPTION
This creates uproxy-action-dialog, a minor extension of
paper-action-dialog.  paper-action-dialog has the possibility of setting
the left and top positions of an element to be <0 which has the
obnoxious side-effect of ruining later calculations of what the width of
an element should be (and which then has the possibility of ruining
later calculations of what the position of the elemnt should be).
uproxy-action-dialog checks that the position set is always on-screen
and corrects that if not.

Fixes #1361 


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1373)
<!-- Reviewable:end -->