### PR TITLE
Disable all languages except English

### DIFF
--- a/src/generic_ui/locales/all/languages.json
+++ b/src/generic_ui/locales/all/languages.json
@@ -3,20 +3,5 @@
     "description": "English language.",
     "language": "English",
     "languageCode": "en"
-  },
-  {
-    "description": "Farsi language.",
-    "language": "فارسی",
-    "languageCode": "fa"
-  },
-  {
-    "description": "Arabic language.",
-    "language": "العربية",
-    "languageCode": "ar"
-  },
-  {
-    "description": "French language.",
-    "language": "Français",
-    "languageCode": "fr"
   }
 ]


### PR DESCRIPTION
We do not want to make these languages available to users to select until we do a manual pass on translation.  This will disable showing the languages to the users, they will still technically be available though.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1617)
<!-- Reviewable:end -->
