### PR TITLE
Open toast message with an event

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -353,11 +353,11 @@
     <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>
 
     <paper-toast id='toast'
-        opened='{{ messageNotNull(ui.toastMessage) }}'
-        text='{{ ui.toastMessage }}' responsiveWidth='320px'
-        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'>
+        text='{{ toastMessage }}' responsiveWidth='320px'
+        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'
+        duration='10000'>
       <div id='toastHelpLink' on-tap="{{ openTroubleshoot }}"
-          hidden?='{{ !stringMatches(ui.toastMessage, user_interface.GET_FAILED_MSG) && !stringMatches(ui.toastMessage, user_interface.SHARE_FAILED_MSG) }}'>GET HELP
+          hidden?='{{ !stringMatches(toastMessage, user_interface.GET_FAILED_MSG) && !stringMatches(toastMessage, user_interface.SHARE_FAILED_MSG) }}'>GET HELP
       </div>
     </paper-toast>
 

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -27,6 +27,7 @@ Polymer({
     heading: '',
     buttons: []
   },
+  toastMessage: '',
   updateView: function(e :Event, detail :{ view :ui_types.View }) {
     // If we're switching from the SPLASH page to the ROSTER, fire an
     // event indicating the user has logged in. roster.ts listens for
@@ -103,7 +104,6 @@ Polymer({
     this.ui_constants = ui_types;
     this.user_interface = user_interface;
     this.model = model;
-    this.closeToastTimeout = null;
     if (ui.browserApi.browserSpecificElement){
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
@@ -151,20 +151,14 @@ Polymer({
   revertProxySettings: function() {
     this.ui.stopGettingInUiAndConfig(false);
   },
-  /* All functions below help manage paper-toast behaviour. */
-  closeToast: function() {
-    ui.toastMessage = null;
-  },
-  messageNotNull: function(toastMessage :string) {
-    // Whether the toast is shown is controlled by if ui.toastMessage
-    // is null. This function returns whether ui.toastMessage == null,
-    // and also sets a timeout to close the toast.
-    if (toastMessage) {
-      clearTimeout(this.clearToastTimeout);
-      this.clearToastTimeout = setTimeout(this.closeToast, 10000);
-      return true;
+  toastMessageChanged: function(oldVal :string, newVal :string) {
+    if (newVal) {
+      this.toastMessage = newVal;
+      this.$.toast.show();
+
+      // clear the message so we can pick up on other changes
+      ui.toastMessage = null;
     }
-    return false;
   },
   openTroubleshoot: function() {
     if (this.stringMatches(ui.toastMessage, user_interface.GET_FAILED_MSG)) {
@@ -172,7 +166,7 @@ Polymer({
     } else {
       this.troubleshootTitle = "Unable to share access";
     }
-    this.closeToast();
+    this.$.toast.dismiss();
     this.fire('core-signal', {name: 'open-troubleshoot'});
   },
   stringMatches: function(str1 :string, str2 :string) {
@@ -215,6 +209,7 @@ Polymer({
     }
   },
   observe: {
-    '$.mainPanel.selected' : 'drawerToggled'
+    '$.mainPanel.selected' : 'drawerToggled',
+    'ui.toastMessage': 'toastMessageChanged',
   }
 });


### PR DESCRIPTION
The previous way we were handling toast messages was to have a flag
(actually the output of a function) that would change depending on
whether the message should be open or not.  This disable the normal ways
of clearing a toast message (e.g. clicking somewhere else or swiping it
offscreen).

We now watch for changes of ui.toastMessage and will fire the open event
when that changes.

Fixes #1333

Tested by getting failures and making sure the message showed up and subsequently went away.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1498)
<!-- Reviewable:end -->
