### PR TITLE
Show Facebook contacts without any known instances

### DIFF
--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -352,14 +352,10 @@ var log :logging.Log = new logging.Log('remote-user');
           isOnline = true;
         }
       }
-      if (allInstanceIds.length === 0) {
-        // Don't send users to UI if they don't have any instances (i.e. are not
+      if (!this.network.areAllContactsUproxy() && allInstanceIds.length === 0) {
+        // For networks which give us profiles for non-uProxy contacts, don't
+        // send users to the UI unless they have instances (they may not be
         // uProxy users).
-        // TODO: ideally we should not have User objects for users without
-        // instances, but for now we create Users whenever we get a UserProfile
-        // or ClientState from the social provider that isn't
-        // ONLINE_WITH_OTHER_APP.  For now this is necessary because we don't
-        // yet load instances from storage until User objects are created.
         return null;
       }
 
@@ -465,7 +461,7 @@ var log :logging.Log = new logging.Log('remote-user');
           this.instances_[instanceId] = new remote_instance.RemoteInstance(this, instanceId);
           onceLoadedPromises.push(this.instances_[instanceId].onceLoaded);
         }
-        
+
       }
       Promise.all(onceLoadedPromises).then(this.fulfillStorageLoad_);
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -40,15 +40,18 @@ import ui = ui_connector.connector;
   export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     'Google': {
       isFirebase: false,
-      enableMonitoring: true
+      enableMonitoring: true,
+      areAllContactsUproxy: false
     },
     'Facebook': {
       isFirebase: true,
-      enableMonitoring: true
+      enableMonitoring: true,
+      areAllContactsUproxy: true
     },
     'Google+': {
       isFirebase: true,
-      enableMonitoring: true
+      enableMonitoring: true,
+      areAllContactsUproxy: false
     }
   }
 
@@ -257,6 +260,12 @@ import ui = ui_connector.connector;
 
     public getNetworkState = () :social.NetworkState => {
       throw new Error('Operation not implemented');
+    }
+
+    public areAllContactsUproxy = () : boolean => {
+      // Default to false.
+      var options :social.NetworkOptions = NETWORK_OPTIONS[this.name];
+      return options ? options.areAllContactsUproxy === true : false;
     }
 
   }  // class AbstractNetwork

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -87,6 +87,7 @@ export interface NetworkState {
 export interface NetworkOptions {
   isFirebase :boolean;
   enableMonitoring :boolean;
+  areAllContactsUproxy :boolean;
 }
 
 /**
@@ -278,5 +279,7 @@ export interface Network {
       => Promise<void>;
 
   getNetworkState : () => NetworkState;
+
+  areAllContactsUproxy : () => boolean;
 }
 


### PR DESCRIPTION
Show Facebook contacts without any known instances.  For Facebook (unlike Google), we know that every contact who we get a UserProfile for must have permissioned uProxy (Facebook's <user>/friends endpoint only returns friends who have granted that app OAuth permission).

This solves the problem where Alice and Bob are both Facebook friends, yet the first time Alice signs into uProxy w/ Facebook Bob is not online, and vice-versa, and they don't appear in each others buddy list.

Tested on Chrome, Firefox, reran "grunt test"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1540)
<!-- Reviewable:end -->
