### PR TITLE
Remove 'Restart' option from Firefox settings.

### DIFF
--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -170,7 +170,7 @@
 
         <hr>
 
-        <uproxy-link on-tap='{{ restart }}' hidden?='{{ ui.browser !== 'chrome' }}' role='button'>
+        <uproxy-link on-tap='{{ restart }}' hidden?='{{ ui.browser !== "chrome" }}' role='button'>
           <core-icon icon='refresh'></core-icon>
           Restart
         </uproxy-link>


### PR DESCRIPTION
The "Restart" option was showing up in Firefox settings and clicking it wasn't doing anything.
Tested manually.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1586)
<!-- Reviewable:end -->
