### PR TITLE
Factor whether statuses are visible into height calculation

### DIFF
--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -59,5 +59,8 @@ Polymer({
   ready: function() {
     this.ui = ui_context.ui;
     this.model = ui_context.model;
-  }
+  },
+  computed: {
+    'opened': '$.feedbackPanel.opened'
+  },
 });

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -201,7 +201,7 @@
     <uproxy-copypaste id='copypaste' hidden?='{{ ui_constants.View.COPYPASTE !== ui.view }}'>
     </uproxy-copypaste>
 
-    <uproxy-feedback></uproxy-feedback>
+    <uproxy-feedback id='feedback'></uproxy-feedback>
 
     <uproxy-splash id='splash' hidden?='{{ui_constants.View.SPLASH!=ui.view}}'>
     </uproxy-splash>
@@ -354,7 +354,7 @@
 
     <paper-toast id='toast'
         text='{{ toastMessage }}' responsiveWidth='320px'
-        style='bottom: {{ topOfStatuses(ui.gettingStatus, ui.sharingStatus) }}px;'
+        style='bottom: {{ topOfStatuses([ui.gettingStatus, ui.sharingStatus], ui.view == ui_constants.View.ROSTER && !$.feedback.opened) }}px;'
         duration='10000'>
       <div id='toastHelpLink' on-tap="{{ openTroubleshoot }}"
           hidden?='{{ !stringMatches(toastMessage, user_interface.GET_FAILED_MSG) && !stringMatches(toastMessage, user_interface.SHARE_FAILED_MSG) }}'>GET HELP

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -177,7 +177,7 @@ Polymer({
     }
     return false;
   },
-  topOfStatuses: function(gettingStatus :social.GettingState, sharingStatus :social.SharingState) {
+  topOfStatuses: function(statuses: string[], visible :boolean) {
     // Returns number of pixels from the bottom of the window a toast
     // can be positioned without interfering with the getting or sharing
     // status bars.
@@ -185,16 +185,21 @@ Polymer({
     // bottom of its parent element, this function is needed to control toast
     // placement rather than a simpler solution such as moving the toast
     // inside the roster element.
-    var padding = 10;
+    var height = 10; // should start 10px up
     var statusRowHeight = 58; // From style of the statusRow divs.
-    if (gettingStatus && sharingStatus) {
-      return 2 * statusRowHeight + padding;
-    } else if (gettingStatus || sharingStatus) {
-      return statusRowHeight + padding;
+
+    if (!visible) {
+      // if the statuses are not on the screen, we don't need to do anything
+      return height;
     }
-    // If there are no status bars, toasts should still 'float' a little
-    // above the bottom of the window.
-    return padding;
+
+    for (var i in statuses) {
+      if (statuses[i]) {
+        height += statusRowHeight;
+      }
+    }
+
+    return height;
   },
   // mainPanel.selected can be either "drawer" or "main"
   // Our "drawer" is the settings panel. When the settings panel is open,


### PR DESCRIPTION
If the statuses at the bottom of the screen are not visible at some
point, we should factor that into the calculation of how tall they are.
In order to do that, we now accept a boolean value into topOfStatuses
that denotes whether or not they can be seen.  If this value is false,
we just use the padding value for the height of the statuses.

In order to check whether they are visible, we also need to figure out
whether or not the feedback window is open (they cannot be seen if it is
open).  To do this, we have it export the attribute opened which is
calculated based off of whether its internal panel is open.

Fixes #1334 

Pictures from testing below:

![toast-on-roster](https://cloud.githubusercontent.com/assets/902894/7520674/60d496a2-f4b6-11e4-9f55-7af091a36fdd.png)

![toast-on-feedback](https://cloud.githubusercontent.com/assets/902894/7520676/6479692c-f4b6-11e4-9335-bda3f23eb2b7.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1501)
<!-- Reviewable:end -->
