### PR TITLE
Reopen stats dialog when root element is ready, if needed.

### DIFF
--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -106,6 +106,11 @@ Polymer({
       var browserCustomElement = document.createElement(browserified_exports.ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
+    if (browserified_exports.ui.view == ui_types.View.ROSTER &&
+        !browserified_exports.model.globalSettings.hasSeenWelcome) {
+      this.statsDialogOrBubbleOpen = true;
+      this.$.statsDialog.open();
+    }
   },
   closeStatsBubble: function() {
     this.statsDialogOrBubbleOpen = false;


### PR DESCRIPTION
Without this, if the user closes the popup when the stats dialog is open, when they reopen the popup (in Chrome), the dialog will be gone.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1374)
<!-- Reviewable:end -->
