### PR TITLE
browserify context.js from chrome/extension/scripts instead of chrome/extension/generic_ui/scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .sass-cache
 .tscache
 build
+.build
 editor_support/*/*.sublime-workspace
 node_modules
 npm-debug.log

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -684,7 +684,7 @@ module.exports = (grunt) ->
         src: [
           firefoxDevPath + '/data/scripts/background.js'
         ]
-        dest: firefoxDevPath + '/data/generic_ui/scripts/context.static.js'
+        dest: firefoxDevPath + '/data/scripts/context.static.js'
         options:
           browserifyOptions:
             standalone: 'ui_context'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -355,7 +355,7 @@ module.exports = (grunt) ->
 
               'generic_ui/scripts/copypaste.js'
               'generic_ui/scripts/get_logs.js'
-              'generic_ui/scripts/context.static.js'
+              'scripts/context.static.js'
               'scripts/background.static.js'
               '!**/*spec*'
 
@@ -674,7 +674,7 @@ module.exports = (grunt) ->
         browserifyOptions:
           standalone: 'ui_context'
       )
-      chromeContext: Rule.browserify('chrome/extension/generic_ui/scripts/context',
+      chromeContext: Rule.browserify('chrome/extension/scripts/context',
         browserifyOptions:
           standalone: 'ui_context'
       )

--- a/src/chrome/extension/polymer/app-missing.ts
+++ b/src/chrome/extension/polymer/app-missing.ts
@@ -1,7 +1,6 @@
 /// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='../../../../../third_party/typings/chrome/chrome.d.ts' />
-
-import context = require('../scripts/context');
+/// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
 // Launch the Chrome webstore page for the uProxy app,
 // or activate the user's tab open to uproxy.org/chrome-install
@@ -29,7 +28,7 @@ function openDownloadAppPage() : void {
       }
     );
     // After the app is installed via the webstore, open up uProxy.
-    context.chromeCoreConnector.onceConnected.then(context.ui.browserApi.bringUproxyToFront);
+    ui_context.browserConnector.onceConnected.then(ui_context.ui.browserApi.bringUproxyToFront);
   });
 }
 

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -23,7 +23,7 @@ export import model = user_interface.model;
 
 export var ui   :user_interface.UserInterface;  // singleton referenced in both options and popup.
 // --------------------- Communicating with the App ----------------------------
-export var chromeCoreConnector :ChromeCoreConnector;  // way for ui to speak to a uProxy.CoreApi
+export var browserConnector :ChromeCoreConnector;  // way for ui to speak to a uProxy.CoreApi
 export var core :CoreConnector;  // way for ui to speak to a uProxy.CoreApi
 var chromeBrowserApi :ChromeBrowserApi;
 // Chrome Window ID of the window used to launch uProxy,
@@ -87,13 +87,13 @@ function initUI() : user_interface.UserInterface {
     chromeBrowserApi.bringUproxyToFront();
   });
 
