### PR TITLE
Disable sharing for Firefox 37 and later

### DIFF
--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -120,9 +120,20 @@ Polymer({
     this.statsDialogOrBubbleOpen = false;
   },
   tabSelected: function(e :Event) {
-    // setting the value is taken care of in the polymer binding, we just need
-    // to sync the value to core
-    browserified_exports.core.updateGlobalSettings(browserified_exports.model.globalSettings);
+    if (browserified_exports.ui.isSharingDisabled &&
+        this.model.globalSettings.mode == ui_types.Mode.SHARE) {
+      // Keep the mode on get and display an error dialog.
+      this.model.globalSettings.mode = ui_types.Mode.GET;
+      this.fire('open-dialog', {
+        heading: 'Sharing Unavailable',
+        message: 'Oops! Unfortunately, due to a bug introduced in Firefox 37, sharing from Firefox currently does not work. You can track the issue at goo.gl/SOltps. We hope this will be fixed soon, but in the mean time, the best workaround is to try the uProxy extension for Chrome.',
+        buttons: [{text: 'Close', dismissive: true}]
+      });
+    } else {
+      // setting the value is taken care of in the polymer binding, we just need
+      // to sync the value to core
+      browserified_exports.core.updateGlobalSettings(browserified_exports.model.globalSettings);
+    }
   },
   signalToFireChanged: function() {
     if (browserified_exports.ui.signalToFire != '') {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -120,7 +120,7 @@ Polymer({
     this.statsDialogOrBubbleOpen = false;
   },
   tabSelected: function(e :Event) {
-    if (browserified_exports.ui.isSharingDisabled &&
+    if (this.ui.isSharingDisabled &&
         this.model.globalSettings.mode == ui_types.Mode.SHARE) {
       // Keep the mode on get and display an error dialog.
       this.model.globalSettings.mode = ui_types.Mode.GET;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -182,6 +182,8 @@ export class UserInterface implements ui_constants.UiApi {
    */
   public copyPastePendingEndpoint :net.Endpoint = null;
 
+  public isSharingDisabled = false;
+
   /**
    * UI must be constructed with hooks to Notifications and Core.
    * Upon construction, the UI installs update handlers on core.
@@ -191,6 +193,13 @@ export class UserInterface implements ui_constants.UiApi {
       public browserApi :BrowserAPI) {
     // TODO: Determine the best way to describe view transitions.
     this.view = ui_constants.View.SPLASH;  // Begin at the splash intro.
+
+    var firefoxMatches = navigator.userAgent.match(/Firefox\/(\d+)/);
+    if (firefoxMatches) {
+      if (parseInt(firefoxMatches[1], 10) >= 37) {
+        this.isSharingDisabled = true;
+      }
+    }
 
     core.on('core_connect', () => {
       this.view = ui_constants.View.SPLASH;
@@ -414,7 +423,7 @@ export class UserInterface implements ui_constants.UiApi {
         if (contact) {
           contact.getExpanded = true;
         }
-      } else if (data.mode === 'share') {
+      } else if (data.mode === 'share' && !this.isSharingDisabled) {
         model.globalSettings.mode = ui_constants.Mode.SHARE;
         this.core.updateGlobalSettings(model.globalSettings);
         if (contact) {


### PR DESCRIPTION
Disable sharing for Firefox 37 and later, due to https://github.com/uProxy/uproxy/issues/1360
![screen shot 2015-04-23 at 2 00 14 pm](https://cloud.githubusercontent.com/assets/6494307/7303859/526dccc8-e9c1-11e4-9af0-dfcc033c3b04.png)

Unforunately we are reusing the polymer paper-dialog, where we can use any links, so we are showing a goo.gl URL rather than do something clickable.

Tested in Chrome (no difference) and Firefox version 37

@lucyhe Can you test in Firefox 36 and verify this doesn't disable sharing?  Sorry I don't have that version

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1390)
<!-- Reviewable:end -->
