### PR TITLE
Add notification numbers to get/share tabs. Expand contacts for new offers.

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -45,9 +45,28 @@
         color: #20F1DE;
         opacity: .4;
       }
+      /* Since notification number should always be opacity = 1, we force
+         the .tab-content to be opacity = 1 and instead add the .notSelected class to just tab text. There's no way to have .tab-content opacity
+         of 0.6 while its child element (the number) has opacity 1.  */
       paper-tab::shadow .tab-content{
         font-size: 14px;
         text-transform: uppercase;
+        opacity: 1;
+      }
+      .notSelected {
+        opacity: 0.6;
+      }
+      .tabNotificationNumber {
+        margin-left: 10px;
+        margin-bottom: 1px;
+        padding: 3px 6px;
+        background-color: #11B6A7;
+        border-radius: 50%;
+        font-weight: 400;
+        font-size: 10px;
+      }
+      .addLeftPadding {
+        padding-left: 10px;
       }
       core-drawer-panel {
         overflow: auto;
@@ -221,8 +240,20 @@
 
           <div class='bottom fit'>
             <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}' on-core-activate='{{ tabSelected }}'>
-              <paper-tab>Get Access</paper-tab>
-              <paper-tab>Share Access</paper-tab>
+              <paper-tab id='getPaperTab'>
+                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.GET, addLeftPadding: model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length > 0} | tokenList }}'>Get Access</span>
+                <span class='tabNotificationNumber'
+                  hidden?='{{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length == 0 }}'>
+                  {{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length }}
+                </span>
+              </paper-tab>
+              <paper-tab id='sharePaperTab'>
+                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.SHARE, addLeftPadding: model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length > 0} | tokenList }}'>Share Access</span>
+                <span class='tabNotificationNumber'
+                  hidden?='{{ model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length == 0 }}'>
+                  {{ model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length }}
+                </span>
+              </paper-tab>
             </paper-tabs>
           </div>
         </core-toolbar>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -240,14 +240,14 @@
 
           <div class='bottom fit'>
             <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}' on-core-activate='{{ tabSelected }}'>
-              <paper-tab id='getPaperTab'>
+              <paper-tab>
                 <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.GET, addLeftPadding: model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length > 0} | tokenList }}'>Get Access</span>
                 <span class='tabNotificationNumber'
                   hidden?='{{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length == 0 }}'>
                   {{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length }}
                 </span>
               </paper-tab>
-              <paper-tab id='sharePaperTab'>
+              <paper-tab>
                 <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.SHARE, addLeftPadding: model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length > 0} | tokenList }}'>Share Access</span>
                 <span class='tabNotificationNumber'
                   hidden?='{{ model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length == 0 }}'>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -51,7 +51,7 @@
       paper-tab::shadow .tab-content{
         font-size: 14px;
         text-transform: uppercase;
-        opacity: 1;
+        opacity: 1 !important;
       }
       .notSelected {
         opacity: 0.6;

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -65,7 +65,7 @@
         font-weight: 400;
         font-size: 10px;
       }
-      .addLeftPadding {
+      .withNotification {
         padding-left: 10px;
       }
       core-drawer-panel {
@@ -241,14 +241,14 @@
           <div class='bottom fit'>
             <paper-tabs id='modeTabs' selected='{{ model.globalSettings.mode }}' on-core-activate='{{ tabSelected }}'>
               <paper-tab>
-                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.GET, addLeftPadding: model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length > 0} | tokenList }}'>Get Access</span>
+                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.GET, withNotification: model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length > 0} | tokenList }}'>Get Access</span>
                 <span class='tabNotificationNumber'
                   hidden?='{{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length == 0 }}'>
                   {{ model.contacts.getAccessContacts.onlinePending.length + model.contacts.getAccessContacts.offlinePending.length }}
                 </span>
               </paper-tab>
               <paper-tab>
