### PR TITLE
Remove excess "ui_context." in Polymer .ts files.  Clean up vulcanize rules in Gruntfile

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -661,11 +661,11 @@ module.exports = (grunt) ->
       chromeAppInline:
         vulcanizeInline(
             chromeAppDevPath + '/polymer/ext-missing.html',
-            'build/dev/uproxy/chrome/app/polymer/vulcanized-inline.html')
+            chromeAppDevPath + '/polymer/vulcanized-inline.html')
       chromeAppCsp:
         vulcanizeCsp(
             chromeAppDevPath + '/polymer/vulcanized-inline.html',
-            'build/dev/uproxy/chrome/app/polymer/vulcanized.html')
+            chromeAppDevPath + '/polymer/vulcanized.html')
       firefoxInline:
         vulcanizeInline(
             firefoxDevPath + '/data/generic_ui/polymer/root.html',

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -39,6 +39,10 @@ taskManager.add 'build_chrome_ext', [
   'copy:chrome_extension_additional'
   'vulcanize:chromeExtInline'
   'vulcanize:chromeExtCsp'
+  'vulcanize:chromeDisconnectedInline'
+  'vulcanize:chromeDisconnectedCsp'
+  'vulcanize:chromeViewLogsInline'
+  'vulcanize:chromeViewLogsCsp'
   'browserify:chromeExtMain'
   'browserify:chromeContext'
   'browserify:chromeVulcanized'
@@ -58,6 +62,10 @@ taskManager.add 'build_firefox', [
   'copy:firefox_additional'
   'vulcanize:firefoxInline'
   'vulcanize:firefoxCsp'
+  'vulcanize:firefoxDisconnectedInline'
+  'vulcanize:firefoxDisconnectedCsp'
+  'vulcanize:firefoxViewLogsInline'
+  'vulcanize:firefoxViewLogsCsp'
   'string-replace:firefoxVulcanized'
   'browserify:firefoxContext'
   'browserify:firefoxVulcanized'
@@ -673,6 +681,74 @@ module.exports = (grunt) ->
         files: [{
           src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html'
           dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized.html'
+        }]
+      chromeDisconnectedInline:
+        options: { inline: true }
+        files: [{
+          src: chromeExtDevPath + '/generic_ui/polymer/confirm.html'
+          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html'
+        }]
+      chromeDisconnectedCsp:
+        options: { csp: true }
+        files: [{
+          src: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html'
+          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected.html'
+        }]
+      firefoxDisconnectedInline:
+        options:
+          inline: true
+          excludes:
+            scripts: [
+              'polymer.js'
+            ]
+        files: [{
+          src: firefoxDevPath + '/data/generic_ui/polymer/confirm.html'
+          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html'
+        }]
+      firefoxDisconnectedCsp:
+        options:
+          inline: true
+          excludes:
+            scripts: [
+              'polymer.js'
+            ]
+        files: [{
+          src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html'
+          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected.html'
+        }]
+      chromeViewLogsInline:
+        options: { inline: true }
+        files: [{
+          src: chromeExtDevPath + '/generic_ui/polymer/logs.html'
+          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html'
+        }]
+      chromeViewLogsCsp:
+        options: { csp: true }
+        files: [{
+          src: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html'
+          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs.html'
+        }]
+      firefoxViewLogsInline:
+        options:
+          inline: true
+          excludes:
+            scripts: [
+              'polymer.js'
+            ]
+        files: [{
+          src: firefoxDevPath + '/data/generic_ui/polymer/logs.html'
+          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html'
+        }]
+      firefoxViewLogsCsp:
+        options:
+          inline: true
+          excludes:
+            scripts: [
+              'polymer.js'
+            ]
+        files: [{
+          src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html'
+          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs.html'
         }]
   }  # grunt.initConfig
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -230,6 +230,30 @@ finishVulcanized = (basePath) ->
       replacement: '<script src="../lib/$1"></script>'
     }]
 
