### PR TITLE
Add a DefinitelyTyped rule for circular-json

### DIFF
--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -37,6 +37,9 @@
     },
     "chrome/chrome.d.ts": {
       "commit": "1957eb54fbb7ef0d0397c2c78a5b5e638e813ec8"
+    },
+    "circular-json/circular-json.d.ts": {
+      "commit": "9c2d795cc1d98cd3e11186de9290776c66578ea0"
     }
   }
 }


### PR DESCRIPTION
We have the really annoying dependency rule that we need to pull in
typings for any child repo since the files get copied to our third_party
directory instead of living in their build directories that have the
typings specified.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1448)
<!-- Reviewable:end -->