-                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.SHARE, addLeftPadding: model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length > 0} | tokenList }}'>Share Access</span>
+                <span class='{{ {notSelected: model.globalSettings.mode != ui_constants.Mode.SHARE, withNotification: model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length > 0} | tokenList }}'>Share Access</span>
                 <span class='tabNotificationNumber'
                   hidden?='{{ model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length == 0 }}'>
                   {{ model.contacts.shareAccessContacts.onlinePending.length + model.contacts.shareAccessContacts.offlinePending.length }}

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -131,6 +131,8 @@ export class User implements social.BaseUser {
 
     // Update gettingConsentState, used to display correct getting buttons.
     if (this.offeringInstances.length > 0) {
+      // Expand the contact if there previously were no offers and we are not
+      // ignoring offers.
       if ((this.gettingConsentState ==
           GettingConsentState.NO_OFFER_OR_REQUEST ||
           this.gettingConsentState ==
@@ -159,6 +161,8 @@ export class User implements social.BaseUser {
 
     // Update sharingConsentState, used to display correct sharing buttons.
     if (this.consent_.remoteRequestsAccessFromLocal) {
+      // Expand the contact if there previously were no requests and we are not
+      // ignoring requests.
       if ((this.sharingConsentState ==
           SharingConsentState.NO_OFFER_OR_REQUEST ||
           this.sharingConsentState ==

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -131,6 +131,13 @@ export class User implements social.BaseUser {
 
     // Update gettingConsentState, used to display correct getting buttons.
     if (this.offeringInstances.length > 0) {
+      if ((this.gettingConsentState ==
+          GettingConsentState.NO_OFFER_OR_REQUEST ||
+          this.gettingConsentState ==
+          GettingConsentState.LOCAL_REQUESTED_REMOTE_NO_ACTION) &&
+          !this.consent_.ignoringRemoteUserOffer) {
+        this.getExpanded = true;
+      }
       if (this.consent_.localRequestsAccessFromRemote) {
         this.gettingConsentState =
             GettingConsentState.LOCAL_REQUESTED_REMOTE_GRANTED;
@@ -152,6 +159,13 @@ export class User implements social.BaseUser {
 
     // Update sharingConsentState, used to display correct sharing buttons.
     if (this.consent_.remoteRequestsAccessFromLocal) {
+      if ((this.sharingConsentState ==
+          SharingConsentState.NO_OFFER_OR_REQUEST ||
+          this.sharingConsentState ==
+          SharingConsentState.LOCAL_OFFERED_REMOTE_NO_ACTION) &&
+          !this.consent_.ignoringRemoteUserRequest) {
+        this.shareExpanded = true;
+      }
       if (this.consent_.localGrantsAccessToRemote) {
         this.sharingConsentState =
             SharingConsentState.LOCAL_OFFERED_REMOTE_ACCEPTED;


### PR DESCRIPTION
Contacts will now expand when an offer or request is received and there previously were no offers or requests for that contact. (However, regardless of offers, a contact will not auto-expand if the user is ignoring that contact.)

Tested manually and ran grunt test.

Chrome
![image](https://cloud.githubusercontent.com/assets/8723127/7311700/df419bd8-ea0d-11e4-96da-b1cd165ca411.png)
![image](https://cloud.githubusercontent.com/assets/8723127/7311704/ea260ad4-ea0d-11e4-8c48-a722d5ebe861.png)
Larger numbers:
![image](https://cloud.githubusercontent.com/assets/8723127/7311813/3d8a64da-ea0f-11e4-9264-e1335928c241.png)


Firefox
![image](https://cloud.githubusercontent.com/assets/8723127/7311794/faa741b0-ea0e-11e4-9cb7-06efd201e0a0.png)
![image](https://cloud.githubusercontent.com/assets/8723127/7311799/02fa00c8-ea0f-11e4-91e9-6ea77304a9bd.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1405)
<!-- Reviewable:end -->