+vulcanizeInline = (src, dest) ->
+  options:
+    inline: true
+    excludes:
+      scripts: [
+        'polymer.js'
+      ]
+  files: [{
+    src: src
+    dest: dest
+  }]
+
+vulcanizeCsp = (src, dest) ->
+  options:
+    csp: true
+    excludes:
+      scripts: [
+        'polymer.js'
+      ]
+  files: [{
+    src: src
+    dest: dest
+  }]
+
 compileTypescript = (files) ->
   src: files.concat('!**/*.d.ts')
   options:
@@ -627,129 +651,61 @@ module.exports = (grunt) ->
 
     vulcanize:
       chromeExtInline:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/root.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-inline.html'
-        }]
+        vulcanizeInline(
+            chromeExtDevPath + '/generic_ui/polymer/root.html',
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-inline.html')
       chromeExtCsp:
-        options:
-          csp: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/vulcanized-inline.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized.html'
-        }]
+        vulcanizeCsp(
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-inline.html',
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized.html')
       chromeAppInline:
-        options: { inline: true }
-        files: [{
-          src: chromeAppDevPath + '/polymer/ext-missing.html'
-          dest: 'build/dev/uproxy/chrome/app/polymer/vulcanized-inline.html'
-        }]
+        vulcanizeInline(
+            chromeAppDevPath + '/polymer/ext-missing.html',
+            'build/dev/uproxy/chrome/app/polymer/vulcanized-inline.html')
       chromeAppCsp:
-        options: { csp: true }
-        files: [{
-          src: chromeAppDevPath + '/polymer/vulcanized-inline.html'
-          dest: 'build/dev/uproxy/chrome/app/polymer/vulcanized.html'
-        }]
+        vulcanizeCsp(
+            chromeAppDevPath + '/polymer/vulcanized-inline.html',
+            'build/dev/uproxy/chrome/app/polymer/vulcanized.html')
       firefoxInline:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/root.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html'
-        }]
+        vulcanizeInline(
+            firefoxDevPath + '/data/generic_ui/polymer/root.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html')
       firefoxCsp:
-        options:
-          csp: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized.html'
-        }]
+        vulcanizeCsp(
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized.html')
       chromeDisconnectedInline:
-        options: { inline: true }
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/confirm.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html'
-        }]
+          vulcanizeInline(
+              chromeExtDevPath + '/generic_ui/polymer/confirm.html',
+              chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html')
       chromeDisconnectedCsp:
-        options: { csp: true }
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected.html'
-        }]
+        vulcanizeCsp(
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected-inline.html',
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-disconnected.html')
       firefoxDisconnectedInline:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/confirm.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html'
-        }]
+        vulcanizeInline(
+            firefoxDevPath + '/data/generic_ui/polymer/confirm.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html')
       firefoxDisconnectedCsp:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected.html'
-        }]
+        vulcanizeCsp(
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected-inline.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-disconnected.html')
       chromeViewLogsInline:
-        options: { inline: true }
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/logs.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html'
-        }]
+        vulcanizeInline(
+            chromeExtDevPath + '/generic_ui/polymer/logs.html',
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html')
       chromeViewLogsCsp:
-        options: { csp: true }
-        files: [{
-          src: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html'
-          dest: chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs.html'
-        }]
+        vulcanizeCsp(
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs-inline.html',
+            chromeExtDevPath + '/generic_ui/polymer/vulcanized-view-logs.html')
       firefoxViewLogsInline:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/logs.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html'
-        }]
+        vulcanizeInline(
+            firefoxDevPath + '/data/generic_ui/polymer/logs.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html')
       firefoxViewLogsCsp:
-        options:
-          inline: true
-          excludes:
-            scripts: [
-              'polymer.js'
-            ]
-        files: [{
-          src: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html'
-          dest: firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs.html'
-        }]
+        vulcanizeCsp(
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs-inline.html',
+            firefoxDevPath + '/data/generic_ui/polymer/vulcanized-view-logs.html')
   }  # grunt.initConfig
 
   #-------------------------------------------------------------------------

