### PR TITLE
Modify reconnect logic to support refresh tokens, work in Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,9 @@
     "freedom-for-chrome": "^0.4.11",
     "freedom-for-firefox": "^0.6.13",
     "freedom-social-firebase": "^1.0.1",
-<<<<<<< HEAD
     "freedom-social-xmpp": "^0.4.0",
-=======
     "freedom-social-xmpp": "^0.3.6",
     "freedomjs-anonymized-metrics": "~0.1.0",
->>>>>>> 7c9b834a05852243a09ee4bbedadea4ecbe6f38e
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-browserify": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "freedom-for-chrome": "^0.4.11",
     "freedom-for-firefox": "0.6.10",
     "freedom-social-firebase": "^1.0.1",
-    "freedom-social-xmpp": "^0.3.6",
+    "freedom-social-xmpp": "^0.4.0",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-browserify": "^3.3.1",

--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -17,18 +17,11 @@ import background = require('./background');
 //   success.
 class ChromeTabAuth {
 
-  // last OAuth reponse URL.
-  private lastOAuthURL_ :string;
-
   constructor() {
   }
 
   public login = (oauthInfo :chromeInterface.OAuthInfo) : void => {
-    if (user_interface.model.reconnecting && this.lastOAuthURL_) {
-      this.sendCredentials_(this.lastOAuthURL_);
-    } else {
-      this.launchAuthTab_(oauthInfo.url, oauthInfo.redirect);
-    }
+    this.launchAuthTab_(oauthInfo.url, oauthInfo.redirect);
   }
 
 
@@ -37,7 +30,6 @@ class ChromeTabAuth {
       if (tab.url.indexOf(redirectUrl) === 0) {
         chrome.tabs.onUpdated.removeListener(onTabChange);
         chrome.tabs.remove(tabId);
-        this.lastOAuthURL_ = tab.url;
         this.sendCredentials_(tab.url);
       }
     };

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -119,3 +119,7 @@ var dailyMetricsReporter = new metrics_module.DailyMetricsReporter(
             {payload: payload, cloudfrontPath: 'submit-rappor-stats'});
       }
     });
+
+ui_connector.onPromiseCommand(
+    uproxy_core_api.Command.PING_UNTIL_ONLINE,
+    core.pingUntilOnline);

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -243,7 +243,7 @@ import ui = ui_connector.connector;
     //================ Subclasses must override these methods ================//
 
     // From Social.Network:
-    public login = (remember :boolean) :Promise<void> => {
+    public login = (reconnect :boolean) :Promise<void> => {
       throw new Error('Operation not implemented');
     }
     public logout = () : Promise<void> => {
@@ -476,7 +476,7 @@ import ui = ui_connector.connector;
 
     //===================== Social.Network implementation ====================//
 
-    public login = (remember :boolean) : Promise<void> => {
+    public login = (reconnect :boolean) : Promise<void> => {
       var request :freedom_Social.LoginRequest = null;
       if (this.isFirebase_()) {
         // Firebase enforces only 1 login per agent per userId at a time.
@@ -498,16 +498,16 @@ import ui = ui_connector.connector;
           agent: agent,
           version: '0.1',
           url: 'https://popping-heat-4874.firebaseio.com/',
-          interactive: true,
-          rememberLogin: remember
+          interactive: !reconnect,
+          rememberLogin: !reconnect
         };
       } else {
         request = {
           agent: 'uproxy',
           version: '0.1',
           url: 'https://github.com/uProxy/uProxy',
-          interactive: true,
-          rememberLogin: remember
+          interactive: !reconnect,
+          rememberLogin: !reconnect
         };
       }
       this.onceLoggedIn_ = this.freedomApi_.login(request)
@@ -671,7 +671,7 @@ import ui = ui_connector.connector;
 
     //===================== Social.Network implementation ====================//
 
-    public login = (remember :boolean) : Promise<void> => {
+    public login = (reconnect :boolean) : Promise<void> => {
       return Promise.resolve<void>();
     }
 

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -22,7 +22,7 @@ describe('Core', () => {
   var network = <social.Network><any>jasmine.createSpy('network');
   network.getUser = null;
   network.getStorePath = function() { return 'network-store-path'; };
-  network['login'] = (remember:boolean) => { return Promise.resolve<void>() };
+  network['login'] = (reconnect :boolean) => { return Promise.resolve<void>() };
   var user = new remote_user.User(network, 'fake-login');
   user.getInstance = null;
   user.notifyUI = () => {};
@@ -82,7 +82,7 @@ describe('Core', () => {
   });
 
   it('login fails for invalid network', (done) => {
-    core.login('nothing').catch(() => {
+    core.login({network: 'nothing', reconnect: false}).catch(() => {
       done();
     });
   });
@@ -99,7 +99,7 @@ describe('Core', () => {
     // Login promise is not resolved so network object stays in pending logins
     var loginSpy = spyOn(network, 'login').and.returnValue(
         new Promise((F, R) => {}));
-    core.login('mockNetwork');
+    core.login({network: 'mockNetwork', reconnect: false});
     expect(Object.keys(social_network.pendingNetworks).length).toEqual(1);
     expect(Object.keys(social_network.networks['mockNetwork']).length).toEqual(0);
 
@@ -109,7 +109,7 @@ describe('Core', () => {
     (<any>loginSpy).and.callFake(() => {
       return Promise.resolve();
     });
-    core.login('mockNetwork').then(() => {
+    core.login({network: 'mockNetwork', reconnect: false}).then(() => {
       expect(Object.keys(social_network.pendingNetworks).length).toEqual(0);
       expect(Object.keys(social_network.networks['mockNetwork']).length).toEqual(1);
     }).then(done);

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -62,10 +62,12 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   /**
    * Access various social networks using the Social API.
    */
-  public login = (networkName :string) :Promise<void> => {
+   // TODO: take reconnect param
+  public login = (loginArgs :uproxy_core_api.LoginArgs) :Promise<void> => {
+    var networkName = loginArgs.network;
     if (networkName === social_network.MANUAL_NETWORK_ID) {
       var network = social_network.getNetwork(networkName, '');
-      var loginPromise = network.login(true);
+      var loginPromise = network.login(loginArgs.reconnect);
       loginPromise.then(() => {
         social_network.notifyUI(networkName);
         log.info('Logged in to manual network');
@@ -82,7 +84,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       network = new social_network.FreedomNetwork(networkName);
       social_network.pendingNetworks[networkName] = network;
     }
-    var loginPromise = network.login(true);
+    var loginPromise = network.login(loginArgs.reconnect);
     loginPromise.then(() => {
       var userId :string = network.myInstance.userId;
       if (userId in social_network.networks[networkName]) {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -424,4 +424,30 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
                         'EMAIL_ADDRESS');
     return text;
   }
+
+  public pingUntilOnline = (pingUrl :string) : Promise<void> => {
+    var ping = () : Promise<void> => {
+      return new Promise<void>(function(fulfill, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', pingUrl);
+        xhr.onload = function() { fulfill(); };
+        xhr.onerror = function(e) { reject(new Error('Ping failed')); };
+        xhr.send();
+      });
+    }
+
+    return new Promise<void>((fulfill, reject) => {
+      var checkIfOnline = () => {
+        ping().then(() => {
+          clearInterval(intervalId);
+          fulfill();
+        }).catch((e) => {
+          // Ping failed (may be because the internet is disconnected),
+          // we will try again on the next interval.
+        });
+      };
+      var intervalId = setInterval(checkIfOnline, 5000);
+      checkIfOnline();
+    });
+  }
 }  // class uProxyCore

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -62,7 +62,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   /**
    * Access various social networks using the Social API.
    */
-   // TODO: take reconnect param
   public login = (loginArgs :uproxy_core_api.LoginArgs) :Promise<void> => {
     var networkName = loginArgs.network;
     if (networkName === social_network.MANUAL_NETWORK_ID) {

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -187,8 +187,8 @@ class CoreConnector implements uproxy_core_api.CoreApi {
   //   this.sendCommand(uproxy_core_api.Command.CHANGE_OPTION, option);
   // }
 
-  login = (network :string) : Promise<void> => {
-    return this.promiseCommand(uproxy_core_api.Command.LOGIN, network);
+  login = (loginArgs :uproxy_core_api.LoginArgs) : Promise<void> => {
+    return this.promiseCommand(uproxy_core_api.Command.LOGIN, loginArgs);
   }
 
   logout = (networkInfo :social.SocialNetworkInfo) : Promise<void> => {

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -206,6 +206,11 @@ class CoreConnector implements uproxy_core_api.CoreApi {
   getNatType = () : Promise<string> => {
     return this.promiseCommand(uproxy_core_api.Command.GET_NAT_TYPE);
   }
+
+  pingUntilOnline = (pingUrl :string) : Promise<void> => {
+    return this.promiseCommand(
+        uproxy_core_api.Command.PING_UNTIL_ONLINE, pingUrl);
+  }
 }  // class CoreConnector
 
 export = CoreConnector;

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -239,7 +239,7 @@ export interface Network {
    * appropriate, and sends an update to the UI upon success. Does nothing if
    * already logged in.
    */
-  login :(remember:boolean) => Promise<void>;
+  login :(reconnect :boolean) => Promise<void>;
 
   getStorePath :() => string;
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -69,7 +69,8 @@ export enum Command {
   SEND_CREDENTIALS,
   UPDATE_GLOBAL_SETTINGS,
   GET_LOGS,
-  GET_NAT_TYPE
+  GET_NAT_TYPE,
+  PING_UNTIL_ONLINE
 }
 
 // Updates are sent from the Core to the UI, to update state that the UI must
@@ -192,5 +193,7 @@ export interface CoreApi {
   // TODO: use Event instead of attaching manual handler. This allows event
   // removal, etc.
   onUpdate(update :Update, handler :Function) :void;
+
+  pingUntilOnline(pingUrl :string) : Promise<void>;
 }
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -131,6 +131,11 @@ export interface CloudfrontPostData {
   cloudfrontPath :string;
 }
 
+export interface LoginArgs {
+  network :string;
+  reconnect :boolean;
+}
+
 /**
  * The primary interface to the uProxy Core.
  *
@@ -181,7 +186,7 @@ export interface CoreApi {
   // TODO: Implement this or remove it.
   // changeOption(option :string) : void;
 
-  login(network :string) : Promise<void>;
+  login(loginArgs :LoginArgs) : Promise<void>;
   logout(networkInfo :social.SocialNetworkInfo) : Promise<void>;
 
   // TODO: use Event instead of attaching manual handler. This allows event


### PR DESCRIPTION
Modify reconnect logic to support refresh tokens, work in Firefox.
* Now when logging in from the splash screen, we set interactive=true and remember=true.  This causes freedom-social-xmpp to store the refresh token (freedom-social-firebase coming soon...)
* Reconnect attempts set interactive=false and remember=false, to use the last stored refresh token
* Pinging to check if we are connected to the internet has been moved to the uProxy core, so that it will work in Firefox without needing to update package.json for each URL we want to ping.
* Reconnect now works in Firefox, but is only enabled for the 'Google' network (until freedom-social-firebase also supports refresh tokens).

Tested in Chrome and Firefox

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1611)
<!-- Reviewable:end -->
