### PR TITLE
Use webcomponents.js v0.6.1. Update grunt file to copy FF scripts to correct places.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -454,7 +454,8 @@ module.exports = (grunt) ->
               'data/**/freedom-module.json'
               '!generic_core/freedom-module.json'
               'data/**/*.static.js'
-              'data/scripts/get_logs.js'
+              'data/generic_ui/scripts/get_logs.js'
+              'data/scripts/content-proxy.js'
               '!**/*spec*'
 
               'data/bower/webcomponentsjs/webcomponents.min.js'

--- a/bower.json
+++ b/bower.json
@@ -15,9 +15,10 @@
     "core-header-panel": "Polymer/core-header-panel#^0.5.6",
     "core-drawer-panel": "Polymer/core-drawer-panel#^0.5.6",
     "core-overlay": "Polymer/core-overlay#^0.5.6",
-    "paper-toast": "Polymer/paper-toast#^0.5.6"
+    "paper-toast": "Polymer/paper-toast#^0.5.6",
+    "webcomponentsjs": "0.6.1"
   },
   "resolutions": {
-    "webcomponentsjs": "^0.6.1"
+    "webcomponentsjs": "0.6.1"
   }
 }


### PR DESCRIPTION
https://github.com/webcomponents/webcomponentsjs released version 0.6.2 a few days ago, which breaks our Firefox UI. This updates our dependency to exactly version 0.6.1.

The changes to the Gruntfile fix the view-logs page in Firefox.

Tested manually in Chrome and Firefox.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1584)
<!-- Reviewable:end -->