--- a/src/generic_ui/disconnected.html
+++ b/src/generic_ui/disconnected.html
@@ -11,7 +11,7 @@
   <script src='scripts/disconnected.js'></script>
 
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
-  <link rel='import' href='polymer/vulcanized.html'>
+  <link rel='import' href='polymer/vulcanized-disconnected.html'>
 </head>
 
 <body>

--- a/src/generic_ui/polymer/confirm.html
+++ b/src/generic_ui/polymer/confirm.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../bower/polymer/polymer.html">
+<link rel='import' href='../../bower/paper-button/paper-button.html'>
 
 <polymer-element name='uproxy-confirm'>
   <template>

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -8,18 +8,22 @@
 import ui_constants = require('../../interfaces/ui');
 import social = require('../../interfaces/social');
 
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 Polymer({
   init: function() {
     /* bring copyPaste to the front in get mode */
-    ui_context.ui.view = ui_constants.View.COPYPASTE;
+    ui.view = ui_constants.View.COPYPASTE;
 
-    if (ui_context.ui.copyPasteGettingState === social.GettingState.NONE) {
+    if (ui.copyPasteGettingState === social.GettingState.NONE) {
       this.startGetting();
     }
   },
   startGetting: function() {
     var doneStopping :Promise<void>;
-    if (ui_context.ui.copyPasteGettingState !== social.GettingState.NONE) {
+    if (ui.copyPasteGettingState !== social.GettingState.NONE) {
       console.warn('aborting previous copy+paste getting connection');
       doneStopping = this.stopGetting();
     } else {
@@ -27,13 +31,13 @@ Polymer({
     }
 
     doneStopping.then(() => {
-      ui_context.ui.copyPasteGettingMessage = '';
-      ui_context.ui.copyPasteError = ui_constants.CopyPasteError.NONE;
-      ui_context.ui.copyPastePendingEndpoint = null;
+      ui.copyPasteGettingMessage = '';
+      ui.copyPasteError = ui_constants.CopyPasteError.NONE;
+      ui.copyPastePendingEndpoint = null;
 
-      return ui_context.core.startCopyPasteGet();
+      return core.startCopyPasteGet();
     }).then((endpoint) => {
-      ui_context.ui.copyPastePendingEndpoint = endpoint;
+      ui.copyPastePendingEndpoint = endpoint;
     }).catch((e) => {
       // TODO we will see this any time the connection is aborted by the user or
       // when something actually goes wrong with the connection.  We should
@@ -42,19 +46,19 @@ Polymer({
       // an error, so we are just going to warn about it.
 
       console.warn('error when starting copy+paste get', e);
-      ui_context.ui.copyPasteError = ui_constants.CopyPasteError.FAILED;
+      ui.copyPasteError = ui_constants.CopyPasteError.FAILED;
     });
   },
   handleBackClick: function() {
     // do not let the user navigate away from this view if copypaste is active
-    if ((ui_context.ui.copyPasteGettingState === social.GettingState.GETTING_ACCESS && ui_context.ui.copyPastePendingEndpoint === null) ||
-        ui_context.ui.copyPasteSharingState === social.SharingState.SHARING_ACCESS) {
+    if ((ui.copyPasteGettingState === social.GettingState.GETTING_ACCESS && ui.copyPastePendingEndpoint === null) ||
+        ui.copyPasteSharingState === social.SharingState.SHARING_ACCESS) {
       return;
     }
 
-    if (ui_context.ui.copyPasteGettingState === social.GettingState.NONE &&
-        ui_context.ui.copyPasteSharingState === social.SharingState.NONE) {
-      ui_context.ui.view = ui_constants.View.SPLASH;
+    if (ui.copyPasteGettingState === social.GettingState.NONE &&
+        ui.copyPasteSharingState === social.SharingState.NONE) {
+      ui.view = ui_constants.View.SPLASH;
       return;
     }
 
@@ -71,46 +75,46 @@ Polymer({
     });
   },
   stopGetting: function() {
-    return ui_context.core.stopCopyPasteGet().then(() => {
+    return core.stopCopyPasteGet().then(() => {
       // clean up the pending endpoint in case we got here from going back
-      ui_context.ui.copyPastePendingEndpoint = null;
+      ui.copyPastePendingEndpoint = null;
     });
   },
   startProxying: function() {
-    if (!ui_context.ui.copyPastePendingEndpoint) {
+    if (!ui.copyPastePendingEndpoint) {
       console.error('Attempting to start copy+paste proxying without a pending endpoint');
       return;
     }
 
-    if (ui_context.ui.copyPasteGettingState !== social.GettingState.GETTING_ACCESS) {
+    if (ui.copyPasteGettingState !== social.GettingState.GETTING_ACCESS) {
       console.error('Attempting to start copy+paste when not getting access');
       return;
     }
 
-    ui_context.ui.startGettingInUiAndConfig(null, ui_context.ui.copyPastePendingEndpoint);
-    ui_context.ui.copyPastePendingEndpoint = null;
+    ui.startGettingInUiAndConfig(null, ui.copyPastePendingEndpoint);
+    ui.copyPastePendingEndpoint = null;
   },
   switchToGetting: function() {
     this.stopSharing().then(() => {
-      if (ui_context.ui.copyPasteGettingState === social.GettingState.NONE) {
+      if (ui.copyPasteGettingState === social.GettingState.NONE) {
         this.startGetting();
       }
     });
   },
   stopSharing: function() {
-    return ui_context.core.stopCopyPasteShare();
+    return core.stopCopyPasteShare();
   },
   select: function(e :Event, d :Object, sender :HTMLInputElement) {
     sender.focus();
     sender.select();
   },
   dismissError: function() {
-    ui_context.ui.copyPasteError = ui_constants.CopyPasteError.NONE;
+    ui.copyPasteError = ui_constants.CopyPasteError.NONE;
   },
   exitMode: function() {
     // if we are currently in the middle of setting up a connection, end it
     var doneStopping :Promise<void>;
-    if (ui_context.ui.copyPasteGettingState !== social.GettingState.NONE) {
+    if (ui.copyPasteGettingState !== social.GettingState.NONE) {
       doneStopping = this.stopGetting()
     } else {
       doneStopping = Promise.resolve<void>();
@@ -119,7 +123,7 @@ Polymer({
     doneStopping.catch((e) => {
       console.warn('Error while closing getting connection', e);
     }).then(() => {
-      if (ui_context.ui.copyPasteSharingState !== social.SharingState.NONE) {
+      if (ui.copyPasteSharingState !== social.SharingState.NONE) {
         return this.stopSharing();
       }
     }).catch((e) => {
@@ -127,13 +131,13 @@ Polymer({
     }).then(() => {
       // go back to the previous view regardless of whether we successfully
       // stopped the connection
-      ui_context.ui.view = ui_constants.View.SPLASH;
+      ui.view = ui_constants.View.SPLASH;
     })
   },
   ready: function() {
-    this.ui = ui_context.ui;
+    this.ui = ui;
     this.ui_constants = ui_constants;
-    this.model = ui_context.model;
+    this.model = model;
     this.GettingState = social.GettingState;
     this.SharingState = social.SharingState;
   }

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -5,6 +5,10 @@ import ui_constants = require('../../interfaces/ui');
 import net = require('../../../../third_party/uproxy-networking/net/net.types');
 import user_interface = require('../scripts/ui');
 
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 Polymer({
   aborted: false, // did the user manually cancel the last connection
   ready: function() {
@@ -18,10 +22,10 @@ Polymer({
     };
     // Expose global ui object and UI module in this context. This allows the
     // hidden? watch for the get/give toggle to actually update.
-    this.ui = ui_context.ui;
+    this.ui = ui;
     this.ui_constants = ui_constants;
     this.GettingState = social.GettingState;
-    this.model = ui_context.model;
+    this.model = model;
   },
   start: function() {
     if (!this.instance.isOnline) {
@@ -33,7 +37,7 @@ Polymer({
     console.log('[polymer] calling core.start(', this.path, ')');
 
     this.aborted = false;
-    ui_context.core.start(this.path).then((endpoint :net.Endpoint) => {
+    core.start(this.path).then((endpoint :net.Endpoint) => {
       console.log('[polymer] received core.start promise fulfillment.');
       console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
       this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
@@ -43,8 +47,8 @@ Polymer({
         // if the failure is because of a user action, do nothing
         return;
       }
-      ui_context.ui.toastMessage = user_interface.GET_FAILED_MSG + this.user.name;
-      ui_context.ui.bringUproxyToFront();
+      ui.toastMessage = user_interface.GET_FAILED_MSG + this.user.name;
+      ui.bringUproxyToFront();
       console.error('Unable to start proxying ', e);
       this.fire('set-trying-to-get', {isTryingToGet: false});
     });
@@ -53,6 +57,6 @@ Polymer({
     this.fire('set-trying-to-get', {isTryingToGet: false});
     this.aborted = true;
     console.log('[polymer] calling core.stop()');
-    ui_context.core.stop();
+    core.stop();
   }
 });

--- a/src/generic_ui/polymer/network.ts
+++ b/src/generic_ui/polymer/network.ts
@@ -4,15 +4,19 @@
 
 import ui_constants = require('../../interfaces/ui');
 
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 Polymer({
   connect: function() {
-    ui_context.ui.login(this.networkName).then(() => {
+    ui.login(this.networkName).then(() => {
       console.log('connected to ' + this.networkName);
       // Fire an update-view event, which root.ts listens for.
       this.fire('update-view', {view: ui_constants.View.ROSTER});
-      ui_context.ui.bringUproxyToFront();
+      ui.bringUproxyToFront();
     }).catch((e :Error) => {
-      ui_context.ui.showNotification('There was a problem signing in to ' + this.networkName + '.  Please try again.');
+      ui.showNotification('There was a problem signing in to ' + this.networkName + '.  Please try again.');
       console.warn('Did not log in ', e);
     });
   },

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -5,6 +5,10 @@ import social = require('../../interfaces/social');
 import ui_types = require('../../interfaces/ui');
 import user_interface = require('../scripts/ui');
 
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 interface button_description {
   text :string;
   signal :string;
@@ -27,16 +31,16 @@ Polymer({
     // If we're switching from the SPLASH page to the ROSTER, fire an
     // event indicating the user has logged in. roster.ts listens for
     // this event.
-    if (detail.view == ui_types.View.ROSTER && ui_context.ui.view == ui_types.View.SPLASH) {
+    if (detail.view == ui_types.View.ROSTER && ui.view == ui_types.View.SPLASH) {
       this.fire('core-signal', {name: "login-success"});
-      if (!ui_context.model.globalSettings.hasSeenWelcome) {
+      if (!model.globalSettings.hasSeenWelcome) {
         this.statsDialogOrBubbleOpen = true;
         this.$.statsDialog.toggle();
       }
       this.closeSettings();
       this.$.modeTabs.updateBar();
     }
-    ui_context.ui.view = detail.view;
+    ui.view = detail.view;
   },
   statsIconClicked: function() {
     this.$.mainPanel.openDrawer();
@@ -46,26 +50,26 @@ Polymer({
   },
   rosterView: function() {
     console.log('rosterView called');
-    ui_context.ui.view = ui_types.View.ROSTER;
+    ui.view = ui_types.View.ROSTER;
   },
   setGetMode: function() {
-    ui_context.model.globalSettings.mode = ui_types.Mode.GET;
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.mode = ui_types.Mode.GET;
+    core.updateGlobalSettings(model.globalSettings);
   },
   setShareMode: function() {
-    ui_context.model.globalSettings.mode = ui_types.Mode.SHARE;
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.mode = ui_types.Mode.SHARE;
+    core.updateGlobalSettings(model.globalSettings);
   },
   closedWelcome: function() {
-    ui_context.model.globalSettings.hasSeenWelcome = true;
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.hasSeenWelcome = true;
+    core.updateGlobalSettings(model.globalSettings);
   },
   closedSharing: function() {
-    ui_context.model.globalSettings.hasSeenSharingEnabledScreen = true;
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.hasSeenSharingEnabledScreen = true;
+    core.updateGlobalSettings(model.globalSettings);
   },
   dismissCopyPasteError: function() {
-    ui_context.ui.copyPasteError = ui_types.CopyPasteError.NONE;
+    ui.copyPasteError = ui_types.CopyPasteError.NONE;
   },
   openDialog: function(e :Event, detail :dialog_description) {
     /* 'detail' parameter holds the data that was passed when the open-dialog
@@ -97,17 +101,17 @@ Polymer({
   },
   ready: function() {
     // Expose global ui object and UI module in this context.
-    this.ui = ui_context.ui;
+    this.ui = ui;
     this.ui_constants = ui_types;
     this.user_interface = user_interface;
-    this.model = ui_context.model;
+    this.model = model;
     this.closeToastTimeout = null;
-    if (ui_context.ui.browserApi.browserSpecificElement){
-      var browserCustomElement = document.createElement(ui_context.ui.browserApi.browserSpecificElement);
+    if (ui.browserApi.browserSpecificElement){
+      var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
-    if (ui_context.ui.view == ui_types.View.ROSTER &&
-        !ui_context.model.globalSettings.hasSeenWelcome) {
+    if (ui.view == ui_types.View.ROSTER &&
+        !model.globalSettings.hasSeenWelcome) {
       this.statsDialogOrBubbleOpen = true;
       this.$.statsDialog.open();
     }
@@ -137,18 +141,18 @@ Polymer({
     } else {
       // setting the value is taken care of in the polymer binding, we just need
       // to sync the value to core
-      ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+      core.updateGlobalSettings(model.globalSettings);
     }
   },
   signalToFireChanged: function() {
-    if (ui_context.ui.signalToFire != '') {
-      this.fire('core-signal', {name: ui_context.ui.signalToFire});
-      ui_context.ui.signalToFire = '';
+    if (ui.signalToFire != '') {
+      this.fire('core-signal', {name: ui.signalToFire});
+      ui.signalToFire = '';
     }
   },
   /* All functions below help manage paper-toast behaviour. */
   closeToast: function() {
-    ui_context.ui.toastMessage = null;
+    ui.toastMessage = null;
   },
   messageNotNull: function(toastMessage :string) {
     // Whether the toast is shown is controlled by if ui.toastMessage
@@ -162,7 +166,7 @@ Polymer({
     return false;
   },
   openTroubleshoot: function() {
-    if (this.stringMatches(ui_context.ui.toastMessage, user_interface.GET_FAILED_MSG)) {
+    if (this.stringMatches(ui.toastMessage, user_interface.GET_FAILED_MSG)) {
       this.troubleshootTitle = "Unable to get access";
     } else {
       this.troubleshootTitle = "Unable to share access";

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -1,10 +1,14 @@
 /// <reference path='./context.d.ts' />
 
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 Polymer({
   displayAdvancedSettings: false,
   logOut: function() {
-    ui_context.ui.logout({name: ui_context.model.onlineNetwork.name,
-                                   userId: ui_context.model.onlineNetwork.userId}).then(() => {
+    ui.logout({name: model.onlineNetwork.name,
+                                   userId: model.onlineNetwork.userId}).then(() => {
       // Nothing to do here - the UI should receive a NETWORK update
       // saying that the network is offline, and will update the display
       // as result of that.
@@ -13,7 +17,7 @@ Polymer({
     });
   },
   restart: function() {
-    ui_context.core.restart();
+    core.restart();
   },
   toggleAdvancedSettings: function() {
     this.displayAdvancedSettings = !this.displayAdvancedSettings;
@@ -25,16 +29,16 @@ Polymer({
     }
   },
   setStunServer: function() {
-    ui_context.model.globalSettings.stunServers = [{urls: [this.stunServer]}];
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.stunServers = [{urls: [this.stunServer]}];
+    core.updateGlobalSettings(model.globalSettings);
     if(!this.$.confirmResetServers.hidden) {
       this.$.confirmResetServers.hidden = true;
     }
     this.$.confirmNewServer.hidden = false;
   },
   resetStunServers: function() {
-    ui_context.model.globalSettings.stunServers = [];
-    ui_context.core.updateGlobalSettings(ui_context.model.globalSettings);
+    model.globalSettings.stunServers = [];
+    core.updateGlobalSettings(model.globalSettings);
     if(!this.$.confirmNewServer.hidden) {
       this.$.confirmNewServer.hidden = true;
     }
@@ -44,7 +48,7 @@ Polymer({
     this.fire('core-signal', {name: 'open-feedback'});
   },
   ready: function() {
-    this.ui = ui_context.ui;
-    this.model = ui_context.model;
+    this.ui = ui;
+    this.model = model;
   }
 });

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -3,6 +3,11 @@
 /**
  * Script for the introductory splash screen.
  */
+
+var ui = ui_context.ui;
+var core = ui_context.core;
+var model = ui_context.model;
+
 Polymer({
   SPLASH_STATES: {
     INTRO: 0,
@@ -13,13 +18,13 @@ Polymer({
       console.error('Invalid call to setState: ' + state);
       return;
     }
-    ui_context.ui.splashState = state;
+    ui.splashState = state;
   },
   next: function() {
-    this.setState(ui_context.ui.splashState + 1);
+    this.setState(ui.splashState + 1);
   },
   prev: function() {
-    this.setState(ui_context.ui.splashState - 1);
+    this.setState(ui.splashState - 1);
   },
   copypaste: function() {
     this.fire('core-signal', { name: 'copypaste-init' });
@@ -28,7 +33,7 @@ Polymer({
     this.fire('core-signal', {name: 'open-feedback'});
   },
   ready: function() {
-    this.ui = ui_context.ui;
-    this.model = ui_context.model;
+    this.ui = ui;
+    this.model = model;
   }
 });

--- a/src/generic_ui/view-logs.html
+++ b/src/generic_ui/view-logs.html
@@ -7,7 +7,7 @@
   <script src='scripts/get_logs.js'></script>
 
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
-  <link rel='import' href='polymer/vulcanized.html'>
+  <link rel='import' href='polymer/vulcanized-view-logs.html'>
 </head>
 
 <body>


### PR DESCRIPTION
Sets file-level globals like ```var ui = ui_context.ui``` in various Polymer .ts files, so that we can turn long lines like ```ui_context.ui.startGettingInUiAndConfig(null, ui_context.ui.copyPastePendingEndpoint);``` into more readable code like ```ui.startGettingInUiAndConfig(null, ui.copyPastePendingEndpoint);```

This pull request also creates separate vulcanized Polymer files for disconnected.html and view-logs.html.  Before those had been using the same vulcanized.html as our main index.html UI, which meant they were pulling in unnecessary Polymer elements like the roster, copypaste, etc, and were also getting exceptions because ui_context is not available in those environments.

Tested in Chrome and Firefox (main UI, disconnected.html, faq.html, view-logs.html, extension missing page)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1446)
<!-- Reviewable:end -->
