### PR TITLE
Update freedom-social-firebase version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "es6-promise": "^2.0.0",
     "freedom-for-chrome": "^0.4.11",
     "freedom-for-firefox": "^0.6.7",
-    "freedom-social-firebase": "^0.0.11",
+    "freedom-social-firebase": "^0.0.12",
     "freedom-social-xmpp": "^0.3.6",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",


### PR DESCRIPTION
freedom-social-firebase 0.0.11 had a bad build (firebase.js was missing, causing Facebook to be completely broken).  0.0.12 fixes this (includes firebase.js in the dist/ directory)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1428)
<!-- Reviewable:end -->
