### PR TITLE
Move the functionality to start a proxying session to UserInterface

### DIFF
--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -3,7 +3,7 @@
 <link rel='import' href='../../bower/core-collapse/core-collapse.html'>
 <link rel='import' href='instance.html'>
 
-<polymer-element name='uproxy-contact' attributes='contact, isOnline' on-set-trying-to-get='{{ setIsTryingToGet }}'>
+<polymer-element name='uproxy-contact' attributes='contact, isOnline'>
 
   <template>
     <style>
@@ -146,13 +146,13 @@
       opened='{{ contact.getExpanded }}'>
 
       <div id='getInstanceControls' hidden?='{{ contact.gettingConsentState != GettingConsentState.LOCAL_REQUESTED_REMOTE_GRANTED }}'>
-        <div horizontal layout hidden?='{{ isTryingToGet }}'>
+        <div horizontal layout hidden?='{{ hasInstance(ui.instanceTryingToGetAccessFrom) }}'>
           <core-icon icon='check'></core-icon>
           <p class='preButtonText' flex>
             {{ contact.name || contact.userId }} has granted you access
           </p>
         </div>
-        <div horizontal layout hidden?='{{ !isTryingToGet }}'>
+        <div horizontal layout hidden?='{{ !hasInstance(ui.instanceTryingToGetAccessFrom) }}'>
           <core-icon icon='query-builder'></core-icon>
           <p class='preButtonText' flex>
             Trying to connect to {{ contact.name || contact.userId }}

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -1,8 +1,11 @@
 /// <reference path='./context.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/typings/lodash/lodash.d.ts' />
 
 import ui_constants = require('../../interfaces/ui');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 import user = require('../scripts/user');
