### PR TITLE
Update global Firefox icon instead of per-window state

### DIFF
--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -57,9 +57,7 @@ function setUpConnection(freedom, panel, button) {
   });
 
   panel.port.on('setIcon', function(iconFiles) {
-    button.state("window", {
-      icon : iconFiles
-    });
+    button.icon = iconFiles;
   });
 
   panel.port.on('showPanel', function() {


### PR DESCRIPTION
When we set the uProxy icon for Firefox, update the global icon state
across windows instead of trying to limit the change to a single window

Fixes #1292

Tested by logging in in Firefox and making sure the icon updates across windows.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1494)
<!-- Reviewable:end -->
