### PR TITLE
Tune metrics checkbox styling. Fix autogrow feedback box in Firefox.

### DIFF
--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -100,10 +100,6 @@
       /* Remove the underline from the Feedback textbox. */
       height: 0px;
     }
-    paper-input-decorator[id=feedbackDecorator] /deep/ .textarea-container {
-      padding: 0.25em;
-      background-color: rgb(240,240,240);
-    }
     paper-input-decorator {
       font-size: 1.4em;
     }
@@ -134,6 +130,14 @@
     #feedbackPaperTextarea {
       height: 190px;
       margin: 0em;
+    }
+    paper-autogrow-textarea::shadow .textarea-container {
+      padding: 0.25em;
+      background-color: rgb(240,240,240);
+    }
+    paper-autogrow-textarea::shadow .mirror-text {
+      white-space: pre-wrap; /* css-3 */
+      white-space: -moz-pre-wrap; /* Mozilla, since 1999 */
     }
     </style>
 

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -84,6 +84,19 @@
     paper-checkbox::shadow #checkboxLabel {
       font-size: 12px;
     }
+    paper-checkbox::shadow #checkboxContainer {
+      margin-left: 1px;
+      width: 16px;
+      height: 16px;
+    }
+    paper-checkbox::shadow #checkbox:not(.checked) {
+      border: solid 2px rgb(112,112,112);
+    }
+    paper-checkbox::shadow #checkmark {
+      position: fixed;
+      margin-top: 1px;
+      margin-left: 1px;
+    }
     #metricsCheckbox core-icon[icon="help"]{
       height: 15px;
       color: grey;


### PR DESCRIPTION
Fixes this: https://github.com/uProxy/uproxy/issues/1357

![image](https://cloud.githubusercontent.com/assets/8723127/7290212/4cf3adf8-e949-11e4-80da-ec4e57597f26.png)
![image](https://cloud.githubusercontent.com/assets/8723127/7290216/530c0b36-e949-11e4-8945-4d1e5e51bcf0.png)

Tested manually + grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1376)
<!-- Reviewable:end -->