-  chromeCoreConnector = new ChromeCoreConnector({ name: 'uproxy-extension-to-app-port' });
-  chromeCoreConnector.onUpdate(uproxy_core_api.Update.LAUNCH_UPROXY,
+  browserConnector = new ChromeCoreConnector({ name: 'uproxy-extension-to-app-port' });
+  browserConnector.onUpdate(uproxy_core_api.Update.LAUNCH_UPROXY,
                            chromeBrowserApi.bringUproxyToFront);
 
-  core = new CoreConnector(chromeCoreConnector);
+  core = new CoreConnector(browserConnector);
   var oAuth = new ChromeTabAuth();
-  chromeCoreConnector.onUpdate(uproxy_core_api.Update.GET_CREDENTIALS,
+  browserConnector.onUpdate(uproxy_core_api.Update.GET_CREDENTIALS,
                            oAuth.login.bind(oAuth));
 
   // used for de-duplicating urls caught by the listeners

--- a/src/chrome/extension/scripts/context.ts
+++ b/src/chrome/extension/scripts/context.ts
@@ -5,11 +5,12 @@ import ui_constants = require('../../../interfaces/ui');
 import user_interface = require('../../../generic_ui/scripts/ui');
 import CoreConnector = require('../../../generic_ui/scripts/core_connector');
 import ChromeCoreConnector = require('./chrome_core_connector');
+import browser_connector = require('../../../interfaces/browser_connector');
 
 var ui_context :UiGlobals = (<any>chrome.extension.getBackgroundPage()).ui_context;
 export var ui :user_interface.UserInterface= ui_context.ui;
 export var core :CoreConnector = ui_context.core;
-export var browserConnector = ui_context.browserConnector;
+export var browserConnector :browser_connector.CoreBrowserConnector = ui_context.browserConnector;
 export var model :user_interface.Model = ui_context.model;
 ui.browser = 'chrome';
 

--- a/src/chrome/extension/scripts/context.ts
+++ b/src/chrome/extension/scripts/context.ts
@@ -6,15 +6,13 @@ import user_interface = require('../../../generic_ui/scripts/ui');
 import CoreConnector = require('../../../generic_ui/scripts/core_connector');
 import ChromeCoreConnector = require('./chrome_core_connector');
 
-interface ChromeGlobals extends UiGlobals {
-  chromeCoreConnector :ChromeCoreConnector;
-}
-
-var ui_context :ChromeGlobals = (<any>chrome.extension.getBackgroundPage()).ui_context;
+var ui_context :UiGlobals = (<any>chrome.extension.getBackgroundPage()).ui_context;
 export var ui :user_interface.UserInterface= ui_context.ui;
 export var core :CoreConnector = ui_context.core;
-export var chromeCoreConnector = ui_context.chromeCoreConnector;
+export var browserConnector = ui_context.browserConnector;
 export var model :user_interface.Model = ui_context.model;
 ui.browser = 'chrome';
+
+//var whatever = new user_interface.UserInterface(core, browserConnector);
 
 console.log('Loaded dependencies for Chrome Extension.');

--- a/src/chrome/extension/scripts/context.ts
+++ b/src/chrome/extension/scripts/context.ts
@@ -13,6 +13,4 @@ export var browserConnector = ui_context.browserConnector;
 export var model :user_interface.Model = ui_context.model;
 ui.browser = 'chrome';
 
-//var whatever = new user_interface.UserInterface(core, browserConnector);
-
 console.log('Loaded dependencies for Chrome Extension.');

--- a/src/firefox/data/scripts/background.ts
+++ b/src/firefox/data/scripts/background.ts
@@ -9,7 +9,7 @@ export var core :CoreConnector;
 export var browserConnector: FirefoxCoreConnector;
 function initUI() {
     browserConnector = new FirefoxCoreConnector();
-    core = new CoreConnector(firefoxCoreConnector);
+    core = new CoreConnector(browserConnector);
     var firefoxBrowserApi = new FirefoxBrowserApi();
 
     return new user_interface.UserInterface(core, firefoxBrowserApi);

--- a/src/firefox/data/scripts/background.ts
+++ b/src/firefox/data/scripts/background.ts
@@ -6,8 +6,9 @@ import FirefoxBrowserApi = require('./firefox_browser_api');
 export import model = user_interface.model;
 export var ui   :user_interface.UserInterface;
 export var core :CoreConnector;
+export var browserConnector: FirefoxCoreConnector;
 function initUI() {
-    var firefoxCoreConnector = new FirefoxCoreConnector();
+    browserConnector = new FirefoxCoreConnector();
     core = new CoreConnector(firefoxCoreConnector);
     var firefoxBrowserApi = new FirefoxBrowserApi();
 

--- a/src/firefox/data/scripts/firefox_connector.ts
+++ b/src/firefox/data/scripts/firefox_connector.ts
@@ -17,6 +17,7 @@ import port = require('./port');
 class FirefoxConnector implements browser_connector.CoreBrowserConnector {
 
   public status :browser_connector.StatusObject;
+  public onceConnected :Promise<void>;
 
   constructor() {
     this.status = { connected: true };
@@ -30,6 +31,7 @@ class FirefoxConnector implements browser_connector.CoreBrowserConnector {
 
   public connect = () :Promise<void> => {
     this.emit('core_connect');
+    this.onceConnected = Promise.resolve<void>();
     return Promise.resolve<void>();
   }
 

--- a/src/generic_ui/index.html
+++ b/src/generic_ui/index.html
@@ -6,7 +6,7 @@
   <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
   <script src='../bower/webcomponentsjs/webcomponents.min.js'></script>
 
-  <script src='scripts/context.static.js'></script>
+  <script src='../scripts/context.static.js'></script>
 
   <link rel='import' href='polymer/vulcanized.html'>
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>

--- a/src/generic_ui/polymer/context.d.ts
+++ b/src/generic_ui/polymer/context.d.ts
@@ -5,6 +5,7 @@ interface UiGlobals {
   ui :any;
   core :any;
   model :any;
+  browserConnector :any
 }
 
 declare var ui_context :UiGlobals;

--- a/src/interfaces/browser_connector.ts
+++ b/src/interfaces/browser_connector.ts
@@ -49,4 +49,5 @@ export interface CoreBrowserConnector {
   on(name :'core_disconnect', callback :() => void) :void;
 
   status :StatusObject;
+  onceConnected :Promise<void>;
 }


### PR DESCRIPTION
We need to browserify context.js from chrome/extension/scripts, otherwise relative paths are wrong.

We copy all polymer files with all the supporting files to chrome/extension directory and vulcanized it from there. This is necessary because we have some browser specific polymer code. So currently vulcanized code lives in chrome/extension/generic_ui/polymer, and it has dependency on context.js, when we try to browserify vulcanized file it breaks again, because paths are wrong.

Possible solutions to this problem are:
1. we don't need to have browser specific elements instead polymer code can live in generic_ui/polymer and bi-browser, similarly the way we do about restart button. That way we could vulcanize polymer code from the common place and copy it to browser specific location. In general generic_ui and generic_core should not depend on browser specifi code and only the other way around. That would allow browserifying and vulcanizing common code in common place.
2. We could make deep copy under chrome/extension, so if we have chrome/extension/generic_ui/scripts/ui.js context.js would have to live in chrome/extension/chrome/extension/scripts/context.js in order "../../../generic_ui/scripts/ui" path to be resolved. I hate this solution.
3. Break the dependency between polymer code and context. js. that way we vulcanize and browserify polymer code from chrome/extension/generic_ui/polymer, and browserify context.js from chrome/extension/scripts. This is what we do in this pull request.

I like first solution more, but I believed that would be more controversial and I'm blocked on this and I wanted to do the quickest fix. Also I just believe it's wrong to have this dependency, that means that code is run twice.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1538)
<!-- Reviewable:end -->
