### PR TITLE
Send name and userId along with the instance handshake

### DIFF
--- a/src/generic_core/local-instance.ts
+++ b/src/generic_core/local-instance.ts
@@ -22,8 +22,8 @@ import Persistent = require('../interfaces/persistent');
     public instanceId  :string;
     public keyHash     :string;
     public clientId    :string;
+    public name        :string;
     private imageData_ :string;
-    private name_      :string;
 
     /**
      * Generate an instance for oneself, either from scratch or based on some
@@ -71,14 +71,14 @@ import Persistent = require('../interfaces/persistent');
     }
 
     public updateProfile = (profile :social.UserProfileMessage) :void => {
-      this.name_ = profile.name;
+      this.name = profile.name;
       this.imageData_ = profile.imageData;
     }
 
     public getUserProfile = () :social.UserProfileMessage => {
       return {
         userId: this.userId,
-        name: this.name_,
+        name: this.name,
         imageData: this.imageData_
       };
     }

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -141,6 +141,8 @@ export interface InstanceHandshake {
   keyHash     :string;
   consent     :ConsentWireState;
   description ?:string;
+  name        :string;
+  userId      :string;
 }
 
 // Describing whether or not a remote instance is currently accessing or not,
@@ -195,6 +197,7 @@ export interface UserState {
  */
 export interface LocalUserInstance extends BaseInstance {
   userId :string;
+  name   :string;
 }
 
 export interface RemoteUserInstance extends BaseInstance {


### PR DESCRIPTION
Fix for https://github.com/uProxy/uproxy/issues/1510 (also consolidated issues #1469, #1485, #1314).

We now send the user's name and userId along with the instance handshake.
* If a peer receives a handshake from a user whose name is still 'pending' (one who they haven't got a UserProfile for), the remoteUser.name will be set to the name sent along with that instance handshake
* Sometimes a user doesn't even know their own name (they haven't received their own UserProfile, due to GTalk XMPP weirdness).  In this case peer's can use their userId as a name.  This userId should be their real user ID (e.g. their GMail address), and not some anonymized @public.talk.google.com ID.  This will result in their email address appearing in the uProxy UI which isn't great but is much better than the buddy not appearing at all.

Tested in Chrome, Firefox, updated unit tests.  Also works fine when interacting with old versions of uProxy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1513)
<!-- Reviewable:end -->
