### PR TITLE
Add some global css rules

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -360,6 +360,8 @@ module.exports = (grunt) ->
               'scripts/background.static.js'
               '!**/*spec*'
 
+              'generic_ui/style/*.css'
+
               # extra components we use
               'generic_ui/fonts/*'
               'generic_ui/icons/*'
@@ -442,6 +444,8 @@ module.exports = (grunt) ->
               'data/generic_ui/polymer/vulcanized*.{html,js}'
               '!data/generic_ui/polymer/vulcanized*inline.html'
               '!data/generic_ui/polymer/vulcanized.js' # vulcanized.html uses vulcanized.static.js
+
+              'data/generic_ui/style/*.css'
 
               'data/fonts/*'
               'data/icons/*'

--- a/src/generic_ui/index.html
+++ b/src/generic_ui/index.html
@@ -10,6 +10,7 @@
 
   <link rel='import' href='polymer/vulcanized.html'>
   <link href='fonts/Roboto.css' rel='stylesheet' type='text/css'>
+  <link href='style/global.css' rel='stylesheet' shim-shadowdom>
 
   <style>
     @font-face {

--- a/src/generic_ui/polymer/app-bar.html
+++ b/src/generic_ui/polymer/app-bar.html
@@ -1,5 +1,4 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
 
 <polymer-element name='uproxy-app-bar' attributes='disableback' center horizontal layout>
   <template>

--- a/src/generic_ui/polymer/bubble.html
+++ b/src/generic_ui/polymer/bubble.html
@@ -62,7 +62,7 @@ uproxy-bubble::shadow #done {
     #actions {
       text-align: right;
     }
-    #done {
+    paper-button#done {
       background-color: #222;
     }
 

--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -79,8 +79,6 @@
       opacity: 0.5;
     }
     paper-button {
-      background: rgb(221, 221, 221);
-      color: rgb(112, 112, 112);
       font-size: 1em;
       margin: 14px 5px 5px 2px;
       padding-left: 1em;
@@ -97,10 +95,6 @@
     }
     core-icon[icon=check] {
       color: #009688;
-    }
-    .highlightedButton {
-      background: #009688;  /* dark green */
-      color: white;
     }
     p.preButtonDetailedText {
       margin: 18px 0px 0px 0px;
@@ -175,22 +169,22 @@
           </p>
         </div>
         <p class='preButtonDetailedText'>You will be able to get access when {{ contact.name }} accepts.</p>
-        <paper-button raised on-tap='{{ cancelRequest }}'>Cancel Request</paper-button>
+        <paper-button class='grey' raised on-tap='{{ cancelRequest }}'>Cancel Request</paper-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.REMOTE_OFFERED_LOCAL_NO_ACTION }}'>
         <p class='preButtonText'>They've offered you access.</p>
-        <paper-button class='highlightedButton' raised on-tap='{{ request }}'>Accept Offer</paper-button>
-        <paper-button class='highlightedButton' raised on-tap='{{ ignoreOffer }}'>Ignore</paper-button>
+        <paper-button raised on-tap='{{ request }}'>Accept Offer</paper-button>
+        <paper-button raised on-tap='{{ ignoreOffer }}'>Ignore</paper-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.REMOTE_OFFERED_LOCAL_IGNORED }}'>
         <p class='preButtonText'>They've offered you access.</p>
-        <paper-button raised on-tap='{{ unignoreOffer }}'>Stop ignoring offers</paper-button>
+        <paper-button class='grey' raised on-tap='{{ unignoreOffer }}'>Stop ignoring offers</paper-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.NO_OFFER_OR_REQUEST }}'>
-        <paper-button raised class='highlightedButton' on-tap='{{ request }}'>
+        <paper-button raised on-tap='{{ request }}'>
           Ask for access
         </paper-button>
       </div>
@@ -203,11 +197,11 @@
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.LOCAL_OFFERED_REMOTE_ACCEPTED }}'>
         <p class='preButtonText'>You've given them access.</p>
-        <paper-button raised on-tap='{{ cancelOffer }}'>Revoke Access</paper-button>
+        <paper-button class='grey' raised on-tap='{{ cancelOffer }}'>Revoke Access</paper-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.LOCAL_OFFERED_REMOTE_NO_ACTION }}'>
-        <paper-button raised on-tap='{{ cancelOffer }}'>Cancel Offer</paper-button>
+        <paper-button class='grey' raised on-tap='{{ cancelOffer }}'>Cancel Offer</paper-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.REMOTE_REQUESTED_LOCAL_NO_ACTION }}'>
@@ -217,18 +211,18 @@
             {{ contact.name }} requests access from you.
           </p>
         </div>
