### PR TITLE
Clear which instance we are trying to get access from on proxy failure

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -611,6 +611,7 @@ export class UserInterface implements ui_constants.UiApi {
       }
 
       this.toastMessage = this.i18n_t('unableToGetFrom', { name: user.name });
+      this.instanceTryingToGetAccessFrom = null;
       this.unableToGet = true;
       this.bringUproxyToFront();
       return Promise.reject(e);


### PR DESCRIPTION
Previously, when we failed to connect to someone, we would not clear
the UI state that showed we were trying to connect.  This caused the
trying-to-connect message to continue to show in the UI.  With this
change, we now correctly clear that value on failure.

Fixes #1499

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1633)
<!-- Reviewable:end -->
