### PR TITLE
Switch syntax for the default device description

### DIFF
--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -49,7 +49,7 @@
       <paper-button raised on-tap="{{ cancelEditing }}">{{ 'cancel' | $$ }}</paper-button>
     </div>
     <div id='savedDescription' hidden?='{{ editing }}' on-tap='{{ editDescription }}'>
-      {{ model.globalSettings.description || ('nameThisDevice' | $$) }}
+      {{ showDescription(model.globalSettings.description) }}
       <core-icon icon='create'></core-icon>
     </div>
   </template>

--- a/src/generic_ui/polymer/description.ts
+++ b/src/generic_ui/polymer/description.ts
@@ -18,5 +18,8 @@ Polymer({
     this.model = ui_context.model;
     this.editing = false;
     this.descriptionInput = '';
+  },
+  showDescription: function(description :string) {
+    return description ? description : ui_context.ui.i18n_t('nameThisDevice');
   }
 });


### PR DESCRIPTION
The syntax we were using does not work, this does it a slightly more
ugly but functional way.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1618)
<!-- Reviewable:end -->
