### PR TITLE
Only launch the extension window on initial install

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -72,7 +72,12 @@ function initUI() : user_interface.UserInterface {
   chromeBrowserApi = new ChromeBrowserApi();
   // TODO (lucyhe): Make sure that the "install" event isn't missed if we
   // are adding the listener after the event is fired.
-  chrome.runtime.onInstalled.addListener(() => {
+  chrome.runtime.onInstalled.addListener((details :chrome.runtime.InstalledDetails) => {
+    if (details.reason !== 'install') {
+      // we only want to launch the window on the first install
+      return;
+    }
+
     chrome.tabs.query({currentWindow: true, active: true}, function(tabs){
         // Do not open the extension when it's installed if the user is
         // going through the inline install flow.


### PR DESCRIPTION
We were previously launching the extension window whenever Chrome or the
extension were updated, this changes the behaviour so that it only
happens the first time the extension is installed.

See https://developer.chrome.com/extensions/runtime#event-onInstalled

Fixes #1364

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1432)
<!-- Reviewable:end -->