### PR TITLE
freedom-for-firefox onDisconnect fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "es6-promise": "^2.0.0",
     "freedomjs-anonymized-metrics": "~0.1.0",
     "freedom-for-chrome": "^0.4.11",
-    "freedom-for-firefox": "0.6.10",
+    "freedom-for-firefox": "^0.6.13",
     "freedom-social-firebase": "^0.0.12",
     "freedom-social-xmpp": "^0.3.6",
     "fs-extra": "^0.12.0",


### PR DESCRIPTION
Tested the resulting built addon, it no longer sporadically disconnects, and proxies at a nice speed. Hopefully getting this in will also enable more anonymized metrics collection in the near future.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1545)
<!-- Reviewable:end -->
