### PR TITLE
Detect and report when we are unable to proxy

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -24,6 +24,8 @@ class ChromeBrowserApi implements BrowserAPI {
 
   public browserSpecificElement = "uproxy-app-missing";
 
+  public canProxy = true;
+
   // For browser action.
 
   public ICON_DIR :string = 'icons/';
@@ -69,6 +71,23 @@ class ChromeBrowserApi implements BrowserAPI {
 
     chrome.proxy.settings.clear({scope: 'regular'});
 
+    chrome.proxy.settings.get({}, (details) => {
+      this.canProxy = this.canControlProxy_(details.levelOfControl);
+    });
+
+    chrome.proxy.settings.onChange.addListener((details) => {
+      if (!this.canControlProxy_(details.levelOfControl)) {
+        if (this.canProxy && this.running_) {
+          // only emit the event if we are learning about this for the first
+          // time and a proxy is currently active
+          this.emit('proxyDisconnected');
+        }
+        this.canProxy = false;
+      } else {
+        this.canProxy = true;
+      }
+    });
+
     chrome.windows.onRemoved.addListener((closedWindowId) => {
       // If either the window launching uProxy, or the popup with uProxy
       // is closed, reset the IDs tracking those windows.
@@ -77,6 +96,11 @@ class ChromeBrowserApi implements BrowserAPI {
         this.popupState_ = PopupState.NOT_LAUNCHED;
       }
     });
+  }
+
+  private canControlProxy_ = (level :string) :boolean => {
+    return level === 'controllable_by_this_extension' ||
+           level === 'controlled_by_this_extension';
   }
 
   public startUsingProxy = (endpoint:net.Endpoint) => {
@@ -100,10 +124,7 @@ class ChromeBrowserApi implements BrowserAPI {
     if (this.running_) {
       console.log('Reverting Chrome proxy settings');
       this.running_ = false;
-      chrome.proxy.settings.set({
-        value: this.preUproxyConfig_,
-        scope: 'regular'
-      });
+      chrome.proxy.settings.clear({ scope: 'regular' });
     }
   };
 

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -21,6 +21,7 @@ interface FullfillAndReject {
 class FirefoxBrowserApi implements BrowserAPI {
 
   public browserSpecificElement :string;
+  public canProxy = true;
 
   // Global unique promise ID.
   private promiseId_ :number = 1;

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -44,7 +44,7 @@
 
       <!-- not getting or trying to get access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
-        <paper-button raised on-tap='{{ start }}'>
+        <paper-button raised on-tap='{{ start }}' disabled?='{{ !ui.browserApi.canProxy }}'>
           Start getting access
         </paper-button>
       </div>

--- a/src/generic_ui/polymer/proxy-error.html
+++ b/src/generic_ui/polymer/proxy-error.html
@@ -1,0 +1,49 @@
+<polymer-element name='uproxy-proxy-error'>
+  <template>
+    <style>
+      :host {
+        text-align: center;
+      }
+
+      core-icon.close {
+        float: right;
+        color: grey;
+        opacity: .6;
+      }
+      core-icon.close:hover {
+        opacity: 1;
+      }
+
+      core-icon.button {
+        cursor: pointer;
+      }
+
+      p {
+        color: rgba(0, 0, 0, .55);
+      }
+    </style>
+
+    <core-signals on-core-signal-open-proxy-error='{{ openWithError }}'></core-signals>
+
+    <uproxy-dialog id='dialog' backdrop layered='false'>
+      <core-icon class="close button" icon="clear" on-tap='{{ close }}'></core-icon>
+      <h2>Unable to get access</h2>
+
+      <p hidden?='{{ !wasError }}'>
+        Your active proxying session has been disconnected as we are no longer
+        able to control the browser proxy settings.
+      </p>
+
+      <p hidden?='{{ wasError }}'>
+        We are currently unable to set up a proxy due to another extension.
+      </p>
+
+      <p>
+        Please disable any other extensions which may be affecting your proxy
+        settings before trying to get access.
+      </p>
+    </uproxy-dialog>
+  </template>
+
+  <script src='proxy-error.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/proxy-error.ts
+++ b/src/generic_ui/polymer/proxy-error.ts
@@ -1,0 +1,17 @@
+/// <reference path='./context.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+
+Polymer({
+  error: false,
+  openWithError: function() {
+    this.wasError = true;
+    this.open();
+  },
+  open: function() {
+    this.$.dialog.open();
+  },
+  close: function() {
+    this.wasError = false;
+    this.$.dialog.close();
+  },
+});

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -20,6 +20,7 @@
 <link rel='import' href='dialog.html'>
 <link rel='import' href='browser-elements.html'>
 <link rel='import' href='icons.html'>
+<link rel='import' href='proxy-error.html'>
 
 <polymer-element name='uproxy-root' attributes='model' on-update-view='{{ updateView }}' on-open-dialog='{{ openDialog }}'>
 
@@ -134,14 +135,22 @@
         padding-left: 20px;
         padding-right: 20px;
         padding-top: 19px;
-        text-overflow: ellipsis;
         white-space: nowrap;
-        overflow: hidden;
         font-size: 14px;
+      }
+      .statusText, .statusText [flex] {
+        /* cut off the statusText itself, or any contained flex-grow element */
+        text-overflow: ellipsis;
+        overflow: hidden;
       }
       .statusRow core-icon {
         padding-right: 20px;
+      }
+      .statusRow a, .statusRow core-icon {
         color: #0EC5AF;
+      }
+      .statusRow.error core-icon {
+        color: #DD2D2D;
       }
       uproxy-bubble {
         z-index: 1;
@@ -303,6 +312,15 @@
             </div>
 
             <div id='status'>
+              <div class='statusRow error' hidden?='{{ ui.browserApi.canProxy }}'>
+                <div class='statusText' horizontal layout>
+                  <core-icon icon='warning'></core-icon>
+                  <span flex>
+                    Other proxy settings in use
+                  </span>
+                  <a href='#' on-tap='{{ openProxyError }}'>GET HELP</a>
+                </div>
+              </div>
               <div class='statusRow' hidden?='{{!ui.gettingStatus}}'>
                 <div class='statusText'>
                   <core-icon icon='uproxy-icons:receive'></core-icon>
@@ -360,9 +378,11 @@
 
     <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>
 
+    <uproxy-proxy-error id='proxyError'></uproxy-proxy-error>
+
     <paper-toast id='toast'
         text='{{ toastMessage }}' responsiveWidth='320px'
-        style='bottom: {{ topOfStatuses([ui.gettingStatus, ui.sharingStatus], ui.view == ui_constants.View.ROSTER && !$.feedback.opened && !$.advancedSettings.opened) }}px;'
++        style='bottom: {{ topOfStatuses($.status.offsetHeight, ui.view == ui_constants.View.ROSTER && !$.feedback.opened) }}px;'
         duration='10000'>
       <div id='toastHelpLink' on-tap="{{ openTroubleshoot }}"
           hidden?='{{ !stringMatches(toastMessage, user_interface.GET_FAILED_MSG) && !stringMatches(toastMessage, user_interface.SHARE_FAILED_MSG) }}'>GET HELP

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -93,6 +93,9 @@ Polymer({
       this.$.dialog.open();
     });
   },
+  openProxyError: function() {
+    this.$.proxyError.open();
+  },
   dialogButtonClick: function(event :Event, detail :Object, target :HTMLElement) {
     var signal = target.getAttribute('data-signal');
     if (signal) {
@@ -144,7 +147,7 @@ Polymer({
     }
   },
   signalToFireChanged: function() {
-    if (ui.signalToFire != '') {
+    if (ui.signalToFire) {
       this.fire('core-signal', {name: ui.signalToFire});
       ui.signalToFire = '';
     }
@@ -178,29 +181,8 @@ Polymer({
     }
     return false;
   },
-  topOfStatuses: function(statuses: string[], visible :boolean) {
-    // Returns number of pixels from the bottom of the window a toast
-    // can be positioned without interfering with the getting or sharing
-    // status bars.
-    // Since the toast always looks for the bottom of the window, not the
-    // bottom of its parent element, this function is needed to control toast
-    // placement rather than a simpler solution such as moving the toast
-    // inside the roster element.
-    var height = 10; // should start 10px up
-    var statusRowHeight = 58; // From style of the statusRow divs.
-
-    if (!visible) {
-      // if the statuses are not on the screen, we don't need to do anything
-      return height;
-    }
-
-    for (var i in statuses) {
-      if (statuses[i]) {
-        height += statusRowHeight;
-      }
-    }
-
-    return height;
+  topOfStatuses: function(statusHeight: number, visible :boolean) {
+    return 10 + (visible ? statusHeight : 0);
   },
   // mainPanel.selected can be either "drawer" or "main"
   // Our "drawer" is the settings panel. When the settings panel is open,
@@ -233,6 +215,7 @@ Polymer({
     //   someMethod(model.contacts.shareAccessContacts.trustedUproxy)
     // in root.html, someMethod is not invoked when items are added or removed.
     'model.contacts.shareAccessContacts.trustedUproxy':
-        'updateIsSharingEnabledWithOthers'
+        'updateIsSharingEnabledWithOthers',
+    'ui.signalToFire': 'signalToFireChanged',
   }
 });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -385,6 +385,7 @@ export class UserInterface implements ui_constants.UiApi {
 
     browserApi.on('urlData', this.handleUrlData);
     browserApi.on('notificationClicked', this.handleNotificationClick);
+    browserApi.on('proxyDisconnected', this.proxyDisconnected);
   }
 
   // Because of an observer (in root.ts) watching the value of
@@ -528,6 +529,14 @@ export class UserInterface implements ui_constants.UiApi {
       }
 
       this.core.sendCopyPasteSignal(payload[i]);
+    }
+  }
+
+  public proxyDisconnected = () => {
+    if (this.isGettingAccess()) {
+      this.stopGettingFromInstance(this.instanceGettingAccessFrom_);
+      this.fireSignal('open-proxy-error');
+      this.bringUproxyToFront();
     }
   }
 

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -1,3 +1,5 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+
 import net = require('../../../third_party/uproxy-lib/net/net.types');
 
 // Describes the interface for functions that have different implications
@@ -16,6 +18,8 @@ export interface BrowserAPI {
   bringUproxyToFront() :void;
   // TODO: write comment to explain what browserSpecificElement is.
   browserSpecificElement :string;
+
+  canProxy :boolean;
 
   /*
    * tag is used to uniquely identify notifications.  If it is a json-encoded
@@ -37,4 +41,5 @@ export interface BrowserAPI {
   on(name :string, callback :Function) :void;
   on(name :'urlData', callback :(url :string) => void) :void;
   on(name :'notificationClicked', callback :(tag :string) => void) :void;
+  on(name :'proxyDisconnected', callback :Function) :void;
 }


### PR DESCRIPTION
This fixes errors in Chrome where we would be unable to proxy but would still tell the user that we were proxying.  With this change, we will not allow the user to set a proxying session when we are unable to actually control the settings.  Additionally, if the browser stops sending traffic through a proxy session, we will display an error.

Check commit messages for more details.

Tested by manual evaluation of the UI while toggling another extension that had precedence with proxy settings (and had them set).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1562)
<!-- Reviewable:end -->
