### PR TITLE
enable basic obfuscation

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^27.2.2",
+    "uproxy-lib": "^27.2.5",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -13,7 +13,8 @@ export var STORAGE_VERSION = 1;
 
 // 1: initial release
 // 2: uproxy-lib v27, move to bridge but no obfuscation yet
-export var MESSAGE_VERSION = 2;
+// 3: offer basicObfuscation
+export var MESSAGE_VERSION = 3;
 
 export var DEFAULT_STUN_SERVERS = [
   {urls: ['stun:stun.l.google.com:19302']},

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -213,14 +213,17 @@ import tcp = require('../../../third_party/uproxy-lib/net/tcp');
       };
 
       var pc: peerconnection.PeerConnection<Object>;
-      if (remoteVersion < 2) {
+      if (remoteVersion === 1) {
         log.debug('peer is running client version 1, using old peerconnection');
         pc = new peerconnection.PeerConnectionClass(
           freedom['core.rtcpeerconnection'](config),
           'sockstortc');
-      } else {
-        log.debug('peer is running client version >1, using bridge');
+      } else if (remoteVersion === 2) {
+        log.debug('peer is running client version 2, using bridge without obfuscation');
         pc = bridge.preObfuscation('sockstortc', config);
+      } else {
+        log.debug('peer is running client version >2, using bridge with basicObfuscation');
+        pc = bridge.basicObfuscation('sockstortc', config);
       }
 
       return this.socksToRtc_.start(tcpServer, pc).then(


### PR DESCRIPTION
This defines `MESSAGE_VERSION` version 3. When a remote peer running this version is encountered, (basic) obfuscation will be offered to them. Older clients will be unaffected.

Tested locally, in the network lab, and across the real internet with a mix of Chrome and Firefox -- but of course we should exercise this quite a bit during the next testing party. If we can't tell the difference during regular browsing, I think we're good to go.

One note: if you experience difficulty establishing a connection in the office, edit your advanced settings to include only `stun.l.google.com`. This only affects the office and we're working on a fix. Of course for any real testing we should be using real home internet and/or mobile connections!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1635)
<!-- Reviewable:end -->