-        <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Grant</paper-button>
-        <paper-button raised class='highlightedButton' on-tap='{{ ignoreRequest }}'>Ignore</paper-button>
+        <paper-button raised on-tap='{{ offer }}'>Grant</paper-button>
+        <paper-button raised on-tap='{{ ignoreRequest }}'>Ignore</paper-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.REMOTE_REQUESTED_LOCAL_IGNORED }}'>
         <p class='preButtonText'>They requested access through you.</p>
-        <paper-button raised on-tap='{{ unignoreRequest }}'>Stop ignoring requests</paper-button>
+        <paper-button class='grey' raised on-tap='{{ unignoreRequest }}'>Stop ignoring requests</paper-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.NO_OFFER_OR_REQUEST }}'>
         <p class='preButtonText'>You have not granted them access.</p>
-        <paper-button raised class='highlightedButton' on-tap='{{ offer }}'>Offer Access</paper-button>
+        <paper-button raised on-tap='{{ offer }}'>Offer Access</paper-button>
       </div>
     </core-collapse> <!-- end of shareControls -->
 

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -20,13 +20,7 @@
       height: 10em;
     }
     paper-button {
-      background: #009688;  /* dark green */
-      color: white;
       margin-bottom: 24px;
-    }
-    paper-button.stop {
-      background: rgb(221, 221, 221);
-      color: rgb(112, 112, 112);
     }
     #getting, #sharing, #nothing {
       margin: 24px;
@@ -107,7 +101,7 @@
           Start getting access
         </paper-button>
 
-        <paper-button raised class='stop' on-tap='{{ stopGetting }}'
+        <paper-button raised class='grey' on-tap='{{ stopGetting }}'
             hidden?='{{ ui.copyPastePendingEndpoint !== null }}'>
           Stop getting access
         </paper-button>
@@ -158,7 +152,7 @@
       <div class='connected' hidden?='{{ ui.copyPasteSharingState !== SharingState.SHARING_ACCESS }}'>
         <p>Success!  A one-time connection has been established.</p>
 
-        <paper-button raised class='stop' on-tap='{{ stopSharing }}'>Stop sharing access</paper-button>
+        <paper-button raised class='grey' on-tap='{{ stopSharing }}'>Stop sharing access</paper-button>
 
         <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}' class='error'>
           <p>You are currently sharing access.</p>

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -18,8 +18,6 @@
         color: rgb(112, 112, 112);
       }
       paper-button {
-        background: #009688;  /* dark green */
-        color: white;
         width: 70px;
         margin-left: 0px;
         margin-right: 5px;

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -1,5 +1,4 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
 <link rel='import' href='../../bower/paper-checkbox/paper-checkbox.html'>
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/paper-input/paper-autogrow-textarea.html'>
@@ -85,11 +84,6 @@
          tooltip, it appears off center. */
       left: -64px !important;
     }
-    paper-button {
-      background-color: #009688; /* teal */
-      color: white;
-      margin-bottom: 3px;
-    }
     paper-input-decorator[id=emailDecorator] /deep/ .unfocused-underline,
     paper-input-decorator[id=emailDecorator] /deep/ .focused-underline,
     paper-input-decorator /deep/ .cursor {
@@ -120,9 +114,6 @@
     #sendingFeedback {
       text-align: center;
       font-size: 16px;
-    }
-    paper-progress::shadow #activeProgress {
-      background-color: #009688;
     }
     #feedbackDecorator {
       height: 190px;

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -9,16 +9,10 @@
       opacity: 0.5;
     }
     paper-button {
-      background: rgb(221, 221, 221);
-      color: rgb(112, 112, 112);
       font-size: 1em;
       margin: 14px 5px 5px 2px;
       padding-left: 1em;
       padding-right: 1em;
-    }
-    .highlightedButton {
-      background: #009688;  /* dark green */
-      color: white;
     }
     .preButtonText {
       margin: 0;
@@ -50,21 +44,21 @@
 
       <!-- not getting or trying to get access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
-        <paper-button class='highlightedButton' raised on-tap='{{ start }}'>
+        <paper-button raised on-tap='{{ start }}'>
           Start getting access
         </paper-button>
       </div>
 
       <!-- trying to get access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.TRYING_TO_GET_ACCESS }}'>
