### PR TITLE
migrate to latest freedom-for-firefox, do not pin to specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "es6-promise": "^2.0.0",
     "freedomjs-anonymized-metrics": "~0.1.0",
     "freedom-for-chrome": "^0.4.11",
-    "freedom-for-firefox": "0.6.10",
+    "freedom-for-firefox": "^0.6.14",
     "freedom-social-firebase": "^1.0.1",
     "freedom-social-xmpp": "^0.3.6",
     "fs-extra": "^0.12.0",


### PR DESCRIPTION
We've been pinning the version, and not updating. Oops.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1606)
<!-- Reviewable:end -->
