### PR TITLE
Pin uproxy-lib at v27.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^27.2.0",
+    "uproxy-lib": "27.2.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },


### PR DESCRIPTION
uproxy-libv27.2.1 is, when installed on the sharer's side, is preventing
sharing between plaftorms.  This pins the version at 27.2.0 until we can
figure out what is wrong.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1615)
<!-- Reviewable:end -->
