### PR TITLE
Try to fix the case where dialogs open too far to the right

### DIFF
--- a/src/generic_ui/polymer/dialog.ts
+++ b/src/generic_ui/polymer/dialog.ts
@@ -1,17 +1,25 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-// we never want to set a position for the dialog that is off the screen, this
-// ensures that the minimum values for left and top will always be >= 0
+// this class covers two different cases: trying to set the dialog to be
+// offscreen and not having correct information on where the dialog should be
+// positioned.  For the case where the dialog is being set to be offscreen
+// (i.e. style.left < 0), this causes issues in later calculations for what the
+// width of the element should end up being.  In cases where there is not
+// enough information about the size of the dialog (i.e.
+// sizingTarget.offsetWidth == 0), the DOM did not have a chance to redraw
+// itself after switching to displaying the element and we are going to set a
+// left position that is ridiculously far to the right (approximately at the
+// center of the screen).  In this case, setting the position to be all the way
+// at the left is probably not the exact desired behaviour (we probably want to
+// be a few pixels over to the right), but it's not going to be noticeable by
+// 99% of our users, only occurs on ititial startup, seems to only occur about
+// 1/10 times, and is immediately fixed by closing and re-opening the panel.
 Polymer({
   repositionTarget: function() {
-    this.super();
+    this.super(arguments);
 
-    if (parseFloat(this.target.style.left) < 0) {
+    if (parseFloat(this.target.style.left) < 0 || !this.sizingTarget.offsetWidth) {
       this.target.style.left = '0px';
-    }
-
-    if (parseFloat(this.target.style.top) < 0) {
-      this.target.style.top = '0px';
     }
   }
 });


### PR DESCRIPTION
The previous fix for dialogs handled the case where we would attempt to
position the dialog to be off the screen which would cause later
calculations for its width to be completely wrong (keeping it off the
screen).  There was another problem we did not notice at the time: that
the second calculation for its position in Firefox would ocasionally
occur before we had any information on what its width would be, set it
to be placed in the middle of the screen, which would end up forcing it
to be offscreen.

Fixes #1361 (again)

Testing
-------
0. Add a logging statement to `repositionTarget` in `dialog.ts`
0. Keep restarting Firefox with logs going somewhere you can read them until that log statement shows up on two consecutive lines (this is the case where the UI did not have a chance to redraw in between)
0. Check how the welcome dialog looks

Yeah, I know this kind of sucks, but it's the best way of checking whether you would have seen the old behaviour.  Alternatively, you could log whenever innerWidth is 0 in the second call and look for that message.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1423)
<!-- Reviewable:end -->
