### PR TITLE
Enable proxying through yourself

### DIFF
--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -25,11 +25,11 @@ import uproxy_core_api = require('../interfaces/uproxy_core_api');
     ignoringRemoteUserRequest :boolean;
     ignoringRemoteUserOffer :boolean;
 
-    constructor(initConsent :boolean) {
-      this.localRequestsAccessFromRemote = initConsent;
+    constructor(initialConsent :boolean) {
+      this.localRequestsAccessFromRemote = initialConsent;
       this.ignoringRemoteUserOffer = false;
-      this.localGrantsAccessToRemote = initConsent;
-      this.remoteRequestsAccessFromLocal = initConsent;
+      this.localGrantsAccessToRemote = initialConsent;
+      this.remoteRequestsAccessFromLocal = initialConsent;
       this.ignoringRemoteUserRequest = false;
     }
   }

--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -25,11 +25,11 @@ import uproxy_core_api = require('../interfaces/uproxy_core_api');
     ignoringRemoteUserRequest :boolean;
     ignoringRemoteUserOffer :boolean;
 
-    constructor() {
-      this.localRequestsAccessFromRemote = false;
+    constructor(initConsent :boolean) {
+      this.localRequestsAccessFromRemote = initConsent;
       this.ignoringRemoteUserOffer = false;
-      this.localGrantsAccessToRemote = false;
-      this.remoteRequestsAccessFromLocal = false;
+      this.localGrantsAccessToRemote = initConsent;
+      this.remoteRequestsAccessFromLocal = initConsent;
       this.ignoringRemoteUserRequest = false;
     }
   }

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -18,6 +18,7 @@ import globals = require('./globals');
 import local_storage = require('./storage');
 import net = require('../../../third_party/uproxy-lib/net/net.types');
 import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