-        <paper-button raised on-tap='{{ stop }}'>
+        <paper-button class='grey' raised on-tap='{{ stop }}'>
           Cancel
         </paper-button>
       </div>
 
       <!-- currently getting access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.GETTING_ACCESS }}'>
-        <paper-button raised on-tap='{{ stop }}'>
+        <paper-button class='grey' raised on-tap='{{ stop }}'>
           Stop getting access
         </paper-button>
       </div>

--- a/src/generic_ui/polymer/network.html
+++ b/src/generic_ui/polymer/network.html
@@ -9,9 +9,7 @@
         box-sizing: border-box;
       }
       paper-button {
-        color: white;
         width: 150px;
-        background: #009688;  /* default to dark green */
       }
       paper-button.Google {
         background: #dd4b39;

--- a/src/generic_ui/polymer/reconnect.html
+++ b/src/generic_ui/polymer/reconnect.html
@@ -11,8 +11,6 @@
       font-color: #009688;  /* dark green */
     }
     paper-button {
-      background-color: #009688; /* teal */
-      color: white;
       margin: 10px 2px 3px 2px;
       font-size: 12px;
     }
@@ -20,9 +18,6 @@
       top: 20%;
       min-width: 305px;
       z-index: 1002; /* Must be greater than core-overlay-backdrop */
-    }
-    paper-progress::shadow #activeProgress {
-      background-color: #009688;
     }
     paper-progress {
       margin-bottom: 1em;

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -157,8 +157,6 @@
         z-index: 1001;
       }
       uproxy-action-dialog paper-button {
-        background-color: #009688; /* teal */
-        color: white;
         margin-bottom: 3px;
       }
       uproxy-faq-link .linkText {

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -57,9 +57,6 @@
     #loadingContacts {
       margin-top: 0.5em;
     }
-    paper-progress::shadow #activeProgress {
-      background-color: #009688;
-    }
     paper-progress {
       margin-bottom: 1em;
     }

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -74,8 +74,6 @@
         background-color: #009688;
     }
     paper-button {
-      background: #009688;  /* dark green */
-      color: white;
       width: 70px;
       margin-left: 0px;
       margin-right: 5px;

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -53,8 +53,6 @@
       z-index: -1;
     }
     paper-button {
-      background: #009688;  /* dark green */
-      color: white;
       width: 150px;
     }
     uproxy-network {

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -40,8 +40,6 @@
       cursor: pointer;
     }
     paper-button {
-      background-color: #009688; /* teal */
-      color: white;
       margin: 10px 2px 3px 2px;
       font-size: 12px;
     }
@@ -66,9 +64,6 @@
     }
     #analyzedNetworkButtons {
       text-align: center;
-    }
-    paper-progress::shadow #activeProgress {
-      background-color: #009688;
     }
     uproxy-faq-link .linkText {
       text-decoration: underline;

--- a/src/generic_ui/style/global.css
+++ b/src/generic_ui/style/global.css
@@ -1,0 +1,20 @@
+/* add simple classes to buttons for green and grey */
+body /deep/ paper-button {
+  background: #009688;  /* teal 500 */
+  color: white;
+}
+
+body /deep/ paper-button[disabled] {
+  background: #4DB6AC;  /* teal 300 */
+  color: white;
+}
+
+body /deep/ paper-button.grey {
+  background: #DDDDDD;
+  color: #707070;
+}
+
+/* all paper-progress places should be green */
+body /deep/ paper-progress::shadow #activeProgress {
+  background: #009688;
+}


### PR DESCRIPTION
This works towards the goal of getting rid of some of our absolutely
dreadful CSS duplication.  Styles that we find ourselves repeatedly
applying everywhere we use some elements should be contained in the same
place, and we should also be trying to do things with as few rules as
possible (e.g. let's pick a default font size and change it, at the
highest level possible, only where it needs to be changed).

This obviously does not address most of our problems, however, it does
create a single file at the global scope that handles colouring
paper-buttons teal (or grey) as well as well as changing the colouring
for the progress bars we use.

Works towards the conveniently opened #1542

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1544)
<!-- Reviewable:end -->
