### PR TITLE
Make the setup.sh script more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-browserify": "^3.3.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-jasmine": "^0.8.0",
@@ -52,9 +53,6 @@
   },
   "peerDependencies": {
     "freedom": "^0.6.18"
-  },
-  "scripts": {
-    "install": "./node_modules/.bin/bower install"
   },
   "private": true
 }

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@
 # allows script to be run from different directories but always act on the
 # directory of the project (which is where this script is located).
 ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
+NPM_BIN_DIR="$ROOT_DIR/node_modules/.bin"
 
 # A simple bash script to run commands to setup and install all dev dependencies
 # (including non-npm ones)
@@ -27,7 +28,7 @@ function runCmd ()
 
 function clean ()
 {
-  runCmd "rm -r $ROOT_DIR/node_modules $ROOT_DIR/build $ROOT_DIR/.tscache"
+  runCmd "rm -rf $ROOT_DIR/node_modules $ROOT_DIR/build $ROOT_DIR/.tscache"
 }
 
 function installTools ()
@@ -38,9 +39,9 @@ function installTools ()
 
 function installThirdParty ()
 {
-  runAndAssertCmd "bower install --allow-root"
-  runAndAssertCmd "node_modules/.bin/tsd reinstall --config ./third_party/tsd.json"
-  runAndAssertCmd "grunt copy:thirdParty"
+  runAndAssertCmd "$NPM_BIN_DIR/bower install --allow-root"
+  runAndAssertCmd "$NPM_BIN_DIR/tsd reinstall --config ./third_party/tsd.json"
+  runAndAssertCmd "$NPM_BIN_DIR/grunt copy:thirdParty"
 }
 
 function installDevDependencies ()


### PR DESCRIPTION
This changes the setup.sh script so that we will pass a -f command to rm
in clean (this avoids a failure error code if it is run twice) and
forces us to use the local versions of both bower and grunt giving us
better control over those packages if neded.

This also removes automatically running bower after doing npm install
since the user should, in theory, never run that directly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1634)
<!-- Reviewable:end -->
