### PR TITLE
Downgrade freedom-for-firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bower": "^1.4.1",
     "es6-promise": "^2.0.0",
     "freedom-for-chrome": "^0.4.11",
-    "freedom-for-firefox": "^0.6.7",
+    "freedom-for-firefox": "0.6.10",
     "freedom-social-firebase": "^0.0.12",
     "freedom-social-xmpp": "^0.3.6",
     "fs-extra": "^0.12.0",


### PR DESCRIPTION
uProxy becomes unusable with freedom-for-firefoxv0.6.11, this changes
the version we require to v0.6.10.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1464)
<!-- Reviewable:end -->
