### PR TITLE
Remove extra freedom-social-xmpp from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "freedom-for-firefox": "^0.6.13",
     "freedom-social-firebase": "^1.0.1",
     "freedom-social-xmpp": "^0.4.0",
-    "freedom-social-xmpp": "^0.3.6",
     "freedomjs-anonymized-metrics": "~0.1.0",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",


### PR DESCRIPTION
Remove extra freedom-social-xmpp from package.json, was accidentally merged into previous pull request

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1612)
<!-- Reviewable:end -->
