### PR TITLE
migrate to uproxy-lib 27.2.2, with fix for chrome/firefox issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "27.2.0",
+    "uproxy-lib": "^27.2.2",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },


### PR DESCRIPTION
I believe uproxy-lib 27.2.2 fixes the issue described here:
https://github.com/uProxy/uproxy/pull/1615

Tested with Firefox getting access from Chrome.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1628)
<!-- Reviewable:end -->