+import _ = require('lodash');
 
 Polymer({
   contact: {
@@ -22,14 +25,10 @@ Polymer({
     this.model = ui_context.model;
     this.GettingConsentState = user.GettingConsentState;
     this.SharingConsentState = user.SharingConsentState;
-    this.isTryingToGet = false;
   },
   openLink: function(event :Event) {
     this.ui.browserApi.openTab(this.contact.url);
     event.stopPropagation();  // Don't toggle when link is clicked.
-  },
-  setIsTryingToGet: function(e :Event, data :{ isTryingToGet :boolean }) {
-    this.isTryingToGet = data.isTryingToGet;
   },
   // |action| is the string end for a uproxy_core_api.ConsentUserAction
   modifyConsent: function(action :uproxy_core_api.ConsentUserAction) {
@@ -62,5 +61,8 @@ Polymer({
     this.modifyConsent(uproxy_core_api.ConsentUserAction.CANCEL_OFFER);
   },
   ignoreRequest: function() { this.modifyConsent(uproxy_core_api.ConsentUserAction.IGNORE_REQUEST) },
-  unignoreRequest: function() { this.modifyConsent(uproxy_core_api.ConsentUserAction.UNIGNORE_REQUEST) }
+  unignoreRequest: function() { this.modifyConsent(uproxy_core_api.ConsentUserAction.UNIGNORE_REQUEST) },
+  hasInstance: function(instanceId :string) {
+    return instanceId && _.contains(this.contact.allInstanceIds, instanceId);
+  },
 });

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -10,16 +10,7 @@ var core = ui_context.core;
 var model = ui_context.model;
 
 Polymer({
-  aborted: false, // did the user manually cancel the last connection
   ready: function() {
-    this.path = <social.InstancePath>{
-      network : {
-       name: this.network.name,
-       userId: this.network.userId
-      },
-      userId: this.user.userId,
-      instanceId: this.instance.instanceId
-    };
     // Expose global ui object and UI module in this context. This allows the
     // hidden? watch for the get/give toggle to actually update.
     this.ui = ui;
@@ -33,30 +24,9 @@ Polymer({
       return;
     }
 
-    this.fire('set-trying-to-get', {isTryingToGet: true});
-    console.log('[polymer] calling core.start(', this.path, ')');
-
-    this.aborted = false;
-    core.start(this.path).then((endpoint :net.Endpoint) => {
-      console.log('[polymer] received core.start promise fulfillment.');
-      console.log('[polymer] endpoint: ' + JSON.stringify(endpoint));
-      this.ui.startGettingInUiAndConfig(this.instance.instanceId, endpoint);
-      this.fire('set-trying-to-get', {isTryingToGet: false});
-    }).catch((e :Error) => {
-      if (this.aborted) {
-        // if the failure is because of a user action, do nothing
-        return;
-      }
-      ui.toastMessage = user_interface.GET_FAILED_MSG + this.user.name;
-      ui.bringUproxyToFront();
-      console.error('Unable to start proxying ', e);
-      this.fire('set-trying-to-get', {isTryingToGet: false});
-    });
+    ui.startGettingFromInstance(this.instance.instanceId);
   },
   stop: function() {
-    this.fire('set-trying-to-get', {isTryingToGet: false});
-    this.aborted = true;
-    console.log('[polymer] calling core.stop()');
-    core.stop();
+    ui.stopGettingFromInstance(this.instance.instanceId);
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -53,12 +53,10 @@ Polymer({
     ui.view = ui_types.View.ROSTER;
   },
   setGetMode: function() {
-    model.globalSettings.mode = ui_types.Mode.GET;
-    core.updateGlobalSettings(model.globalSettings);
+    ui.setMode(ui_types.Mode.GET);
   },
   setShareMode: function() {
-    model.globalSettings.mode = ui_types.Mode.SHARE;
-    core.updateGlobalSettings(model.globalSettings);
+    ui.setMode(ui_types.Mode.SHARE);
   },
   closedWelcome: function() {
     model.globalSettings.hasSeenWelcome = true;
@@ -132,7 +130,7 @@ Polymer({
     if (this.ui.isSharingDisabled &&
         this.model.globalSettings.mode == ui_types.Mode.SHARE) {
       // Keep the mode on get and display an error dialog.
-      this.model.globalSettings.mode = ui_types.Mode.GET;
+      this.ui.setMode(ui_types.Mode.GET);
       this.fire('open-dialog', {
         heading: 'Sharing Unavailable',
         message: 'Oops! You\'re using Firefox 37, which has a bug that prevents sharing from working (see git.io/vf5x1). This bug is fixed in Firefox 38, so you can enable sharing by upgrading Firefox or switching to Chrome.',

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -880,4 +880,9 @@ export class UserInterface implements ui_constants.UiApi {
       return doAttempts();
     });
   }
+
+  public setMode = (mode :ui_constants.Mode) => {
+    model.globalSettings.mode = mode;
+    this.core.updateGlobalSettings(model.globalSettings);
+  }
 }  // class UserInterface

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -139,6 +139,7 @@ export class UserInterface implements ui_constants.UiApi {
 
   // Instance you are getting access from.
   // Null if you are not getting access.
+  public instanceTryingToGetAccessFrom :string = null;
   private instanceGettingAccessFrom_ :string = null;
 
   // The instances you are giving access to.
@@ -560,6 +561,51 @@ export class UserInterface implements ui_constants.UiApi {
 
     this.proxySet_ = false;
     this.browserApi.stopUsingProxy();
+  }
+
+  public startGettingFromInstance = (instanceId :string) :Promise<void> => {
+    var user = this.mapInstanceIdToUser_[instanceId];
+
+    var path = <social.InstancePath>{
+      network: {
+        name: user.network.name,
+        userId: user.network.userId
+      },
+      userId: user.userId,
+      instanceId: instanceId
+    };
+
+    this.instanceTryingToGetAccessFrom = instanceId;
+
+    return this.core.start(path).then((endpoint :net.Endpoint) => {
+      this.instanceTryingToGetAccessFrom = null;
+
+      this.startGettingInUiAndConfig(instanceId, endpoint);
+    }).catch((e :Error) => {
+      // this is only an error if we are still trying to get access from the
+      // instance
+      if (this.instanceTryingToGetAccessFrom !== instanceId) {
+        return;
+      }
+
+      this.toastMessage = GET_FAILED_MSG + user.name;
+      this.bringUproxyToFront();
+      return Promise.reject(e);
+    });
+  }
+
+  public stopGettingFromInstance = (instanceId :string) :void => {
+    if (instanceId === this.instanceTryingToGetAccessFrom) {
+      // aborting pending connection
+      this.instanceTryingToGetAccessFrom = null;
+    } else if (instanceId === this.instanceGettingAccessFrom_) {
+      // instance will be unset in eventual callback from core
+    } else {
+      // we have no idea what's going on
+      console.error('Attempting to stop getting from unknown instance');
+    }
+
+    this.core.stop();
   }
 
   public startGettingInUi = () => {


### PR DESCRIPTION
Move the functionality to start a proxying session to UserInterface

Starting a connection through a given user is an action that is being
taken place on the level of the entire UI, not specific to a single
instance.  This moves the functionality to actually do that out of the
instance code to the top-level.  By doing this, we are able to get
better checking of whether there was a problem connecting or whether a
user aborted the connection.

To keep track of the current status of our connection, we now use a
variable in the UI that is set to whatever instance we are trying to get
access through.

Fixes #1409

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1462)
<!-- Reviewable:end -->
