### PR TITLE
add fix for polymer/webcomponentsjs version bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,19 +2,22 @@
   "name": "uProxy",
   "version": "0.8.6",
   "dependencies": {
-    "polymer": "^0.5.2",
-    "paper-elements": "Polymer/paper-elements#~0.5.1",
-    "core-input": "Polymer/core-input#^0.5.0",
-    "core-style": "Polymer/core-style#^0.5.0",
-    "core-icons": "Polymer/core-icons#~0.5.1",
-    "core-signals": "Polymer/core-signals#~0.5.5",
-    "paper-dialog": "Polymer/paper-dialog#~0.5.5",
-    "core-label": "Polymer/core-label#~0.5.5",
-    "core-tooltip": "Polymer/core-tooltip#~0.5.5",
-    "core-collapse": "Polymer/core-collapse#~0.5.5",
-    "core-header-panel": "Polymer/core-header-panel#~0.5.5",
-    "core-drawer-panel": "Polymer/core-drawer-panel#~0.5.5",
-    "core-overlay": "Polymer/core-overlay#~0.5.5",
-    "paper-toast": "Polymer/paper-toast#~0.5.5"
+    "polymer": "^0.5.6",
+    "paper-elements": "Polymer/paper-elements#^0.5.6",
+    "core-input": "Polymer/core-input#^0.5.6",
+    "core-style": "Polymer/core-style#^0.5.6",
+    "core-icons": "Polymer/core-icons#^0.5.6",
+    "core-signals": "Polymer/core-signals#^0.5.6",
+    "paper-dialog": "Polymer/paper-dialog#^0.5.6",
+    "core-label": "Polymer/core-label#^0.5.6",
+    "core-tooltip": "Polymer/core-tooltip#^0.5.6",
+    "core-collapse": "Polymer/core-collapse#^0.5.6",
+    "core-header-panel": "Polymer/core-header-panel#^0.5.6",
+    "core-drawer-panel": "Polymer/core-drawer-panel#^0.5.6",
+    "core-overlay": "Polymer/core-overlay#^0.5.6",
+    "paper-toast": "Polymer/paper-toast#^0.5.6"
+  },
+  "resolutions": {
+    "webcomponentsjs": "^0.6.1"
   }
 }


### PR DESCRIPTION
This is a workaround for a bug in the current polymer dependencies that has inconsistent dependencies on "webcomponentsjs".

It also uses standard and consistent version dependency specifications. 

TESTED: 
./setup install
grunt

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1514)
<!-- Reviewable:end -->
