### PR TITLE
Change settings text, remove sizing override

### DIFF
--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -81,9 +81,6 @@
       margin-right: 5px;
       font-size: 10px;
     }
-    paper-checkbox::shadow #checkboxLabel {
-      font-size: 12px;
-    }
     paper-checkbox::shadow #checkboxContainer {
       margin-left: 1px;
       width: 16px;
@@ -184,7 +181,7 @@
           <p id='confirmResetServers' class='advancedSettingsText' hidden>STUN servers reset. Default servers will be used for future connections.</p>
         </div>
         <div id='metricsCheckbox'>
-          <paper-checkbox checked='{{ model.globalSettings.statsReportingEnabled }}' label='Anonymous stats reporting enabled'></paper-checkbox>
+          <paper-checkbox checked='{{ model.globalSettings.statsReportingEnabled }}' label='Anonymous stats enabled'></paper-checkbox>
           <uproxy-faq-link anchor='doesUproxyLogData'>
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link>


### PR DESCRIPTION
This changes the settings text to something that is not so ridiculously
large and removes our manual override on the font size for the labe.

Fixes #1412
Fixes #1419

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1447)
<!-- Reviewable:end -->