+import local_instance = require('./local-instance');
 
 
 describe('remote_instance.RemoteInstance', () => {
@@ -105,6 +106,8 @@ describe('remote_instance.RemoteInstance', () => {
             'network', ['getUser']);
         network['getStorePath'] = function() { return 'networkPath'; };
         network['getLocalInstanceId'] = function() { return 'myInstanceId'; };
+        network['myInstance'] =
+            new local_instance.LocalInstance(network, 'localUserId');
         var user = new remote_user.User(network, 'testUser');
         user.update({userId: 'testUser', name: 'Alice'});
         instance = new remote_instance.RemoteInstance(user, INSTANCE_ID);

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -30,7 +30,7 @@ describe('remote_instance.RemoteInstance', () => {
       'sendInstanceHandshake',
       'updateRemoteRequestsAccessFromLocal'
   ]);
-  user.consent = new consent.State();
+  user.consent = new consent.State(false);
 
   user.network = <social.Network><any>jasmine.createSpyObj(
       'network', ['getUser']);

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -393,19 +393,15 @@ describe('remote_user.User', () => {
   it('Initializes with consent for local user', () => {
     user = new remote_user.User(network, network.myInstance.userId);
     expect(user.consent.localRequestsAccessFromRemote).toEqual(true);
-    expect(user.consent.ignoringRemoteUserOffer).toEqual(false);
     expect(user.consent.localGrantsAccessToRemote).toEqual(true);
     expect(user.consent.remoteRequestsAccessFromLocal).toEqual(true);
-    expect(user.consent.ignoringRemoteUserRequest).toEqual(false);
   });
 
   it('Initializes without consent for other users', () => {
     user = new remote_user.User(network, 'otherUser');
     expect(user.consent.localRequestsAccessFromRemote).toEqual(false);
-    expect(user.consent.ignoringRemoteUserOffer).toEqual(false);
     expect(user.consent.localGrantsAccessToRemote).toEqual(false);
     expect(user.consent.remoteRequestsAccessFromLocal).toEqual(false);
-    expect(user.consent.ignoringRemoteUserRequest).toEqual(false);
   });
 
 });  // uProxy.User

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -295,9 +295,9 @@ describe('remote_user.User', () => {
     });
 
     it('invalid proxy transitions do not modify consent', (done) => {
-      var emptyConsent = new consent.State();
+      var emptyConsent = new consent.State(false);
 
-      user.consent = new consent.State();
+      user.consent = new consent.State(false);
       user.modifyConsent(uproxy_core_api.ConsentUserAction.CANCEL_REQUEST).then(() => {
         expect(user.consent).toEqual(emptyConsent);
         user.modifyConsent(uproxy_core_api.ConsentUserAction.UNIGNORE_OFFER).then(() => {
@@ -371,9 +371,9 @@ describe('remote_user.User', () => {
     });
 
     it('invalid client transitions do not modify consent', (done) => {
-      var emptyConsent = new consent.State();
+      var emptyConsent = new consent.State(false);
 
-      user.consent = new consent.State();
+      user.consent = new consent.State(false);
       user.modifyConsent(uproxy_core_api.ConsentUserAction.CANCEL_OFFER).then(() => {
         expect(user.consent).toEqual(emptyConsent);
         user.modifyConsent(

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -9,6 +9,7 @@ import consent = require('./consent');
 
 import globals = require('./globals');
 import storage = globals.storage;
+import local_instance = require('./local-instance');
 
 describe('remote_user.User', () => {
   // Prepare a fake Social.Network object to construct User on top of.
@@ -19,6 +20,8 @@ describe('remote_user.User', () => {
   ]);
   network['getLocalInstanceId'] = function() { return 'dummyInstanceId'; };
   network['send'] = () => { return Promise.resolve(); };
+  network['myInstance'] =
+      new local_instance.LocalInstance(network, 'localUserId');
 
   var user :remote_user.User;
   var instance :remote_instance.RemoteInstance;
@@ -385,6 +388,24 @@ describe('remote_user.User', () => {
         });
       });
     });
+  });
+
+  it('Initializes with consent for local user', () => {
+    user = new remote_user.User(network, network.myInstance.userId);
+    expect(user.consent.localRequestsAccessFromRemote).toEqual(true);
+    expect(user.consent.ignoringRemoteUserOffer).toEqual(false);
+    expect(user.consent.localGrantsAccessToRemote).toEqual(true);
+    expect(user.consent.remoteRequestsAccessFromLocal).toEqual(true);
+    expect(user.consent.ignoringRemoteUserRequest).toEqual(false);
+  });
+
+  it('Initializes without consent for other users', () => {
+    user = new remote_user.User(network, 'otherUser');
+    expect(user.consent.localRequestsAccessFromRemote).toEqual(false);
+    expect(user.consent.ignoringRemoteUserOffer).toEqual(false);
+    expect(user.consent.localGrantsAccessToRemote).toEqual(false);
+    expect(user.consent.remoteRequestsAccessFromLocal).toEqual(false);
+    expect(user.consent.ignoringRemoteUserRequest).toEqual(false);
   });
 
 });  // uProxy.User

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -97,7 +97,7 @@ var log :logging.Log = new logging.Log('remote-user');
       this.instanceToClientMap_ = {};
 
       this.consent =
-          new consent.State(userId == this.network.myInstance.userId);
+          new consent.State(userId === this.network.myInstance.userId);
 
       storage.load<social.UserState>(this.getStorePath()).then((state) => {
         this.restoreState(state);
@@ -356,18 +356,12 @@ var log :logging.Log = new logging.Log('remote-user');
         }
       }
 
-      if (this.network.areAllContactsUproxy()) {
-        // All contacts have uProxy enabled for this network.  Only keep the
-        // contact from the UI if it is the logged in user and there are no
-        // other instances.
-        if (this.userId == this.network.myInstance.userId &&
-            allInstanceIds.length === 0) {
-          return null;
-        }
-      } else if (allInstanceIds.length === 0) {
-        // For networks which give us profiles for non-uProxy contacts, don't
-        // send users to the UI unless they have instances (they may not be
-        // uProxy users).
+      if (allInstanceIds.length === 0 &&
+          (!this.network.areAllContactsUproxy() ||
+           this.userId === this.network.myInstance.userId)) {
+        // Don't send users with no instances to the UI if either the network
+        // gives us non-uProxy contacts, or it is the user we are logged in
+        // with.
         return null;
       }
 

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -321,25 +321,11 @@ describe('social_network.FreedomNetwork', () => {
 
   });  // describe events & communication
 
-  describe('outgoing communications', () => {
-
-    it('calls the social provider sendMessage', () => {
-      var network = new social_network.FreedomNetwork('mock');
-      spyOn(network, 'getStorePath').and.returnValue('');
-      network['freedomApi_'].sendMessage = jasmine.createSpy('sendMessage');
-      var msg = {type: social.PeerMessageType.INSTANCE, data: {'doge': 'wows'}};
-      network.send(network.addUser('mockuser'), 'fakeclient', msg);
-      expect(network['freedomApi_'].sendMessage).toHaveBeenCalledWith(
-        'fakeclient',
-        JSON.stringify({
-          type: msg.type, data: msg.data, version: globals.MESSAGE_VERSION
-        }));
-    });
-  });
-
   it('JSON.parse and stringify messages at the right layer', (done) => {
     var network = new social_network.FreedomNetwork('mock');
-      spyOn(network, 'getStorePath').and.returnValue('');
+    spyOn(network, 'getStorePath').and.returnValue('');
+    network['myInstance'] =
+            new local_instance.LocalInstance(network, 'localUserId');
     var user = network.addUser('mockuser');
     spyOn(user, 'handleMessage');
     var inMsg = {
@@ -385,61 +371,5 @@ describe('social_network.FreedomNetwork', () => {
     });
   });
   */
-
-});
-
-
-describe('social_network.ManualNetwork', () => {
-
-  var network :social_network.ManualNetwork =
-      new social_network.ManualNetwork('Manual');
-
-  var loginPromise :Promise<void>;
-
-  beforeEach(() => {
-    // Silence logging to keep test output clean.
-    spyOn(console, 'log');
-  });
-
-  it('can send messages to the UI', () => {
-    spyOn(ui, 'update');
-
-    var message :social.PeerMessage = {
-      type: social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER,
-      data: {
-        elephants: 'have trunks',
-        birds: 'do not'
-      }
-    };
-    network.send(network.getUser('mockuser'), 'dummyClientId', message);
-    expect(ui.update).toHaveBeenCalledWith(
-        uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE, message);
-  });
-
-  it('adds the sender to the roster upon receving a message', (done) => {
-    var senderClientId = 'dummy_client_id';
-    var senderUserId = senderClientId;
-    spyOn(network, 'getStorePath').and.returnValue('');
-
-    network.receive(senderClientId, VALID_MESSAGE);
-    expect(network.getUser(senderUserId)).toBeDefined();
-    done();
-  });
-
-  it('routes received messages appropriately', (done) => {
-    var senderClientId = 'dummy_client_id';
-    var senderUserId = senderClientId;
-
-    // Send an initial message so ManualNetwork creates the user object that we
-    // will spy on.
-    network.receive(senderClientId, VALID_MESSAGE)
-    var user = network.getUser(senderUserId);
-    expect(user).toBeDefined();
-    spyOn(user, 'handleMessage').and.returnValue(Promise.resolve());
-    network.receive(senderClientId, VALID_MESSAGE);
-    expect(user.handleMessage).toHaveBeenCalledWith(
-        senderClientId, VALID_MESSAGE);
-    done();
-  });
 
 });

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -224,8 +224,7 @@ import ui = ui_connector.connector;
      * messages for ourself too.
      */
     protected isNewFriend_ = (userId :string) :boolean => {
-      return !(this.myInstance && this.myInstance.userId == userId) &&
-             !(userId in this.roster);
+      return !(userId in this.roster);
     }
 
     public getLocalInstanceId = () : string => {
@@ -371,12 +370,8 @@ import ui = ui_connector.connector;
         });
 
         this.myInstance.updateProfile(userProfileMessage);
-
-        return;
       }
-      // Otherwise, this is a remote contact. Add them to the roster if
-      // necessary, and update their profile.
-      log.debug('Received UserProfile for other user', profile);
+      log.debug('Received UserProfile', profile);
       this.getOrAddUser_(userId).update(profile);
     }
 
@@ -404,11 +399,12 @@ import ui = ui_connector.connector;
         return;
       }
 
-      if (client.userId == this.myInstance.userId) {
-        // Log out if it's our own client id.
-        // TODO: Consider adding myself to the roster.
-        if (client.clientId === this.myInstance.clientId &&
-            client.status === social.ClientStatus.OFFLINE) {
+      if (client.userId == this.myInstance.userId &&
+          client.clientId === this.myInstance.clientId) {
+        if (client.status === social.ClientStatus.OFFLINE) {
+          // Our client is disconnected, log out of the social network
+          // (the social provider is responsible for clean up so we don't
+          // need to call logout here).
           this.fulfillLogout_();
         }
         log.info('received own ClientState', client);

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -219,9 +219,7 @@ import ui = ui_connector.connector;
     }
 
     /**
-     * Helper to determine if |userId| is a "new friend" to be added to the
-     * roster, and also isn't just our own userId, since we can receive XMPP
-     * messages for ourself too.
+     * Helper to determine if |userId| is a "new friend".
      */
     protected isNewFriend_ = (userId :string) :boolean => {
       return !(userId in this.roster);

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -23,6 +23,8 @@ describe('Core', () => {
   network.getUser = null;
   network.getStorePath = function() { return 'network-store-path'; };
   network['login'] = (remember:boolean) => { return Promise.resolve<void>() };
+  network['myInstance'] =
+            new local_instance.LocalInstance(network, 'localUserId');
   var user = new remote_user.User(network, 'fake-login');
   user.getInstance = null;
   user.notifyUI = () => {};

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -244,11 +244,11 @@
 
           <core-tooltip label='You are available for sharing.' position='left'>
             <core-icon id='sharingEnabledIcon' icon='uproxy-icons:share' class='status'
-              hidden?='{{ model.contacts.shareAccessContacts.trustedUproxy.length === 0 }}'
+              hidden?='{{ !isSharingEnabledWithOthers }}'
               on-tap='{{ setShareMode }}'></core-icon>
           </core-tooltip>
 
-          <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && model.contacts.shareAccessContacts.trustedUproxy.length > 0 }}'>
+          <uproxy-bubble on-closed='{{ closedSharing }}' active='{{ !model.globalSettings.hasSeenSharingEnabledScreen && isSharingEnabledWithOthers }}'>
             <h3>Sharing Enabled</h3>
             <p>This icon means you're available for sharing access with friends you've offered access to.</p>
           </uproxy-bubble>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -4,6 +4,7 @@
 import social = require('../../interfaces/social');
 import ui_types = require('../../interfaces/ui');
 import user_interface = require('../scripts/ui');
+import user_module = require('../scripts/user');
 
 var ui = ui_context.ui;
 var core = ui_context.core;
@@ -213,8 +214,20 @@ Polymer({
       this.$.statsTooltip.disabled = false;
     }
   },
+  isSharingEnabledWithOthers: false,
+  updateIsSharingEnabledWithOthers: function() {
+    var trustedContacts = model.contacts.shareAccessContacts.trustedUproxy;
+    if (trustedContacts.length === 1) {
+      this.isSharingEnabledWithOthers =
+          trustedContacts[0].userId != model.onlineNetwork.userId;
+    } else {
+      this.isSharingEnabledWithOthers = trustedContacts.length > 0;
+    }
+  },
   observe: {
     '$.mainPanel.selected' : 'drawerToggled',
     'ui.toastMessage': 'toastMessageChanged',
+    'model.contacts.shareAccessContacts.trustedUproxy':
+        'updateIsSharingEnabledWithOthers'
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -219,7 +219,7 @@ Polymer({
     var trustedContacts = model.contacts.shareAccessContacts.trustedUproxy;
     if (trustedContacts.length === 1) {
       this.isSharingEnabledWithOthers =
-          trustedContacts[0].userId != model.onlineNetwork.userId;
+          trustedContacts[0].userId !== model.onlineNetwork.userId;
     } else {
       this.isSharingEnabledWithOthers = trustedContacts.length > 0;
     }
@@ -227,6 +227,11 @@ Polymer({
   observe: {
     '$.mainPanel.selected' : 'drawerToggled',
     'ui.toastMessage': 'toastMessageChanged',
+    // Use an observer on model.contacts.shareAccessContacts.trustedUproxy
+    // so that we can detect any time elements are added or removed from this
+    // array.  Unfortunately if we try doing
+    //   someMethod(model.contacts.shareAccessContacts.trustedUproxy)
+    // in root.html, someMethod is not invoked when items are added or removed.
     'model.contacts.shareAccessContacts.trustedUproxy':
         'updateIsSharingEnabledWithOthers'
   }

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -12,6 +12,8 @@ describe('UI.User', () => {
   beforeEach(() => {
     spyOn(console, 'log');
     ui = jasmine.createSpyObj<user_interface.UserInterface>('UserInterface', ['showNotification']);
+    user_interface.model.onlineNetwork =
+        {name: 'testNetwork', userId: 'localUserId', roster: {}};
     sampleUser = new user.User('fakeuser', null, ui);
     sampleUser.update(makeUpdateMessage({}));
   });

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -72,7 +72,9 @@ export class User implements social.BaseUser {
     }
 
     // if we do not have stored state, no use in checking for changes
-    if (this.consent_) {
+    if (this.consent_ &&
+        // Don't show notifications for other instances of yourself
+        this.userId != user_interface.model.onlineNetwork.userId) {
       // notifications for get mode
       if (!payload.consent.ignoringRemoteUserOffer) {
         if (this.offeringInstances.length === 0 && payload.offeringInstances.length > 0) {

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -74,7 +74,7 @@ export class User implements social.BaseUser {
     // if we do not have stored state, no use in checking for changes
     if (this.consent_ &&
         // Don't show notifications for other instances of yourself
-        this.userId != user_interface.model.onlineNetwork.userId) {
+        this.userId !== user_interface.model.onlineNetwork.userId) {
       // notifications for get mode
       if (!payload.consent.ignoringRemoteUserOffer) {
         if (this.offeringInstances.length === 0 && payload.offeringInstances.length > 0) {


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/688

We now allow proxying through other instances of yourself, which works in both Google and Facebook.

Some additional changes:
* Other instances of yourself are automatically permissioned for access
* We don't display you as a user in the buddylist unless you have another instance (i.e. multiple instances).  This is to prevent brand new users from signing in with Facebook and just seeing themselves on the buddylist
* We don't display desktop notifications for permission changes for other instances of yourself (to prevent "X has granted you access" from automatically appearing as soon as you sign on in 2 places with the same user)
* We only show the sharing enabled icon and tooltip if you are sharing with someone other than yourself
* Removed some bad tests

Tested in Chrome, Firefox, and with updated grunt tests

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1569)
<!-- Reviewable:end -->
