### PR TITLE
migrate to uproxy-lib v27, use the bridge (without obfuscation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^27.1.0",
+    "uproxy-lib": "^27.2.0",
     "utransformers": "^0.2.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^26.0.0",
+    "uproxy-lib": "^27.0.0",
     "utransformers": "^0.2.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^27.0.0",
+    "uproxy-lib": "^27.1.0",
     "utransformers": "^0.2.1"
   },
   "peerDependencies": {

--- a/src/generic_core/dev_build/freedom-module.json
+++ b/src/generic_core/dev_build/freedom-module.json
@@ -30,6 +30,10 @@
     "metrics": {
       "url": "../freedomjs-anonymized-metrics/anonmetrics.json",
       "api": "metrics"
+    },
+    "churnPipe": {
+      "url": "../uproxy-lib/churn-pipe/freedom-module.json",
+      "api": "churnPipe"
     }
   },
   "permissions": [

--- a/src/generic_core/dist_build/freedom-module.json
+++ b/src/generic_core/dist_build/freedom-module.json
@@ -26,6 +26,10 @@
     "metrics": {
       "url": "../freedomjs-anonymized-metrics/anonmetrics.json",
       "api": "metrics"
+    },
+    "churnPipe": {
+      "url": "../uproxy-lib/churn-pipe/freedom-module.json",
+      "api": "churnPipe"
     }
   },
   "permissions": [

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -12,7 +12,7 @@ export var storage = new local_storage.Storage();
 export var STORAGE_VERSION = 1;
 
 // 1: initial release
-// 2: uproxy-lib v27, move to bridge and support basicObfuscation
+// 2: uproxy-lib v27, move to bridge but no obfuscation yet
 export var MESSAGE_VERSION = 2;
 
 export var DEFAULT_STUN_SERVERS = [

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -10,16 +10,19 @@ var log :logging.Log = new logging.Log('globals');
 export var storage = new local_storage.Storage();
 
 export var STORAGE_VERSION = 1;
-export var MESSAGE_VERSION = 1;
+
+// 1: initial release
+// 2: uproxy-lib v27, move to bridge and support basicObfuscation
+export var MESSAGE_VERSION = 2;
 
 export var DEFAULT_STUN_SERVERS = [
-  {urls: ['stun:stun.services.mozilla.com']},
-  {urls: ['stun:stun.stunprotocol.org']},
   {urls: ['stun:stun.l.google.com:19302']},
   {urls: ['stun:stun1.l.google.com:19302']},
   {urls: ['stun:stun2.l.google.com:19302']},
   {urls: ['stun:stun3.l.google.com:19302']},
   {urls: ['stun:stun4.l.google.com:19302']},
+  {urls: ['stun:stun.services.mozilla.com']},
+  {urls: ['stun:stun.stunprotocol.org']}
 ];
 
   // Initially, the STUN servers are a copy of the default.

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -219,8 +219,8 @@ import tcp = require('../../../third_party/uproxy-lib/net/tcp');
           freedom['core.rtcpeerconnection'](config),
           'sockstortc');
       } else {
-        log.debug('peer is running client version >1, offering basicObfuscation');
-        pc = bridge.basicObfuscation('sockstortc', config);
+        log.debug('peer is running client version >1, using bridge');
+        pc = bridge.preObfuscation('sockstortc', config);
       }
 
       return this.socksToRtc_.start(tcpServer, pc).then(

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -245,7 +245,8 @@ describe('remote_instance.RemoteInstance', () => {
     var fakeSignallingMessage :bridge.SignallingMessage = {
       providers: {
         'FAKE': {}
-      }
+      },
+      first: true
     };
 
     beforeEach(() => {

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -82,7 +82,7 @@ describe('remote_instance.RemoteInstance', () => {
         instanceId : 'newInstanceId', keyHash : 'key', description: 'desc',
         consent: {isRequesting: true, isOffering: true},
         name: 'name', userId: 'userId'
-      }).then(() => {
+      }, globals.MESSAGE_VERSION).then(() => {
         expect(instance0.keyHash).toEqual('key');
         expect(instance0.description).toEqual('desc');
         expect(instance0.wireConsentFromRemote.isOffering).toEqual(true);
@@ -126,7 +126,7 @@ describe('remote_instance.RemoteInstance', () => {
         instanceId: INSTANCE_ID, description: '', keyHash: '',
         consent: {isOffering: true, isRequesting: true},
         name: 'name', userId: 'userId'
-      }).then(() => {
+      }, globals.MESSAGE_VERSION).then(() => {
         expect(instance.wireConsentFromRemote.isOffering).toEqual(true);
         expect(instance.wireConsentFromRemote.isRequesting).toEqual(true);
         expect(userConsent.remoteRequestsAccessFromLocal).toEqual(true);
@@ -262,7 +262,8 @@ describe('remote_instance.RemoteInstance', () => {
     });
 
     it('handles OFFER signal from client peer as server', (done) => {
-      alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER, fakeOffer).then(() => {
+      alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER,
+          fakeOffer, globals.MESSAGE_VERSION).then(() => {
         expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
         expect(fakeRtcToNet.handleSignalFromPeer).toHaveBeenCalledWith(fakeOffer);
         done();
@@ -272,7 +273,8 @@ describe('remote_instance.RemoteInstance', () => {
     it('handles signal from server peer as client', (done) => {
       alice.wireConsentFromRemote.isOffering = true;
       alice.start().then(() => {
-        alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_SERVER_PEER, fakeCandidate).then(() => {
+        alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_SERVER_PEER,
+            fakeCandidate, globals.MESSAGE_VERSION).then(() => {
           expect(fakeSocksToRtc.handleSignalFromPeer).toHaveBeenCalledWith(fakeCandidate);
           expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
           done();
@@ -281,7 +283,8 @@ describe('remote_instance.RemoteInstance', () => {
     });
 
     it('rejects invalid signals', (done) => {
-      alice.handleSignal(social.PeerMessageType.INSTANCE, fakeCandidate).then(() => {
+      alice.handleSignal(social.PeerMessageType.INSTANCE, fakeCandidate,
+          globals.MESSAGE_VERSION).then(() => {
         expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
         expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
         done();
@@ -290,7 +293,8 @@ describe('remote_instance.RemoteInstance', () => {
 
     it('rejects message from client if consent has not been granted', (done) => {
       alice.user.consent.localGrantsAccessToRemote = false;
-      alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate).then(() => {
+      alice.handleSignal(social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER, fakeCandidate,
+          globals.MESSAGE_VERSION).then(() => {
         expect(fakeSocksToRtc.handleSignalFromPeer).not.toHaveBeenCalled();
         expect(fakeRtcToNet.handleSignalFromPeer).not.toHaveBeenCalled();
         done();

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -14,7 +14,7 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
 import net = require('../../../third_party/uproxy-lib/net/net.types');
 import remote_connection = require('./remote-connection');
 import remote_user = require('./remote-user');
-import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
+import bridge = require('../../../third_party/uproxy-lib/bridge/bridge');
 import social = require('../interfaces/social');
 import ui_connector = require('./ui_connector');
 import uproxy_core_api = require('../interfaces/uproxy_core_api');
@@ -180,7 +180,7 @@ export var remoteProxyInstance :RemoteInstance = null;
      * TODO: return a boolean on success/failure
      */
     public handleSignal = (type:social.PeerMessageType,
-                           signalFromRemote:signals.Message,
+                           signalFromRemote:bridge.SignallingMessage,
                            messageVersion:number) :Promise<void> => {
       if (social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER === type) {
         // If the remote peer sent signal as the client, we act as server.
@@ -253,7 +253,7 @@ export var remoteProxyInstance :RemoteInstance = null;
           this.stopShare();
         }, this.RTC_TO_NET_TIMEOUT);
 
-        this.connection_.startShare().then(() => {
+        this.connection_.startShare(this.messageVersion).then(() => {
           clearTimeout(this.startRtcToNetTimeout_);
         }, () => {
           log.warn('Could not start sharing.');
@@ -290,7 +290,8 @@ export var remoteProxyInstance :RemoteInstance = null;
         this.connection_.stopGet();
       }, this.SOCKS_TO_RTC_TIMEOUT);
 
-      return this.connection_.startGet().then((endpoints :net.Endpoint) => {
+      return this.connection_.startGet(this.messageVersion).then(
+          (endpoints :net.Endpoint) => {
         clearTimeout(this.startSocksToRtcTimeout_);
         return endpoints;
       });

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -50,6 +50,9 @@ export var remoteProxyInstance :RemoteInstance = null;
     public keyHash     :string;
     public description :string;
 
+    // Client version of the remote peer.
+    public messageVersion :number;
+
     public bytesSent   :number = 0;
     public bytesReceived    :number = 0;
     // Current proxy access activity of the remote instance with respect to the
@@ -177,7 +180,8 @@ export var remoteProxyInstance :RemoteInstance = null;
      * TODO: return a boolean on success/failure
      */
     public handleSignal = (type:social.PeerMessageType,
-                           signalFromRemote:signals.Message) :Promise<void> => {
+                           signalFromRemote:signals.Message,
+                           messageVersion:number) :Promise<void> => {
       if (social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER === type) {
         // If the remote peer sent signal as the client, we act as server.
         if (!this.user.consent.localGrantsAccessToRemote) {
@@ -304,11 +308,13 @@ export var remoteProxyInstance :RemoteInstance = null;
      * Instance Message.
      * Assumes that |data| actually belongs to this instance.
      */
-    public update = (data :social.InstanceHandshake) :Promise<void> => {
+    public update = (data:social.InstanceHandshake,
+        messageVersion:number) :Promise<void> => {
       return this.onceLoaded.then(() => {
         this.keyHash = data.keyHash;
         this.description = data.description;
         this.updateConsentFromWire_(data.consent);
+        this.messageVersion = messageVersion;
         this.saveToStorage();
       });
     }

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -92,11 +92,6 @@ export var remoteProxyInstance :RemoteInstance = null;
 
     private connection_ :remote_connection.RemoteConnection = null;
 
-    // True once we have called startShare() on the remote connection since
-    // construction or since state changed to STOP_GIVING. Used to ensure
-    // only one RtcToNet instance is created for each proxying attempt.
-    private haveCalledStartShare_ = false;
-
     /**
      * Construct a Remote Instance as the result of receiving an instance
      * handshake, or loadig from storage. Typically, instances are initialized
@@ -135,7 +130,6 @@ export var remoteProxyInstance :RemoteInstance = null;
           this.user.network.send(this.user, clientId, data);
           break;
         case uproxy_core_api.Update.STOP_GIVING:
-          this.haveCalledStartShare_ = false;
           ui.update(uproxy_core_api.Update.STOP_GIVING_TO_FRIEND, this.instanceId);
           break;
         case uproxy_core_api.Update.START_GIVING:
@@ -191,8 +185,7 @@ export var remoteProxyInstance :RemoteInstance = null;
 
         // Create a new RtcToNet instance each time a new round of client peer
         // messages begins.
-        if (!this.haveCalledStartShare_) {
-          this.haveCalledStartShare_ = true;
+        if (signalFromRemote.first) {
           this.connection_.resetSharerCreated();
           this.startShare_();
         }

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -150,7 +150,8 @@ describe('remote_user.User', () => {
         data: {
           instanceId: 'instanceId', description: '', keyHash: '',
           consent: {isOffering: false, isRequesting: false}
-        }
+        },
+        version: globals.MESSAGE_VERSION
       });
       expect(user.syncInstance_).toHaveBeenCalled();
     });
@@ -161,7 +162,8 @@ describe('remote_user.User', () => {
       spyOn(user, 'getInstance').and.returnValue(instance);
       user.handleMessage('fakeclient', {
         type: social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER,
-        data: {}
+        data: {},
+        version: globals.MESSAGE_VERSION
       });
       expect(instance.handleSignal).toHaveBeenCalled();
     });
@@ -187,7 +189,8 @@ describe('remote_user.User', () => {
       };
       expect(user.instanceToClient('fakeinstance')).toBeUndefined();
       expect(user.clientToInstance('fakeclient')).toBeUndefined();
-      user.syncInstance_('fakeclient', instanceHandshake).then(() => {
+      user.syncInstance_('fakeclient', instanceHandshake,
+          globals.MESSAGE_VERSION).then(() => {
         expect(user.instanceToClient('fakeinstance')).toEqual('fakeclient');
         expect(user.clientToInstance('fakeclient')).toEqual('fakeinstance');
         instance = user.getInstance('fakeinstance');
@@ -208,14 +211,15 @@ describe('remote_user.User', () => {
       // Add the new client.
       user.handleClient(clientState);
       // Pretend a valid instance message has been sent from the new client.
-      user.syncInstance_('fakeclient2', instanceHandshake);
+      user.syncInstance_('fakeclient2', instanceHandshake,
+          globals.MESSAGE_VERSION);
       expect(user.instanceToClient('fakeinstance')).toEqual('fakeclient2');
       expect(user.clientToInstance('fakeclient')).toEqual(null);
       expect(user.clientToInstance('fakeclient2')).toEqual('fakeinstance');
     });
 
     it('syncs UI after updating instance', () => {
-      user.syncInstance_('fakeclient', instanceHandshake);
+      user.syncInstance_('fakeclient', instanceHandshake, globals.MESSAGE_VERSION);
     });
 
     it('Sets user name if pending', () => {
@@ -225,7 +229,8 @@ describe('remote_user.User', () => {
         status: social.ClientStatus.ONLINE, timestamp: 12345
       });
       expect(pendingUser.name).toEqual('pending');
-      pendingUser.syncInstance_('fakeclient', instanceHandshake);
+      pendingUser.syncInstance_('fakeclient', instanceHandshake,
+          globals.MESSAGE_VERSION);
       expect(pendingUser.name).toEqual(instanceHandshake.name);
     });
 
@@ -240,7 +245,7 @@ describe('remote_user.User', () => {
         instanceId: 'fakeinstance', keyHash: <string>null, description: 'x',
         consent: {isRequesting: false, isOffering: false},
         name: '', userId: 'userIdFromInstance'
-      });
+      }, globals.MESSAGE_VERSION);
       expect(pendingUser.name).toEqual('userIdFromInstance');
     });
 
@@ -251,7 +256,8 @@ describe('remote_user.User', () => {
         status: social.ClientStatus.ONLINE, timestamp: 12345
       });
       namedUser.update({name: 'Henry', userId: 'userId', timestamp: 42});
-      namedUser.syncInstance_('fakeclient', instanceHandshake);
+      namedUser.syncInstance_('fakeclient', instanceHandshake,
+          globals.MESSAGE_VERSION);
       expect(namedUser.name).toEqual('Henry');
     });
 

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -181,7 +181,8 @@ var log :logging.Log = new logging.Log('remote-user');
      * handler.
      * Emits an error for a message from a client which doesn't exist.
      */
-    public handleMessage = (clientId :string, msg :social.PeerMessage) : void => {
+    public handleMessage = (clientId :string,
+        msg :social.VersionedPeerMessage) : void => {
       if (!(clientId in this.clientIdToStatusMap)) {
         log.error('%1 received message for non-existing client %2',
                   this.userId, clientId);
@@ -189,8 +190,8 @@ var log :logging.Log = new logging.Log('remote-user');
       }
       switch (msg.type) {
         case social.PeerMessageType.INSTANCE:
-          this.syncInstance_(clientId, <social.InstanceHandshake>msg.data)
-              .catch((e) => {
+          this.syncInstance_(clientId, <social.InstanceHandshake>msg.data,
+              msg.version).catch((e) => {
             log.error('syncInstance_ failed for ', msg.data);
           });
           return;
@@ -207,7 +208,8 @@ var log :logging.Log = new logging.Log('remote-user');
             log.error('failed to get instance', clientId);
             return;
           }
-          instance.handleSignal(msg.type, <signals.Message>msg.data);
+          instance.handleSignal(msg.type, <signals.Message>msg.data,
+              msg.version);
           return;
 
         case social.PeerMessageType.INSTANCE_REQUEST:
@@ -247,7 +249,8 @@ var log :logging.Log = new logging.Log('remote-user');
      */
     public syncInstance_ = (
         clientId :string,
-        instanceHandshake :social.InstanceHandshake) : Promise<void> => {
+        instanceHandshake :social.InstanceHandshake,
+        messageVersion :number) : Promise<void> => {
       // TODO: use handlerQueues to process instances messages in order, to
       // address potential race conditions described in
       // https://github.com/uProxy/uproxy/issues/734
@@ -298,7 +301,8 @@ var log :logging.Log = new logging.Log('remote-user');
         instance = new remote_instance.RemoteInstance(this, instanceId);
         this.instances_[instanceId] = instance;
       }
-      return instance.update(instanceHandshake).then(() => {
+      return instance.update(instanceHandshake,
+          messageVersion).then(() => {
         this.saveToStorage();
         this.notifyUI();
       });

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -25,7 +25,7 @@
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
 import remote_instance = require('./remote-instance');
 import social = require('../interfaces/social');
-import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
+import bridge = require('../../../third_party/uproxy-lib/bridge/bridge');
 import consent = require('./consent');
 import globals = require('./globals');
 import ui = require('./ui_connector');
@@ -208,7 +208,7 @@ var log :logging.Log = new logging.Log('remote-user');
             log.error('failed to get instance', clientId);
             return;
           }
-          instance.handleSignal(msg.type, <signals.Message>msg.data,
+          instance.handleSignal(msg.type, <bridge.SignallingMessage>msg.data,
               msg.version);
           return;
 

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -346,7 +346,8 @@ describe('social_network.FreedomNetwork', () => {
       type: social.PeerMessageType.INSTANCE,
       data: {
         'tigers': 'are also cats'
-      }
+      },
+      version: globals.MESSAGE_VERSION
     };
     spyOn(JSON, 'stringify').and.callThrough();
     network.send(network.getUser('mockuser'), 'fakeclient', outMsg)

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -428,7 +428,7 @@ import ui = ui_connector.connector;
         return;
       }
       var userId = incoming.from.userId;
-      var msg :social.PeerMessage = JSON.parse(incoming.message);
+      var msg :social.VersionedPeerMessage = JSON.parse(incoming.message);
 
       var client :social.ClientState =
           freedomClientToUproxyClient(incoming.from);
@@ -559,11 +559,12 @@ import ui = ui_connector.connector;
     public send = (user :remote_user.User,
                    clientId :string,
                    message :social.PeerMessage) : Promise<void> => {
-      var messageString = JSON.stringify({
+      var versionedMessage :social.VersionedPeerMessage = {
         type: message.type,
         data: message.data,
         version: globals.MESSAGE_VERSION
-      });
+      };
+      var messageString = JSON.stringify(versionedMessage);
       log.info('sending message', {
         userTo: user.userId,
         clientTo: clientId,
@@ -678,7 +679,13 @@ import ui = ui_connector.connector;
                    message :social.PeerMessage) : Promise<void> => {
       // TODO: Batch messages.
       // Relay the message to the UI for display to the user.
-      ui.update(uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE, message);
+      var versionedMessage :social.VersionedPeerMessage = {
+        type: message.type,
+        data: message.data,
+        version: globals.MESSAGE_VERSION
+      };
+      ui.update(uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE,
+          versionedMessage);
 
       return Promise.resolve<void>();
     }
@@ -686,7 +693,7 @@ import ui = ui_connector.connector;
     // TODO: Consider adding a mechanism for reporting back to the UI that a
     // message is malformed or otherwise invalid.
     public receive = (senderClientId :string,
-                      message :social.PeerMessage) : void => {
+                      message :social.VersionedPeerMessage) : void => {
       log.debug('Received incoming manual message from %1: %2',
                 senderClientId, message);
 

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -8,6 +8,7 @@
  */
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import globals = require('./globals');
 import social = require('../interfaces/social');
 import social_network = require('./social');
 import remote_user = require('./remote-user');
@@ -66,12 +67,13 @@ describe('Core', () => {
     spyOn(manualNetwork, 'receive');
 
     var senderClientId = 'dummy_sender';
-    var message :social.PeerMessage = {
+    var message :social.VersionedPeerMessage = {
       type: social.PeerMessageType.SIGNAL_FROM_SERVER_PEER,
       data: {
         elephants: 'have trunks',
         birds: 'do not'
-      }
+      },
+      version: globals.MESSAGE_VERSION
     };
     var command :social.HandleManualNetworkInboundMessageCommand = {
       senderClientId: senderClientId,

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -200,7 +200,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       remoteProxyInstance = null;
     }
 
-    return copyPasteConnection.startGet();
+    return copyPasteConnection.startGet(globals.MESSAGE_VERSION);
   }
 
   public stopCopyPasteGet = () :Promise<void> => {
@@ -208,7 +208,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   }
 
   public startCopyPasteShare = () => {
-    copyPasteConnection.startShare();
+    copyPasteConnection.startShare(globals.MESSAGE_VERSION);
   }
 
   public stopCopyPasteShare = () :Promise<void> => {

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -4,7 +4,6 @@
  */
 
 import net = require('../../../third_party/uproxy-lib/net/net.types');
-import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
 import uproxy_core_api = require('./uproxy_core_api');
 
 export interface UserPath {
@@ -113,7 +112,7 @@ export interface PeerMessage {
   type :PeerMessageType;
   // TODO: Add a comment to explain the types that data can take and their
   // relationship to MessageType.
-  data : InstanceHandshake | signals.Message | {};
+  data: Object;
 }
 
 // Actual type sent over the wire; version is added immediately before

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -109,7 +109,6 @@ export enum PeerMessageType {
   INSTANCE_REQUEST
 }
 
-// Messages to the peer form the boundary for JSON parse / stringify.
 export interface PeerMessage {
   type :PeerMessageType;
   // TODO: Add a comment to explain the types that data can take and their
@@ -117,12 +116,19 @@ export interface PeerMessage {
   data : InstanceHandshake | signals.Message | {};
 }
 
+// Actual type sent over the wire; version is added immediately before
+// JSON-ification.
+export interface VersionedPeerMessage extends PeerMessage {
+  // Client version of the peer, viz. MESSAGE_VERSION.
+  version: number;
+}
+
 // The payload of a HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE command. There is a
 // client ID for the sender but no user ID because in the manual network
 // there is no concept of a single user having multiple clients; in the
 // manual network the client ID uniquely identifies the user.
 export interface HandleManualNetworkInboundMessageCommand {
-  message         :PeerMessage;
+  message         :VersionedPeerMessage;
   senderClientId  :string;
 }
 

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -10,6 +10,7 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/storage.d.ts' />
 
+import MockEventHandler = require('../../../third_party/uproxy-lib/freedom/mocks/mock-eventhandler');
 
 export class MockFreedomStorage implements freedom_Storage {
 
@@ -66,5 +67,12 @@ export class MockMetrics {
   }
   public retrieveUnsafe = () => {
     return Promise.resolve(this.data_);
+  }
+}
+
+// TODO: push into uproxy-lib
+export class MockTcpSocket extends MockEventHandler {
+  constructor() {
+    super(['onConnection', 'onDisconnect']);
   }
 }

--- a/src/mocks/rtc-to-net.ts
+++ b/src/mocks/rtc-to-net.ts
@@ -1,8 +1,7 @@
 import handler_queue = require('../../../third_party/uproxy-lib/handler/queue');
-import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
 
 export class RtcToNetMock { // TODO implements rtc_to_net.RtcToNet {
-  public signalsForPeer = new handler_queue.Queue<signals.Message, void>();
+  public signalsForPeer = new handler_queue.Queue<Object, void>();
   public bytesReceivedFromPeer = new handler_queue.Queue<number, void>();
   public bytesSentToPeer = new handler_queue.Queue<number, void>();
 

--- a/src/mocks/socks-to-rtc.ts
+++ b/src/mocks/socks-to-rtc.ts
@@ -7,6 +7,10 @@ export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
   public rejectStart :(v :Object) => void;
 
   public start = () => {
+    return new Promise<net.Endpoint>((resolve, reject) => {
+      this.resolveStart = resolve;
+      this.rejectStart = reject;
+    });
   }
 
   public stop = () => {
@@ -17,13 +21,6 @@ export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
 
   public on = (name :string, fn :(...args :Object[]) => void) => {
     this.events[name] = fn;
-  }
-
-  public startFromConfig = () => {
-    return new Promise<net.Endpoint>((resolve, reject) => {
-      this.resolveStart = resolve;
-      this.rejectStart = reject;
-    });
   }
 
   // TODO: remove onceStopping_ when


### PR DESCRIPTION
This moves to uproxy-lib v27's `BridgingPeerConnection` which provides support for negotiating obfuscated peerconnections. This is backwards compatible *except for one-time connections*: If we know a client is running with `MESSAGE_VERSION` 2, initiate an obfuscated connection; for older clients, same as today.

There's one outstanding thing missing from churn: support for generating a random key for each connection. I will work on that, it shouldn't change this pull request.

Tested on Chrome with the Google+ social provider and one-time connections.

Question: I had to re-order the STUN servers in order to make churn work from my internal network...should we bump the `STORAGE_VERSION` too?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1590)
<!-- Reviewable:end -->
