### PR TITLE
Treat welcome bubble as part of header

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -272,7 +272,7 @@
           </div>
         </core-toolbar>
 
-        <uproxy-bubble on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome && !statsDialogOrBubbleOpen }}'>
+        <uproxy-bubble class='core-header' on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome && !statsDialogOrBubbleOpen }}'>
           <h3>Welcome to uProxy!</h3>
           <p>
             To get started, choose "Get access" or "Share access" and then click

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -272,6 +272,11 @@
           </div>
         </core-toolbar>
 
+        <!--
+          core-header class ensures this gets inserted in the header portion of
+          core-header-panel and it is positioned below the toolbar (see
+          https://www.polymer-project.org/0.5/docs/elements/core-header-panel.html)
+        -->
         <uproxy-bubble class='core-header' on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome && !statsDialogOrBubbleOpen }}'>
           <h3>Welcome to uProxy!</h3>
           <p>


### PR DESCRIPTION
This starts treating the welcome bubble as part of the header for the
core-header-panel.

For the position of bubbles, we try to do the computation based on the
height of the previous element and its position (prev.height + prev.top
should give us the top amount that we want to use).  This works usually,
but we were running into a problem where the calculation would be done
based on the core-toolbar but the actual positioning would be done based
on a separate div that was placed below core-toolbar due to the selector
in core-header-panel.

In order to fix this, we have added the class core-header to the bubble
which causes it to be filled into the same div in core-header-panel as
the toolbar itself.

Fixes #1523

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1532)
<!-- Reviewable:end -->
