### PR TITLE
Add missing translations. Update strings for NAT types. Use official Farsi translations.

### DIFF
--- a/src/generic_core/diagnose-nat.ts
+++ b/src/generic_core/diagnose-nat.ts
@@ -729,7 +729,7 @@ export function doNatProvoking() :Promise<string> {
       var rsp = JSON.parse(rspStr);
 
       if (rsp['answer'] == 'FullCone') {
-        F('FullCone');
+        F('full-cone NAT');
       } else if (rsp['answer'] == 'RestrictedConePrepare') {
         var peer_addr: string[] = rsp['prepare_peer'].split(':');
         var req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
@@ -737,7 +737,7 @@ export function doNatProvoking() :Promise<string> {
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] == 'RestrictedCone') {
-        F('RestrictedCone');
+        F('restricted-cone NAT');
       } else if (rsp['answer'] == 'PortRestrictedConePrepare') {
         var peer_addr: string[] = rsp['prepare_peer'].split(':');
         var req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
@@ -745,7 +745,7 @@ export function doNatProvoking() :Promise<string> {
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] == 'PortRestrictedCone') {
-        F('PortRestrictedCone');
+        F('port-restricted cone NAT');
       } else if (rsp['answer'] == 'SymmetricNATPrepare') {
         var peer_addr: string[] = rsp['prepare_peer'].split(':');
         var reqStr: string = JSON.stringify({ 'ask': 'AmISymmetricNAT' });
@@ -753,7 +753,7 @@ export function doNatProvoking() :Promise<string> {
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] == 'SymmetricNAT') {
-        F('SymmetricNAT');
+        F('symmetric NAT');
       } else {
         return;
       }

--- a/src/generic_ui/locales/ar/messages.json
+++ b/src/generic_ui/locales/ar/messages.json
@@ -435,6 +435,10 @@
     "message": "وصف",
     "description": "Placeholder for the input field for the name of the user's device."
   },
+  "connectedAccounts": {
+    "description": "In settings, title for the social networks you can connect to.",
+    "message": "الحسابات المتصلة"
+  },
   "connect": {
     "message": "ربط",
     "description": "User clicks this to connect to a network"
@@ -518,6 +522,14 @@
   "askToAnalyze": {
     "message": "يمكن أن يكون هذا النوع NAT الشبكة غير متوافق مع uProxy. تريد uProxy لتحليل الشبكة؟",
     "description": "Text in a popup that appears when an attempt to access the Internet through a friend fails."
+  },
+  "unableToGet": {
+    "description": "Title for popup that appears when an attempt to access the Internet through a friend fails.",
+    "message": "غير قادر على الحصول"
+  },
+  "unableToShare": {
+    "description": "Title for popup that appears when an attempt to share the Internet with a friend fails.",
+    "message": "غير قادر على مشاركة الوصول"
   },
   "analyzingNetwork": {
     "message": "شبكة تحليل",

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -553,7 +553,7 @@
   },
   "possibly": {
     "description": "Meaning medium probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string.",
-    "message": "probably"
+    "message": "possibly"
   },
   "unlikely": {
     "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string.",

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -548,16 +548,16 @@
     "message": "Would you like to submit your NAT type to the uProxy team, to help us better understand the networks our users are on?"
   },
   "veryLikely": {
-    "description": "Meaning high probability. Used in context of the probability that network settings are preventing a uProxy connection from being established.",
-    "message": "very likely"
+    "description": "Meaning high probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string.",
+    "message": "most likely"
   },
   "possibly": {
-    "description": "Meaning medium probability. Used in context of the probability that network settings are preventing a uProxy connection from being established.",
-    "message": "possibly"
+    "description": "Meaning medium probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string.",
+    "message": "probably"
   },
   "unlikely": {
-    "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established.",
-    "message": "unlikely"
+    "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string.",
+    "message": "probably not"
   },
   "privacyPolicy": {
     "description": "Link to uProxy's privacy policy.",

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -435,6 +435,10 @@
     "description": "Placeholder for the input field for the name of the user's device.",
     "message": "Description"
   },
+  "connectedAccounts": {
+    "description": "In settings, title for the social networks you can connect to.",
+    "message": "Connected Accounts"
+  },
   "connect": {
     "description": "User clicks this to connect to a network",
     "message": "Connect"
@@ -518,6 +522,14 @@
   "askToAnalyze": {
     "description": "Text in a popup that appears when an attempt to access the Internet through a friend fails.",
     "message": "It could be that your network's NAT type is incompatible with uProxy. Would you like uProxy to analyze your network?"
+  },
+  "unableToGet": {
+    "description": "Title for popup that appears when an attempt to access the Internet through a friend fails.",
+    "message": "Unable to get access"
+  },
+  "unableToShare": {
+    "description": "Title for popup that appears when an attempt to share the Internet with a friend fails.",
+    "message": "Unable to share access"
   },
   "analyzingNetwork": {
     "description": "Message shown when the user's network is being analyzed.",

--- a/src/generic_ui/locales/fa/messages.json
+++ b/src/generic_ui/locales/fa/messages.json
@@ -1,634 +1,646 @@
 {
-  "done": {
-    "message": "انجام شده",
-    "description": "Button label that suggests acknowledgement and that closes a popup."
-  },
-  "yes": {
-    "message": "بله",
-    "description": "Button label."
-  },
-  "no": {
-    "message": "بدون",
-    "description": "Button label."
-  },
-  "ok": {
-    "message": "باشه",
-    "description": "Button label."
-  },
-  "close": {
-    "message": "نزدیک",
-    "description": "Button label to close a popup."
-  },
-  "cancel": {
-    "message": "لغو کردن",
-    "description": "Button label that rejects a proposed action."
-  },
-  "startGetting": {
-    "message": "شروع به گرفتن دسترسی",
-    "description": "Start accessing the Internet through a friend's connection."
-  },
-  "stopGetting": {
-    "message": "توقف گرفتن دسترسی",
-    "description": "Stop accessing the Internet through a friend's connection."
-  },
-  "submitFeedback": {
-    "message": "ارسال ها",
-    "description": "Submit feedback to the uProxy team."
-  },
-  "getHelp": {
-    "message": "کمک بگیر",
-    "description": "Get help from the frequently asked questions page."
-  },
-  "logout": {
-    "message": "ورود از uProxy",
-    "description": "Log-out of uProxy."
-  },
-  "grantedYouAccess": {
-    "message": "__name__ دسترسی شما اعطا",
-    "description": "The user's friend has allowed the user to use the friend's Internet connection."
-  },
-  "tryingToConnect": {
-    "message": "تلاش برای اتصال به __name__",
-    "description": "The user is trying to connect to the Internet through their friend."
-  },
-  "askingForAccess": {
-    "message": "در خواست دسترسی",
-    "description": "The user is asking for permission to access the Internet through their friend; user is waiting for the friend's reply."
-  },
-  "waitingForAccess": {
-    "message": "شما می توانید برای دسترسی هنگامی که __name__ را قبول خواهد بود.",
-    "description": "User will be able to access the Internet through their friend, once that friend gives the user permission."
-  },
-  "cancelRequest": {
-    "message": "لغو درخواست",
-    "description": "Label for button which will take back a request to get Internet access through a friend."
-  },
-  "offeredYouAccess": {
-    "message": "آنها دسترسی شما ارائه شده است.",
-    "description": "A friend has offered their Internet access to the user."
-  },
-  "acceptOffer": {
-    "message": "شرایط پیشنهاد",
-    "description": "Accept a friend's offer that would allow the user to access the Internet through their friend."
-  },
-  "ignore": {
-    "message": "نادیده گرفتن",
-    "description": "Button label that ignores an offer or request."
-  },
-  "stopIgnoringOffers": {
-    "message": "توقف نادیده گرفتن پیشنهادات",
-    "description": "Button label for if the user wants to stop ignoring offers."
-  },
-  "askForAccess": {
-    "message": "برای دسترسی بپرسید",
-    "description": "Button label that sends a request to the user's friend, asking if the user can access the Internet through them."
-  },
-  "friendOffline": {
-    "message": "__name__ آنلاین نیست.",
-    "description": "Message shown when trying to get access from a friend who is offline."
-  },
-  "grantedFriendAccess": {
-    "message": "شما به آنها اجازه دسترسی داده ام.",
-    "description": "The user has agreed to let their friend access the Internet through the user."
-  },
-  "revokeAccess": {
-    "message": "لغو دسترسی",
-    "description": "Label for button that takes back an offer to a friend who has already accepted that offer. If the button is clicked, the friend will no longer be able to connect to the Internet through the user."
-  },
-  "cancelOffer": {
-    "message": "لغو پیشنهاد",
-    "description": "Label for button that takes back an offer to a friend who has not yet accepted that offer. If the button is clicked, the friend will no longer be able to connect to the Internet through the user."
-  },
-  "friendRequestsAccess": {
-    "message": "__name__ درخواست دسترسی از شما است.",
-    "description": "A friend has requested to access the Internet through the user."
-  },
-  "grant": {
-    "message": "گرانت",
-    "description": "Label for button that accepts a friend's request to access the Internet through the user."
-  },
-  "friendRequestedAccess": {
-    "message": "آنها دسترسی از طریق شما درخواست شده است.",
-    "description": "A friend has requested to access the Internet through the user."
-  },
-  "stopIgnoringRequests": {
-    "message": "توقف نادیده گرفتن درخواست",
-    "description": "Button label for if the user wants to stop ignoring requests."
-  },
-  "accessNotGranted": {
-    "message": "شما آنها را دسترسی به داده نمی شود.",
-    "description": "The user has not permissioned a friend to access the Internet through the user."
-  },
-  "offerAccess": {
-    "message": "ارائه دسترسی",
-    "description": "Label for button that will offer a friend access to the Internet through the user, even though the friend has not requested access."
-  },
-  "shareOneTime": {
-    "message": "به اشتراک گذاشتن یک اتصال یک بار",
-    "description": "Share access to the user's Internet using a link that will only work once."
-  },
-  "requestOneTime": {
-    "message": "درخواست اتصال یک بار",
-    "description": "Request access to the user's friend's Internet using a link that will only work once."
-  },
-  "startOneTime": {
-    "message": "شروع یک ارتباط یک بار",
-    "description": "Start an Internet connection using a link that will only work once."
-  },
-  "errorParsingLink": {
-    "message": "خطا در تجزیه لینک ارتباط uproxy، لطفا رفتن به لینک دوباره و یا درخواست دوستان خود را برای یک لینک جدید را امتحان کنید وجود دارد.",
-    "description": "Error shown if a one-time connection link did not work."
-  },
-  "noLongerGetting": {
-    "message": "شما در حال گرفتن دیگر دسترسی داشته باشید. برای درخواست یک اتصال، زیر کلیک بر روی دکمه.",
-    "description": "Message shown when a one-time connection ends."
-  },
-  "startNewConnection": {
-    "message": "شروع به گرفتن یک اتصال جدید",
-    "description": "Label for button that takes user back to the 'Start a one-time connection' page."
-  },
-  "errorStartingConnection": {
-    "message": "خطا در شروع ارتباط وجود دارد و آن تا به حال به خاتمه داده شود. لطفا با شروع اتصال دیگری را امتحان کنید.",
-    "description": "Error shown if a one-time connection failed to start."
-  },
-  "sendConnectionLink": {
-    "message": "به اشتراک گذاشتن اتصال خود، لطفا به دوستان خود بخواهید که شما را لینک خود را ارسال کنید.",
-    "description": "Instructions for the user to share their connection with a one-time link."
-  },
-  "copyConnectionLink": {
-    "message": "برای درخواست دسترسی از یک دوست، کپی کرده و URL را به آنها بیش از یک کانال امن رب",
-    "description": "Instructions for the user to request access from a friend with a one-time link."
-  },
-  "loading": {
-    "message": "در حال بارگذاری ...",
-    "description": "Message show when something is taking time to load."
-  },
-  "friendNeedsToClick": {
-    "message": "به پایان رساندن ایجاد اتصال، دوست شما نیاز به کلیک بر روی لینک و به شما یک لینک ارسال از مشتری uProxy خود را. هنگامی که شما بر روی آن کلیک کنید، شما آماده برای شروع گرفتن دسترسی باشد.",
-    "description": "Instructions telling the user that starting a one-time connection is waiting for action from their friend."
-  },
-  "oneTimeSuccess": {
-    "message": "موفقیت! اتصال یک بار تاسیس شده است.",
-    "description": "Inform the user that a one-time connection was successfully established."
-  },
-  "startOneTimeInstruction": {
-    "message": "برای شروع گرفتن دسترسی از دوستان خود، زیر کلیک بر روی دکمه.",
-    "description": ""
-  },
-  "stopOneTimeInstruction": {
-    "message": "برای جلوگیری از دسترسی از دوستان خود، زیر کلیک بر روی دکمه.",
-    "description": ""
-  },
-  "oneTimeGetting": {
-    "message": "شما در حال حاضر دسترسی.",
-    "description": "The user is connected to the Internet through their friend."
-  },
-  "stopOneTimeGettingBeforeNew": {
-    "message": "اگر شما می خواهم برای شروع یک ارتباط یک بار جدید، دکمه \"توقف دسترسی\" برای اولین بار.",
-    "description": "Instruction for the user to stop a current one-time connection if they want to start a new one."
-  },
-  "friendRequestedOneTime": {
-    "message": "دوست شما درخواست کرده است که از اتصال اینترنت شما.",
-    "description": "A friend has requested to access the Internet through the user."
-  },
-  "howToOfferOneTime": {
-    "message": "اگر شما می خواهم به آنها اجازه دسترسی بدهید، کپی و چسباندن URL این به آنها.",
-    "description": "Instructions for user if they'd like to share their Internet connection with a one-time link."
-  },
-  "getOneTimeInstead": {
-    "message": "دسترسی به جای",
-    "description": "Label for a link to the 'Start a one-time connection' page."
-  },
-  "tryingToShareOneTime": {
-    "message": "شما در حال حاضر در روند تلاش برای به اشتراک گذاشتن دسترسی داشته باشید. اگر شما می خواهم به جای به دست آوردن دسترسی، لینک بالا کلیک کنید.",
-    "description": "Instructions for user if they want to get access instead, while attempting to share access."
-  },
-  "getOneTimeInsteadInstruction": {
-    "message": "اگر شما می خواهم برای شروع یک ارتباط یک بار با فرد دیگری، دکمه \"بازگشت\" را فشار دهید و سپس \"شروع یک ارتباط یک بار\" برای شروع یک جلسه جدید.",
-    "description": "Instructions for the user if they want to abort an existing attempt and start a new one-time connection."
-  },
-  "oneTimeSharing": {
-    "message": "شما در حال حاضر به اشتراک گذاری دسترسی داشته باشید.",
-    "description": "The user is sharing their Internet access with a friend."
-  },
-  "stopOneTimeSharing": {
-    "message": "توقف اشتراک گذاری دسترسی",
-    "description": "Label for button to terminate your connection to a friend who is accessing the Internet through you."
-  },
-  "stopOneTimeSharingBeforeNew": {
-    "message": "اگر شما می خواهم برای شروع یک ارتباط جدید یک بار، دکمه \"متوقف کردن اشتراک گذاری دسترسی\" برای اولین بار.",
-    "description": "Instruction for the user to stop a current one-time connection if they want to start a new one."
-  },
-  "goBack": {
-    "message": "برگرد؟",
-    "description": "Go back to the main page from the one-time connection page."
-  },
-  "areYouSure": {
-    "message": "آیا شما مطمئن هستید که میخواهید برای پایان دادن به این رابطه یک بار؟",
-    "description": "Question confirming if the user wants to end an active connection to a friend."
-  },
-  "submitFeedback_sentenceCase": {
-    "message": "ارسال بازخورد",
-    "description": "Submit feedback to the uProxy team."
-  },
-  "emailTitle": {
-    "message": "پست الکترونیک (اختیاری)",
-    "description": ""
-  },
-  "emailPlaceholder": {
-    "message": "آدرس ایمیل",
-    "description": ""
-  },
-  "feedbackTitle": {
-    "message": "بازخورد خود را در زیر وارد کنید",
-    "description": "Label for textbox for user's to submit feedback and comments to uProxy."
-  },
-  "feedbackPlaceholder": {
-    "message": "ارسال نظرات شما",
-    "description": "The default text that appears in the user feedback textbox."
-  },
-  "networkAndLogs": {
-    "message": "تجزیه و تحلیل شبکه و شامل سیاهههای مربوط",
-    "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
-  },
-  "PIIMessage": {
-    "message": "بازخورد و آدرس ایمیل خود را به uProxy.org ارسال می شود. سیاهههای مربوط، اطلاعات شبکه و ایمیل ممکن است اطلاعات شناسایی شخصی باشد.",
-    "description": "Message helping make sure the user understands that personally identifiable information may be included in their feedback to uProxy."
-  },
-  "thankYou": {
-    "message": "متشکرم!",
-    "description": ""
-  },
-  "feedbackSubmitted": {
-    "message": "بازخورد شما به تیم توسعه uProxy کنید.",
-    "description": "User feedback was successfully submitted."
-  },
-  "emailInsteadTitle": {
-    "message": "بازخورد ایمیل به جای؟",
-    "description": "Title for error that appears if feedback submission failed."
-  },
-  "emailInsteadMessage": {
-    "message": "وای! ما قادر به ارائه بازخورد خود را به uproxy.org بودند. لطفا کپی کنید و نظرات خود را یک ایمیل به info@uproxy.org در پیست کنید.",
-    "description": "Seen if feedback submission through uProxy fails. Message asks users to email their feedback instead."
-  },
-  "logsTitle": {
-    "message": "گزارش ها و تجزیه و تحلیل شبکه",
-    "description": "Title for the page that displays a user's network information and uProxy logs."
-  },
-  "toSendLogs": {
-    "message": "برای ارسال سیاهههای مربوط خود را به تیم uProxy برای کمک، باز uProxy و بر روی \"ارسال بازخورد\"",
-    "description": "Instructions guiding the user through how to submit their logs to uProxy."
-  },
-  "retrievingLogs": {
-    "message": "بازیابی سیاهههای مربوط و تجزیه و تحلیل شبکه خود را ...",
-    "description": "Message shown while uProxy is analyzing the user's network settings."
-  },
-  "errorSigningIn": {
-    "message": "یک مشکل در ورود به __network__ وجود دارد. لطفا دوباره تلاش کنید.",
-    "description": "Notification for when the user could not be signed in to a social network."
-  },
-  "attemptingReconnect": {
-    "message": "تلاش برای اتصال مجدد.",
-    "description": "uProxy was disconnected from the social network and is trying to reconnect."
-  },
-  "cannotOpenOneTimeTitle": {
-    "message": "آیا می توانم یک بار اتصال باز نشد",
-    "description": "Title for an error popup that appears if the user tries to open a one-time link while signed in to a social network."
-  },
-  "cantOpenOneTimeMessage": {
-    "message": "در حال حاضر امکان پذیر نیست برای باز کردن یک ارتباط تجاری را در همان زمان به عنوان به یک شبکه اجتماعی را امضا کردند. برای راه اندازی یک اتصال کتابچه راهنمای کاربر، لطفا ورود به سیستم از طریق منوی تنظیمات و دوباره خمیر را لینک کنید.",
-    "description": "Text for an error popup that appears if the user tries to open a one-time link while signed in to a social network."
-  },
-  "statsEnabledTitle": {
-    "message": "آمار ناشناس فعال",
-    "description": "The user has elected to submit anonymous statistics about their uProxy usage to the uProxy team."
-  },
-  "statsEnabledMessage": {
-    "message": "این نماد معنی است که شما در به اشتراک گذاری آمار ناشناس با تیم uProxy تصمیم گرفتند. برای تنظیم تنظیمات کلیک کنید.",
-    "description": "Text that appears in a popup explaining the 'anonymous stats enabled' icon."
-  },
-  "statsEnabledTooltip": {
-    "message": "شما به اشتراک گذاشتن آمار ناشناس.",
-    "description": "Text that appears in a tooltip when the user hovers over the 'anonymous stats enabled' icon."
-  },
-  "sharingEnabledTitle": {
-    "message": "به اشتراک گذاری فعال",
-    "description": "Title for popup that points to the sharing icon in uProxy's top toolbar. The popup appears when the user first grants access to one of their friends. The sharing icon is visible as long as there are friends who can get access to the user's Internet."
-  },
-  "sharingEnabledMessage": {
-    "message": "این نماد معنی است که شما در دسترس برای به اشتراک گذاری با دوستان دسترسی شما برای دسترسی به ارائه کردهاید.",
-    "description": "Text in a popup that explains what the sharing icon (on the toolbar) is."
-  },
-  "sharingEnabledTooltip": {
-    "message": "شما در دسترس برای به اشتراک گذاری می باشد.",
-    "description": "Text that appears in a tooltip when the user hovers over the sharing icon."
-  },
-  "getAccess": {
-    "message": "دسترسی",
-    "description": "Text for the tab on the toolbar. When the user is on the 'Get Access' tab, they are looking to get access to the Internet through a friend."
-  },
-  "shareAccess": {
-    "message": "به اشتراک گذاشتن دسترسی",
-    "description": "Text for the tab on the toolbar. When the user is on the 'Share Access' tab, they are looking to share access to their Internet with a friend."
-  },
-  "welcome": {
-    "message": "به uProxy خوش آمدید",
-    "description": ""
-  },
-  "welcomeMessage": {
-    "message": "برای شروع، گزینه «دریافت دسترسی\" و یا \"به اشتراک گذاشتن دسترسی\" و سپس با کلیک بر روی یکی از دوستان برای اتصال.",
-    "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
-  },
-  "alphaMessage": {
-    "message": "این یک نسخه آلفا از uProxy است. شما می توانید به ما کمک uProxy بهبود با به اشتراک گذاشتن معیارهای ناشناس با تیم توسعه. اطلاعات گزارش شده است توسط مشتری بینام و انتقال ایمن.",
-    "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
-  },
-  "moreInformation": {
-    "message": "اطلاعات بیشتر.",
-    "description": ""
-  },
-  "changeStatsChoice": {
-    "message": "شما می توانید انتخاب خود را در هر زمان از منوی تنظیمات تغییر دهید.",
-    "description": "Informs the user that they can opt in and out of sending anonymous statistics at any time they choose, from the Settings menu."
-  },
-  "enableMetrics": {
-    "message": "آیا می خواهید به فعال کردن مجموعه معیارهای ناشناس؟",
-    "description": "Asks the user if they want to send anonymous metrics about their uProxy usage."
-  },
-  "imIn": {
-    "message": "من هستم",
-    "description": "Agree to submitting anonymous metrics to uProxy."
-  },
-  "noThanks": {
-    "message": "نه ممنون",
-    "description": "Do not agree to submitting anonymous metrics to uProxy."
-  },
-  "disconnectedTitle": {
-    "message": "وای! شما از دوستان خود قطع شده است.",
-    "description": "Title for error that appears when the user was getting access to the Internet through their friend, but that connection was terminated."
-  },
-  "disconnectedMessage": {
-    "message": "لطفا با احتیاط ادامه دهید. ترافیک وب شما دیگر از طریق دوست شما روت. شما ممکن است بخواهید برای بستن هر پنجره حساس شما باز، قبل از ادامه.",
-    "description": "Instruction informing the user that to continue browsing the Internet, the user will need to use their local (potentially unsafe and/or censored) connection."
-  },
-  "continueBrowsing": {
-    "message": "ادامه مرور بدون uProxy",
-    "description": "Label for button that will change the users Internet settings back to using the user's local connection (i.e. not their friend's Internet)."
-  },
-  "sharingUnavailableTitle": {
-    "message": "به اشتراک گذاری در دسترس نیست",
-    "description": "Title for error that appears when the user can not share their Internet access with friends."
-  },
-  "sharingUnavailableMessage": {
-    "message": "وای! شما با استفاده از فایرفاکس 37، که دارای یک اشکال است که مانع از به اشتراک گذاری از کار (git.io/vf5x1 را ببینید). این اشکال در فایرفاکس 38 ثابت، بنابراین شما می توانید به اشتراک گذاری با ارتقاء Firefox یا تعویض به کروم را فعال کنید.",
-    "description": "Text for error that appears when the user can not share their Internet access with friends."
-  },
-  "loadingFriends": {
-    "message": "در حال بارگیری دوستان uProxy",
-    "description": "User's friends are being loaded from a social network."
-  },
-  "noFriendsOnline": {
-    "message": "هیچ یک از دوستان شما به uProxy در این زمان به امضا رساند.",
-    "description": "None of the user's friends are currently signed in."
-  },
-  "toInviteFriends": {
-    "message": "به دعوت دوستان به uProxy، آنها یک لینک ارسال به https://www.uproxy.org",
-    "description": "Instruction informing the user how to invite their friends to uProxy."
-  },
-  "offers": {
-    "message": "پیشنهادات",
-    "description": "Title for the group of friends who have sent offers of access to their Internet, which the user have not yet accepted."
-  },
-  "requests": {
-    "message": "درخواست",
-    "description": "Title for the group of friends who have sent requests to access the user's Internet, which the user have not yet granted."
-  },
-  "friendsWhoShare": {
-    "message": "دوستان شما می توانید دسترسی از دریافت",
-    "description": "Title for the group of friends who the user can get Internet access from."
-  },
-  "friendsWhoCanGet": {
-    "message": "دوستان که می تواند دسترسی از شما",
-    "description": "Title for the group of friends who can access the Internet through the user."
-  },
-  "uproxyFriends": {
-    "message": "دوستان که uProxy",
-    "description": "Title for the group of friends who have uProxy but who don't fit into any of the other contact groups."
-  },
-  "connectedWith": {
-    "message": "ارتباط با __network__",
-    "description": "Text in settings that informs the user which social network they're connected to."
-  },
-  "connectedWithNumber": {
-    "message": "ارتباط با __number__ شبکه",
-    "description": "Text in settings informing the user of how many networks they're connected to."
-  },
-  "nameThisDevice": {
-    "message": "نام و نام خانوادگی این دستگاه",
-    "description": "If the user has not named their device (e.g. 'laptop' or 'home computer'), they will see this message in the Settings panel."
-  },
-  "deviceDescription": {
-    "message": "توضیحات دستگاه",
-    "description": "Title for the section in Settings where the user can edit the name of their device."
-  },
-  "description": {
-    "message": "شرح",
-    "description": "Placeholder for the input field for the name of the user's device."
-  },
-  "connect": {
-    "message": "اتصال",
-    "description": "User clicks this to connect to a network"
-  },
-  "disconnect": {
-    "message": "قطع کردن",
-    "description": "User clicks this to disconnect from a network"
-  },
-  "save": {
-    "message": "ذخیره",
-    "description": "Label for button that saves the user's text input."
-  },
-  "restart": {
-    "message": "شروع دوباره",
-    "description": "Restart uProxy completely."
-  },
-  "advancedSettings": {
-    "message": "تنظیمات پیشرفته",
-    "description": "Clickable text from the Settings menu. Clicking this opens the advanced settings screen."
-  },
-  "advancedSettings_sentenceCase": {
-    "message": "تنظیمات پیشرفته",
-    "description": "Title for the advanced settings screen."
-  },
-  "editAdvancedSettings": {
-    "message": "تنظیمات خود را در زیر ویرایش",
-    "description": "Instruction for the user to edit their advanced settings (by typing JSON in a textbox)."
-  },
-  "editAdvancedSettingsPlaceholder": {
-    "message": "ویرایش تنظیمات شما",
-    "description": "Default text in the advanced settings textbox."
-  },
-  "settingsSaved": {
-    "message": "تنظیمات ذخیره شده",
-    "description": "Message that confirms to the user that their advanced settings were saved."
-  },
-  "settingsBadFormatError": {
-    "message": "می تواند تنظیم نشده: فرمت بد",
-    "description": "Error shown to the user if their input for advanced settings is badly formed JSON."
-  },
-  "settingsJsonError": {
-    "message": "می تواند تنظیم نشده: JSON ارزش عدم تطابق",
-    "description": "Error shown to the user if their input for advanced settings is incomplete or incompatible with expected settings configurations."
-  },
-  "set": {
-    "message": "SET",
-    "description": "Label for button that saves the user's advanced settings."
-  },
-  "aboutUproxy": {
-    "message": "uProxy شما کمک می کند دسترسی شما به اینترنت به اشتراک بگذارید و یا دسترسی به اینترنت از دوستان",
-    "description": "Description on uProxy's introduction screen explaining what uProxy is."
-  },
-  "next": {
-    "message": "بعد",
-    "description": "Label for button that proceeds from the introduction page to the login page."
-  },
-  "learnMoreUproxy": {
-    "message": "اطلاعات بیشتر در مورد uProxy بدانید",
-    "description": "Label for button that brings user to more information about uProxy."
-  },
-  "whichSocialNetwork": {
-    "message": "از کجا می توانم مخاطبین خود را سریعترین را پیدا کردید؟",
-    "description": "Question seen at the top of uProxy's login page. Asks which social network should be used to find the user's friends."
-  },
-  "whySocialNetwork": {
-    "message": "uProxy با استفاده از شبکه های اجتماعی برای کمک به شما در تنظیم ارتباطات با دوستان خود",
-    "description": "Explains why uProxy needs social networks. (Friends need to login with the same social network on uProxy for friends to see each other.)"
-  },
-  "setUpOneTime": {
-    "message": "راه اندازی یک اتصال یک بار",
-    "description": "Clickable link on the login page. As an alternative to logging in to a social network, user's can attempt a connection with a one-time link."
-  },
-  "weWontPost": {
-    "message": "ما داده ها و یا پست شما بدون رضایت شما را به اشتراک بگذارید عمومی",
-    "description": "Inform the user that uProxy does not share data or post to their social network accounts without agreement from the user."
-  },
-  "learnMoreSocial": {
-    "message": "اطلاعات بیشتر در مورد شبکه های اجتماعی بیشتر بدانید",
-    "description": "Label for button that brings user to more information about why social networks are used for uProxy."
-  },
-  "askToAnalyze": {
-    "message": "این می تواند باشد که نوع شبکه خود را NAT با uProxy ناسازگار است. آیا می خواهید uProxy به تجزیه و تحلیل شبکه شما؟",
-    "description": "Text in a popup that appears when an attempt to access the Internet through a friend fails."
-  },
-  "analyzingNetwork": {
-    "message": "شبکه تجزیه و تحلیل",
-    "description": "Message shown when the user's network is being analyzed."
-  },
-  "analysisResults": {
-    "message": "به نظر میرسد شما در __natType__، که __natImpact__ تداخل با توانایی خود را برای اتصال به دوست هستند.",
-    "description": "A summary of the user's network analysis."
-  },
-  "moreInfo": {
-    "message": "اطلاعات بیشتر",
-    "description": "Link to 'Does uProxy log data about me?' question in the FAQ."
-  },
-  "askToSubmitAnalysis": {
-    "message": "آیا می خواهید برای ارسال نوع NAT خود را به تیم uProxy، برای کمک به ما را بهتر درک شبکه های کاربران ما در؟",
-    "description": "Asks the user if they are willing to share their network analysis results with uProxy, to help the development of uProxy."
-  },
-  "veryLikely": {
-    "message": "به احتمال بسیار زیاد",
-    "description": "Meaning high probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
-  },
-  "possibly": {
-    "message": "احتمالا",
-    "description": "Meaning medium probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
-  },
-  "unlikely": {
-    "message": "بعید",
-    "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
-  },
-  "privacyPolicy": {
-    "message": "سیاست حفظ حریم خصوصی",
-    "description": "Link to uProxy's privacy policy."
-  },
-  "startedProxying": {
-    "message": "__name__ وکالتی از طریق شما آغاز شده",
-    "description": "Notification for when a friend has started accessing the Internet through the user."
-  },
-  "stoppedProxying": {
-    "message": "__name__ وکالتی از طریق شما متوقف",
-    "description": "Notification for when a friend has stopped accessing the Internet through the user."
-  },
-  "unableToShareWith": {
-    "message": "قادر به اشتراک گذاشتن دسترسی با __name__",
-    "description": "Error message seen in uProxy when a friend failed to get access to the Internet through the user."
-  },
-  "unableToGetFrom": {
-    "message": "قادر به دسترسی از __name__",
-    "description": "Error message seen in uProxy when the user failed to get access to the Internet through a friend."
-  },
-  "gettingAccessFrom": {
-    "message": "گرفتن دسترسی از __name__",
-    "description": "Message in a status bar that is visible when the user is getting access from a friend."
-  },
-  "sharingAccessWith_one": {
-    "message": "به اشتراک گذاری دسترسی با __name__",
-    "description": "Message in a status bar that is visible when one friend is getting access through the user."
-  },
-  "sharingAccessWith_two": {
-    "message": "به اشتراک گذاری دسترسی با __name1__ و __name2__",
-    "description": "Message in a status bar that is visible when two friends are getting access through the user."
-  },
-  "sharingAccessWith_many": {
-    "message": "به اشتراک گذاری دسترسی با __name__ و __numOthers__ دیگران",
-    "description": "Message in a status bar that is visible when three or more friends are getting access through the user."
-  },
-  "loggedOut": {
-    "message": "شما از __network__ به ثبت رسیده است",
-    "description": "Notification for when the user has been logged out of the social network."
-  },
-  "grantedAccessNotification": {
-    "message": "__name__ دسترسی شما اعطا",
-    "description": "Notification for when a user's request to access the Internet through a friend has been accepted by that friend."
-  },
-  "offeredAccessNotification": {
-    "message": "__name__ دسترسی شما ارائه",
-    "description": "Notification for when the user receives an offer from a friend to access the Internet through them."
-  },
-  "acceptedOfferNotification": {
-    "message": "__name__ پیشنهاد خود را برای دسترسی پذیرفته است",
-    "description": "Notification for when a friend has accepted the user's offer to share their Internet with that friend."
-  },
-  "requestingAccessNotification": {
-    "message": "__name__ درخواست دسترسی",
-    "description": "Notification for when a friend sends a request to access the Internet through the user."
-  },
-  "descriptionDefault": {
-    "message": "__number__ کامپیوتر",
-    "description": "If a friend has more than one computer, the computers are given this default name (with increasing numbers) to differentiate them."
-  },
-  "language": {
-    "message": "زبان",
-    "description": "Language used by the application."
-  },
-  "selectLanguage": {
-    "message": "انتخاب زبان",
-    "description": "Instruction to select language used by the application."
-  },
-  "extMissingTitle": {
-    "message": "شما تقریبا آماده برای استفاده uProxy هستید!",
-    "description": "Shown in Chrome if the user has not finished installing both parts of uProxy."
-  },
-  "extMissingMessage": {
-    "message": "دانلود و فعال کردن قسمت 1 از uProxy برای شروع.",
-    "description": "Shown in Chrome to instruct the user to install part 1 of uProxy."
-  },
-  "appMissingTitle": {
-    "message": "شما تقریبا آماده برای استفاده uProxy هستید!",
-    "description": "Shown in Chrome if the user has not finished installing both parts of uProxy."
-  },
-  "appMissingMessage": {
-    "message": "دانلود و فعال کردن قسمت 2 از uProxy برای شروع.",
-    "description": "Shown in Chrome to instruct the user to install part 2 of uProxy."
-  }
+    "friendOffline": {
+        "message": "__name__ در دسترس نیست",
+        "description": "Message shown when trying to get access from a friend who is offline."
+    },
+    "sendConnectionLink": {
+        "message": "برای این که ارتباط خود را به اشتراک بگذارید، از دوست خود بخواهید که لینک خود را برای شما ارسال کند.",
+        "description": "Instructions for the user to share their connection with a one-time link."
+    },
+    "welcome": {
+        "message": "به یوپراکسی خوش آمدید",
+        "description": ""
+    },
+    "oneTimeSharing": {
+        "message": "شما در حال به اشتراک گذاری دسترسی تان هستید. ",
+        "description": "The user is sharing their Internet access with a friend."
+    },
+    "requestingAccessNotification": {
+        "message": "__name__ از شما درخواست دسترسی دارد",
+        "description": "Notification for when a friend sends a request to access the Internet through the user."
+    },
+    "changeStatsChoice": {
+        "message": "شما می توانید در هر زمان و از طریق منوی تنظیمات، انتخاب های خود را تغییر دهید.",
+        "description": "Informs the user that they can opt in and out of sending anonymous statistics at any time they choose, from the Settings menu."
+    },
+    "sharingAccessWith_two": {
+        "message": "به اشتراک گذاری دسترسی با __name1__ و __name2__",
+        "description": "Message in a status bar that is visible when two friends are getting access through the user."
+    },
+    "emailInsteadMessage": {
+        "message": "متاسفانه بازخورد شما به uProxy.org نرسید. لطفا بازخورد خود را کپی کرده و به نشانی info@uproxy.org ایمیل کنید.",
+        "description": "Seen if feedback submission through uProxy fails. Message asks users to email their feedback instead."
+    },
+    "weWontPost": {
+        "message": "ما اطلاعات شما را به اشتراک نمی گذاریم و بدون رضایت شما پستی منتشر نخواهیم کرد",
+        "description": "Inform the user that uProxy does not share data or post to their social network accounts without agreement from the user."
+    },
+    "imIn": {
+        "message": "بله",
+        "description": "Agree to submitting anonymous metrics to uProxy."
+    },
+    "stopOneTimeInstruction": {
+        "message": "برای قطع گرفتن دسترسی از دوست خود، دکمه زیر را بفشارید.",
+        "description": ""
+    },
+    "thankYou": {
+        "message": "ممنونیم!",
+        "description": ""
+    },
+    "emailInsteadTitle": {
+        "message": "ارسال بازخورد از طریق ایمیل؟",
+        "description": "Title for error that appears if feedback submission failed."
+    },
+    "selectLanguage": {
+        "message": "انتخاب زبان",
+        "description": "Instruction to select language used by the application."
+    },
+    "getHelp": {
+        "message": "درخواست کمک",
+        "description": "Get help from the frequently asked questions page."
+    },
+    "yes": {
+        "message": "بله",
+        "description": "Button label."
+    },
+    "submitFeedback_sentenceCase": {
+        "message": "ارسال بازخورد",
+        "description": "Submit feedback to the uProxy team."
+    },
+    "getOneTimeInsteadInstruction": {
+        "message": "در صورتی که تمایل دارید با فرد دیگری ارتباط برقرار کنید، بر روی دکمه \"بازگشت\" کلیک کرده و برای شروع یک اتصال جدید، بر روی \"شروع یک ارتباط یک بار مصرف\" کلیک کنید.",
+        "description": "Instructions for the user if they want to abort an existing attempt and start a new one-time connection."
+    },
+    "errorParsingLink": {
+        "message": "مشکلی در تجزیه لینک اتصال یوپراکسی به وجود آمد، لطفا لینک را بازبینی مجدد کرده و یا از دوست خود لینک جدیدی درخواست کنید.",
+        "description": "Error shown if a one-time connection link did not work."
+    },
+    "feedbackTitle": {
+        "message": "بازخورد خود را در زیر بنویسید",
+        "description": "Label for textbox for user's to submit feedback and comments to uProxy."
+    },
+    "howToOfferOneTime": {
+        "message": "در صورتی که تمایل دارید به آن ها دسترسی دهید، این آدرس URL را کپی و برای آن ها ارسال کنید.",
+        "description": "Instructions for user if they'd like to share their Internet connection with a one-time link."
+    },
+    "loadingFriends": {
+        "message": "بازیابی دوستان در یوپراکسی",
+        "description": "User's friends are being loaded from a social network."
+    },
+    "acceptOffer": {
+        "message": "پذیرش پیشنهاد",
+        "description": "Accept a friend's offer that would allow the user to access the Internet through their friend."
+    },
+    "sharingAccessWith_one": {
+        "message": "به اشتراک گذاری دسترسی با __name__",
+        "description": "Message in a status bar that is visible when one friend is getting access through the user."
+    },
+    "statsEnabledMessage": {
+        "message": "این آیکون بدان معناست که شما تصمیم گرفته اید گزارش های آماری خود را به صورت ناشناس برای تیم یوپراکسی ارسال کنید. برای انجام تغییرات کلیک کنید.",
+        "description": "Text that appears in a popup explaining the 'anonymous stats enabled' icon."
+    },
+    "requests": {
+        "message": "درخواست ها",
+        "description": "Title for the group of friends who have sent requests to access the user's Internet, which the user have not yet granted."
+    },
+    "startGetting": {
+        "message": "شروع دریافت دسترسی",
+        "description": "Start accessing the Internet through a friend's connection."
+    },
+    "stopGetting": {
+        "message": "پایان دریافت دسترسی",
+        "description": "Stop accessing the Internet through a friend's connection."
+    },
+    "advancedSettings_sentenceCase": {
+        "message": "تنظیمات پیشرفته",
+        "description": "Title for the advanced settings screen."
+    },
+    "enableMetrics": {
+        "message": "آیا تمایل دارید که آمار گیری به صورت ناشناس فعال باشد؟",
+        "description": "Asks the user if they want to send anonymous metrics about their uProxy usage."
+    },
+    "tryingToShareOneTime": {
+        "message": "شما در حال حاضر در روند به اشتراک گذاری دسترسی تان هستید. در صورتی که تمایل دارید به جای آن دسترسی بگیرید، بر روی لینک زیر کلیک کنید.",
+        "description": "Instructions for user if they want to get access instead, while attempting to share access."
+    },
+    "language": {
+        "message": "زبان",
+        "description": "Language used by the application."
+    },
+    "unlikely": {
+        "message": "نه اصلا",
+        "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
+    },
+    "alphaMessage": {
+        "message": "این نسخه آلفا یوپراکسی است. شما با به اشتراک گذاری اطلاعات آماری خود با تیم توسعه دهندگان به صورت ناشناس می توانید به توسعه نرم افزار کمک کنید. داده های گزارش در سیستم کلاینت ناشناس شده و سپس به صورت کاملا امن منتقل می شوند.",
+        "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
+    },
+    "moreInformation": {
+        "message": "اطلاعات بیشتر.",
+        "description": ""
+    },
+    "possibly": {
+        "message": "تا حدودی",
+        "description": "Meaning medium probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
+    },
+    "friendRequestsAccess": {
+        "message": "__name__ از شما درخواست دسترسی دارد.",
+        "description": "A friend has requested to access the Internet through the user."
+    },
+    "getOneTimeInstead": {
+        "message": "به جای آن دسترسی بگیر",
+        "description": "Label for a link to the 'Start a one-time connection' page."
+    },
+    "setUpOneTime": {
+        "message": "راه اندازی یک ارتباط یک بار مصرف",
+        "description": "Clickable link on the login page. As an alternative to logging in to a social network, user's can attempt a connection with a one-time link."
+    },
+    "friendRequestedOneTime": {
+        "message": "دوستتان درخواست استفاده از ارتباط اینترنت شما را دارد.",
+        "description": "A friend has requested to access the Internet through the user."
+    },
+    "no": {
+        "message": "نه",
+        "description": "Button label."
+    },
+    "areYouSure": {
+        "message": "آیا مطمئن هستید که می خواهید این ارتباط یک بار مصرف را پایان دهید؟",
+        "description": "Question confirming if the user wants to end an active connection to a friend."
+    },
+    "acceptedOfferNotification": {
+        "message": "__name__ پیشنهاد دسترسی شما را پذیرفت",
+        "description": "Notification for when a friend has accepted the user's offer to share their Internet with that friend."
+    },
+    "sharingUnavailableTitle": {
+        "message": "به اشتراک گذاری در دسترس نیست",
+        "description": "Title for error that appears when the user can not share their Internet access with friends."
+    },
+    "learnMoreUproxy": {
+        "message": "درباره یوپراکسی بیشتر بخوانید",
+        "description": "Label for button that brings user to more information about uProxy."
+    },
+    "startOneTimeInstruction": {
+        "message": "برای گرفتن دسترسی از دوست خود، بر روی دکمه زیر کلیک کنید.",
+        "description": ""
+    },
+    "noFriendsOnline": {
+        "message": "در حال حاضر هیچ یک از دوستانتان از یوپراکسی استفاده نمی کنند.",
+        "description": "None of the user's friends are currently signed in."
+    },
+    "continueBrowsing": {
+        "message": "به مرور وب بدون یوپراکسی ادامه دهید",
+        "description": "Label for button that will change the users Internet settings back to using the user's local connection (i.e. not their friend's Internet)."
+    },
+    "grantedAccessNotification": {
+        "message": "__name__ دسترسی شما را تضمین کرد",
+        "description": "Notification for when a user's request to access the Internet through a friend has been accepted by that friend."
+    },
+    "emailTitle": {
+        "message": "ایمیل (اختیاری)",
+        "description": ""
+    },
+    "askToAnalyze": {
+        "message": "ممکن است نوع NAT شبکه شما با یوپراکسی سازگار نباشد. آیا تمایل دارید که یوپراکسی شبکه شما را تحلیل کند؟",
+        "description": "Text in a popup that appears when an attempt to access the Internet through a friend fails."
+    },
+    "unableToGet": {
+        "description": "Title for popup that appears when an attempt to access the Internet through a friend fails.",
+        "message": "قادر به دسترسی"
+    },
+    "unableToShare": {
+        "description": "Title for popup that appears when an attempt to share the Internet with a friend fails.",
+        "message": "قادر به اشتراک گذاشتن دسترسی"
+    },
+    "shareOneTime": {
+        "message": "اشتراک گذاری ارتباط برای یک مرتبه",
+        "description": "Share access to the user's Internet using a link that will only work once."
+    },
+    "askToSubmitAnalysis": {
+        "message": "آیا تمایل دارید که تیم یوپراکسی را در جریان نوع NAT مورد استفاده تان قرار دهید تا از این طریق بتوانیم تصور بهتری از شبکه هایی که کاربران از آن استفاده می کنند داشته باشیم؟",
+        "description": "Asks the user if they are willing to share their network analysis results with uProxy, to help the development of uProxy."
+    },
+    "getAccess": {
+        "message": "دریافت دسترسی",
+        "description": "Text for the tab on the toolbar. When the user is on the 'Get Access' tab, they are looking to get access to the Internet through a friend."
+    },
+    "retrievingLogs": {
+        "message": "بازیابی لاگ ها و آنالیز شبکه شما",
+        "description": "Message shown while uProxy is analyzing the user's network settings."
+    },
+    "learnMoreSocial": {
+        "message": "درباره شبکه های اجتماعی بیشتر بدانید",
+        "description": "Label for button that brings user to more information about why social networks are used for uProxy."
+    },
+    "waitingForAccess": {
+        "message": "هر زمان که  __name__ بپذیرد، دسترسی شما فعال خواهد شد.",
+        "description": "User will be able to access the Internet through their friend, once that friend gives the user permission."
+    },
+    "connectedWith": {
+        "message": "به __network__ متصل شده است",
+        "description": "Text in settings that informs the user which social network they're connected to."
+    },
+    "requestOneTime": {
+        "message": "درخواست ارتباط برای یک مرتبه",
+        "description": "Request access to the user's friend's Internet using a link that will only work once."
+    },
+    "connect": {
+        "message": "اتصال",
+        "description": "User clicks this to connect to a network"
+    },
+    "close": {
+        "message": "بستن",
+        "description": "Button label to close a popup."
+    },
+    "deviceDescription": {
+        "message": "شرح دستگاه",
+        "description": "Title for the section in Settings where the user can edit the name of their device."
+    },
+    "logout": {
+        "message": "خروج از یوپراکسی",
+        "description": "Log-out of uProxy."
+    },
+    "editAdvancedSettings": {
+        "message": "تنظیمات خود را در زیر تغییر دهید",
+        "description": "Instruction for the user to edit their advanced settings (by typing JSON in a textbox)."
+    },
+    "revokeAccess": {
+        "message": "ابطال دسترسی",
+        "description": "Label for button that takes back an offer to a friend who has already accepted that offer. If the button is clicked, the friend will no longer be able to connect to the Internet through the user."
+    },
+    "unableToGetFrom": {
+        "message": "امکان گرفتن دسترسی از __name__ وجود ندارد",
+        "description": "Error message seen in uProxy when the user failed to get access to the Internet through a friend."
+    },
+    "friendsWhoCanGet": {
+        "message": "دوستانی که می توانند از شما دسترسی بگیرند",
+        "description": "Title for the group of friends who can access the Internet through the user."
+    },
+    "submitFeedback": {
+        "message": "ارسال بازخورد",
+        "description": "Submit feedback to the uProxy team."
+    },
+    "askingForAccess": {
+        "message": "درخواست دسترسی",
+        "description": "The user is asking for permission to access the Internet through their friend; user is waiting for the friend's reply."
+    },
+    "analyzingNetwork": {
+        "message": "تحلیل شبکه",
+        "description": "Message shown when the user's network is being analyzed."
+    },
+    "stopOneTimeGettingBeforeNew": {
+        "message": "در صورتی که می خواهید یک ارتباط یک بار مصرف جدید آغاز کنید، ابتدا باید کلید \"توقف دریافت دسترسی\" را فشار دهید.",
+        "description": "Instruction for the user to stop a current one-time connection if they want to start a new one."
+    },
+    "moreInfo": {
+        "message": "اطلاعات بیشتر",
+        "description": "Link to 'Does uProxy log data about me?' question in the FAQ."
+    },
+    "privacyPolicy": {
+        "message": "سیاست حفظ حریم خصوصی",
+        "description": "Link to uProxy's privacy policy."
+    },
+    "stopIgnoringOffers": {
+        "message": "توقف نادیده گرفتن پیشنهادها",
+        "description": "Button label for if the user wants to stop ignoring offers."
+    },
+    "errorSigningIn": {
+        "message": "مشکلی برای ورود به  __network__ به وجود آمد. لطفا مجددا تلاش کنید.",
+        "description": "Notification for when the user could not be signed in to a social network."
+    },
+    "sharingEnabledMessage": {
+        "message": "این آیکون بدان معناست که شما برای به اشتراک گذاری دسترسی با افرادی که به آن ها پیشنهاد دسترسی داده اید آماده هستید.",
+        "description": "Text in a popup that explains what the sharing icon (on the toolbar) is."
+    },
+    "stopOneTimeSharingBeforeNew": {
+        "message": "در صورتی که می خواهید یک ارتباط یک بار مصرف جدید شروع کنید، ابتدا \"توقف به اشترام گذاری دسترسی\" را بفشارید.",
+        "description": "Instruction for the user to stop a current one-time connection if they want to start a new one."
+    },
+    "ignore": {
+        "message": "نادیده بگیر",
+        "description": "Button label that ignores an offer or request."
+    },
+    "logsTitle": {
+        "message": "لاگ ها و آنالیزهای شبکه",
+        "description": "Title for the page that displays a user's network information and uProxy logs."
+    },
+    "friendRequestedAccess": {
+        "message": "آنها درخواست دسترسی از طریق شما را داده اند.",
+        "description": "A friend has requested to access the Internet through the user."
+    },
+    "goBack": {
+        "message": "بازگشت؟",
+        "description": "Go back to the main page from the one-time connection page."
+    },
+    "accessNotGranted": {
+        "message": "شما دسترسی آن ها را تضمین نکرده اید.",
+        "description": "The user has not permissioned a friend to access the Internet through the user."
+    },
+    "networkAndLogs": {
+        "message": " تحلیل شبکه و لاگ ها ",
+        "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
+    },
+    "welcomeMessage": {
+        "message": "برای شروع کار، \"دریافت دسترسی\" یا \"به اشتراک گذاری دسترسی\" را فعال کرده و سپس بر روی دوستی که تمایل دارید به او متصل شوید کلیک کنید. ",
+        "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
+    },
+    "noThanks": {
+        "message": "نه ممنونم",
+        "description": "Do not agree to submitting anonymous metrics to uProxy."
+    },
+    "friendsWhoShare": {
+        "message": "دوستانی که می توانید از آن ها دسترسی بگیرید",
+        "description": "Title for the group of friends who the user can get Internet access from."
+    },
+    "unableToShareWith": {
+        "message": "امکان به اشتراک گذاری دسترسی با __name__ وجود ندارد",
+        "description": "Error message seen in uProxy when a friend failed to get access to the Internet through the user."
+    },
+    "settingsJsonError": {
+        "message": "امکان تنظیم وجود ندارد: عدم مطابقت میزان JSON",
+        "description": "Error shown to the user if their input for advanced settings is incomplete or incompatible with expected settings configurations."
+    },
+    "offerAccess": {
+        "message": "پیشنهاد دسترسی",
+        "description": "Label for button that will offer a friend access to the Internet through the user, even though the friend has not requested access."
+    },
+    "next": {
+        "message": "بعدی",
+        "description": "Label for button that proceeds from the introduction page to the login page."
+    },
+    "sharingUnavailableMessage": {
+        "message": "اوه! شما از فایرفاکس 37 استفاده می کنید که به دلیل وجود یک باگ از اشتراک گذاری جلوگیرری می کند (git.io/vf5x1 را ببینید). این باگ در فایرفاکس 38 برطرف شده است، پس برای فعال کردن به اشتراک گذاری دسترسی باید فایرفاکس را به روز کرده و یا از کروم استفاده کنید. ",
+        "description": "Text for error that appears when the user can not share their Internet access with friends."
+    },
+    "analysisResults": {
+        "message": "به نظر می رسد شما بر روی __natType__ هستید که __natImpact__  برای ارتباط با دوستانتان تداخل ایجاد می کند.",
+        "description": "A summary of the user's network analysis."
+    },
+    "sharingEnabledTitle": {
+        "message": "به اشتراک گذاری فعال شد",
+        "description": "Title for popup that points to the sharing icon in uProxy's top toolbar. The popup appears when the user first grants access to one of their friends. The sharing icon is visible as long as there are friends who can get access to the user's Internet."
+    },
+    "startNewConnection": {
+        "message": "یک اتصال جدید بگیر",
+        "description": "Label for button that takes user back to the 'Start a one-time connection' page."
+    },
+    "appMissingTitle": {
+        "message": "شما حدودا آماده هستید که از یوپراکسی استفاده کنید!",
+        "description": "Shown in Chrome if the user has not finished installing both parts of uProxy."
+    },
+    "cancelRequest": {
+        "message": "لغو درخواست",
+        "description": "Label for button which will take back a request to get Internet access through a friend."
+    },
+    "sharingAccessWith_many": {
+        "message": "به اشتراک گذاری دسترسی با __name__ و __numOthers__ دیگر",
+        "description": "Message in a status bar that is visible when three or more friends are getting access through the user."
+    },
+    "cannotOpenOneTimeTitle": {
+        "message": "امکان باز کردن ارتباط یک بار مصرف وجود ندارد",
+        "description": "Title for an error popup that appears if the user tries to open a one-time link while signed in to a social network."
+    },
+    "loggedOut": {
+        "message": "شما از __network__ خارج شدید",
+        "description": "Notification for when the user has been logged out of the social network."
+    },
+    "restart": {
+        "message": "شروع مجدد",
+        "description": "Restart uProxy completely."
+    },
+    "startOneTime": {
+        "message": "شروع ارتباط یک بار مصرف",
+        "description": "Start an Internet connection using a link that will only work once."
+    },
+    "stoppedProxying": {
+        "message": "__name__ پروکسی کردن از طریق شما را متوقف کرد",
+        "description": "Notification for when a friend has stopped accessing the Internet through the user."
+    },
+    "disconnectedTitle": {
+        "message": "اوه! ارتباط شما با دوستتان قطع شد.",
+        "description": "Title for error that appears when the user was getting access to the Internet through their friend, but that connection was terminated."
+    },
+    "connectedWithNumber": {
+        "message": "متصل با __number__ شبکه",
+        "description": "Text in settings informing the user of how many networks they're connected to."
+    },
+    "attemptingReconnect": {
+        "message": "تلاش برای ارتباط مجدد.",
+        "description": "uProxy was disconnected from the social network and is trying to reconnect."
+    },
+    "whichSocialNetwork": {
+        "message": "از کجا می توانید به سرعت به اطلاعات تماستان دسترسی داشته باشید؟",
+        "description": "Question seen at the top of uProxy's login page. Asks which social network should be used to find the user's friends."
+    },
+    "tryingToConnect": {
+        "message": "تلاش می کند به __name__ متصل شود",
+        "description": "The user is trying to connect to the Internet through their friend."
+    },
+    "emailPlaceholder": {
+        "message": "آدرس ایمیل",
+        "description": ""
+    },
+    "save": {
+        "message": "ذخیره",
+        "description": "Label for button that saves the user's text input."
+    },
+    "offeredYouAccess": {
+        "message": "آنها به شما پیشنهاد دسترسی داده اند.",
+        "description": "A friend has offered their Internet access to the user."
+    },
+    "sharingEnabledTooltip": {
+        "message": "برای به اشتراک گذاری در دسترس هستید.",
+        "description": "Text that appears in a tooltip when the user hovers over the sharing icon."
+    },
+    "shareAccess": {
+        "message": "به اشتراک گذاری دسترسی",
+        "description": "Text for the tab on the toolbar. When the user is on the 'Share Access' tab, they are looking to share access to their Internet with a friend."
+    },
+    "disconnect": {
+        "message": "قطع ارتباط",
+        "description": "User clicks this to disconnect from a network"
+    },
+    "disconnectedMessage": {
+        "message": "لطفا به این اخطار توجه کنید و با احتیاط ادامه دهید. ترافیک شما دیگر از طریق دوستتان ارسال نخواهد شد. در صورتی که صفحه حساسی بر روی مرورگرتان باز است، لطفا پیش از هر عملی آن را ببندید.",
+        "description": "Instruction informing the user that to continue browsing the Internet, the user will need to use their local (potentially unsafe and/or censored) connection."
+    },
+    "whySocialNetwork": {
+        "message": "یوپراکسی از شبکه های اجتماعی استفاده می کند تا بتوانید از آن طریق به دوستانتان متصل شوید",
+        "description": "Explains why uProxy needs social networks. (Friends need to login with the same social network on uProxy for friends to see each other.)"
+    },
+    "toSendLogs": {
+        "message": "برای ارسال لاگ ها به منظور کمک به تیم یوپراکسی، نرم افزار را باز کرده و بر روی \"ارسال بازخورد\" کلیک کنید",
+        "description": "Instructions guiding the user through how to submit their logs to uProxy."
+    },
+    "cancel": {
+        "message": "لغو کن",
+        "description": "Button label that rejects a proposed action."
+    },
+    "feedbackSubmitted": {
+        "message": "بازخورد شما به دست تیم توسعه دهندگان یوپراکسی رسید.",
+        "description": "User feedback was successfully submitted."
+    },
+    "aboutUproxy": {
+        "message": "یوپراکسی به شما کمک می کند تا با به اشتراک گذاری دسترسی خود به اینترنت، امکان استفاده از اینترنت را برای دوستانتان فراهم کنید",
+        "description": "Description on uProxy's introduction screen explaining what uProxy is."
+    },
+    "editAdvancedSettingsPlaceholder": {
+        "message": "تغییر در تنظیمات",
+        "description": "Default text in the advanced settings textbox."
+    },
+    "statsEnabledTooltip": {
+        "message": "شما اطلاعات آماری را به صخورت ناشناس به اشتراک گذارده اید.",
+        "description": "Text that appears in a tooltip when the user hovers over the 'anonymous stats enabled' icon."
+    },
+    "descriptionDefault": {
+        "message": "__number__ کامپیوتر",
+        "description": "If a friend has more than one computer, the computers are given this default name (with increasing numbers) to differentiate them."
+    },
+    "friendNeedsToClick": {
+        "message": "برای کامل کردن ارتباط، دوست شما باید بر روی لینک ارسالی کلیک کرده و لینک گرفته شده از یوپراکسی خود را برای شما ارسال کند. زمانی که بر روی لینک کلیک کنید، آماده خواهید بود که دسترسی بگیرید. ",
+        "description": "Instructions telling the user that starting a one-time connection is waiting for action from their friend."
+    },
+    "offers": {
+        "message": "پیشنهادها",
+        "description": "Title for the group of friends who have sent offers of access to their Internet, which the user have not yet accepted."
+    },
+    "done": {
+        "message": "انجام شد",
+        "description": "Button label that suggests acknowledgement and that closes a popup."
+    },
+    "extMissingMessage": {
+        "message": "بخش ۱ یوپراکسی را دانلود کرده و برای شروع فعال کن.",
+        "description": "Shown in Chrome to instruct the user to install part 1 of uProxy."
+    },
+    "cancelOffer": {
+        "message": "رد پیشنهاد",
+        "description": "Label for button that takes back an offer to a friend who has not yet accepted that offer. If the button is clicked, the friend will no longer be able to connect to the Internet through the user."
+    },
+    "copyConnectionLink": {
+        "message": "برای درخواست دسترسی از یک دوست، آدرس URL را کپی کرده و از طریق یک کانال امن برای او ارسال کنید.",
+        "description": "Instructions for the user to request access from a friend with a one-time link."
+    },
+    "loading": {
+        "message": "در حال بارگذاری...",
+        "description": "Message show when something is taking time to load."
+    },
+    "askForAccess": {
+        "message": "ارسال درخواست برای دسترسی",
+        "description": "Button label that sends a request to the user's friend, asking if the user can access the Internet through them."
+    },
+    "grantedYouAccess": {
+        "message": " __name__ اجازه دسترسی را تضمین کرد",
+        "description": "The user's friend has allowed the user to use the friend's Internet connection."
+    },
+    "cantOpenOneTimeMessage": {
+        "message": " در حال حاضر ایجاد یک ارتباط دستی، همزمان با استفاده از یوپروکسی از طریق شبکه های اجتماعی وجود ندارد. برای ایجاد یک ارتباط دستی، لطفا از طریق منوی تنظیمات لاگ اوت کرده و لینک را مجددا وارد کنید. ",
+        "description": "Text for an error popup that appears if the user tries to open a one-time link while signed in to a social network."
+    },
+    "extMissingTitle": {
+        "message": "شما حدودا آماده هستید که از یوپراکسی استفاده کنید!",
+        "description": "Shown in Chrome if the user has not finished installing both parts of uProxy."
+    },
+    "oneTimeSuccess": {
+        "message": "با موفقیت انجام شد! ارتباطی یک بار مصرف برقرار شد. ",
+        "description": "Inform the user that a one-time connection was successfully established."
+    },
+    "oneTimeGetting": {
+        "message": "شما در حال گرفتن دسترسی هستید.",
+        "description": "The user is connected to the Internet through their friend."
+    },
+    "set": {
+        "message": "تنظیم کن",
+        "description": "Label for button that saves the user's advanced settings."
+    },
+    "gettingAccessFrom": {
+        "message": "دریافت دسترسی از __name__",
+        "description": "Message in a status bar that is visible when the user is getting access from a friend."
+    },
+    "startedProxying": {
+        "message": "__name__ شروع به پروکسی کردن از طریق شما کرد",
+        "description": "Notification for when a friend has started accessing the Internet through the user."
+    },
+    "toInviteFriends": {
+        "message": "برای دعوت دوستانتان به یوپراکسی، لینک https://www.uproxy.org را برای آن ها ارسال کنید.",
+        "description": "Instruction informing the user how to invite their friends to uProxy."
+    },
+    "veryLikely": {
+        "message": "بسیار زیاد",
+        "description": "Meaning high probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
+    },
+    "statsEnabledTitle": {
+        "message": "آمارگیری ناشناس فعال شد",
+        "description": "The user has elected to submit anonymous statistics about their uProxy usage to the uProxy team."
+    },
+    "appMissingMessage": {
+        "message": "بخش ۲ یوپراکسی را دانلود کرده و برای شروع فعال کن.",
+        "description": "Shown in Chrome to instruct the user to install part 2 of uProxy."
+    },
+    "uproxyFriends": {
+        "message": "دوستانی که یوپراکسی دارند",
+        "description": "Title for the group of friends who have uProxy but who don't fit into any of the other contact groups."
+    },
+    "stopIgnoringRequests": {
+        "message": "اتمام نادیده گرفتن درخواست ها",
+        "description": "Button label for if the user wants to stop ignoring requests."
+    },
+    "stopOneTimeSharing": {
+        "message": "توقف به اشتراک گذاری دسترسی",
+        "description": "Label for button to terminate your connection to a friend who is accessing the Internet through you."
+    },
+    "settingsBadFormatError": {
+        "message": "امکان تنظیم وجود ندارد: قالب اشتباه",
+        "description": "Error shown to the user if their input for advanced settings is badly formed JSON."
+    },
+    "PIIMessage": {
+        "message": "بازخورد  و آدرس ایمیل شما به uProxy.org ارسال شد. لاگ ها، اطلاعات شبکه و ایمیل ممکن است شامل اطلاعات شناسایی فردی باشد. ",
+        "description": "Message helping make sure the user understands that personally identifiable information may be included in their feedback to uProxy."
+    },
+    "settingsSaved": {
+        "message": "تنظیمات ذخیره شد",
+        "description": "Message that confirms to the user that their advanced settings were saved."
+    },
+    "ok": {
+        "message": "بله",
+        "description": "Button label."
+    },
+    "grantedFriendAccess": {
+        "message": "شما به آن ها دسترسی داده اید.",
+        "description": "The user has agreed to let their friend access the Internet through the user."
+    },
+    "offeredAccessNotification": {
+        "message": "__name__ به شما پیشنهاد دسترسی داده است",
+        "description": "Notification for when the user receives an offer from a friend to access the Internet through them."
+    },
+    "grant": {
+        "message": "اجازه",
+        "description": "Label for button that accepts a friend's request to access the Internet through the user."
+    },
+    "noLongerGetting": {
+        "message": "شما دیگر دسترسی دریافت نمی کنید. برای درخواست اتصال، بر روی دکمه زیر کلیک کنید.",
+        "description": "Message shown when a one-time connection ends."
+    },
+    "nameThisDevice": {
+        "message": "برای دستگاه یک نام انتخاب کنید",
+        "description": "If the user has not named their device (e.g. 'laptop' or 'home computer'), they will see this message in the Settings panel."
+    },
+    "feedbackPlaceholder": {
+        "message": "بازخورد خود را بنویسید",
+        "description": "The default text that appears in the user feedback textbox."
+    },
+    "connectedAccounts": {
+        "message": "حساب های کاربری مرتبط",
+        "description": "In settings, title for the social networks you can connect to."
+    },
+    "description": {
+        "message": "توضیح",
+        "description": "Placeholder for the input field for the name of the user's device."
+    },
+    "advancedSettings": {
+        "message": "تنظیمات پیشرفته",
+        "description": "Clickable text from the Settings menu. Clicking this opens the advanced settings screen."
+    },
+    "errorStartingConnection": {
+        "message": "ایرادی در شروع اتصال وجود داشت و ارتباط باید فسخ شود. لطفا یک ارتباط دیگر شروع کنید. ",
+        "description": "Error shown if a one-time connection failed to start."
+    }
 }

--- a/src/generic_ui/locales/fr/messages.json
+++ b/src/generic_ui/locales/fr/messages.json
@@ -435,6 +435,10 @@
     "message": "Description",
     "description": "Placeholder for the input field for the name of the user's device."
   },
+  "connectedAccounts": {
+    "description": "In settings, title for the social networks you can connect to.",
+    "message": "Comptes connectés"
+  },
   "connect": {
     "message": "relier",
     "description": "User clicks this to connect to a network"
@@ -518,6 +522,14 @@
   "askToAnalyze": {
     "message": "Il se pourrait que le type de NAT de votre réseau est incompatible avec uProxy. Aimeriez-vous uProxy pour analyser votre réseau?",
     "description": "Text in a popup that appears when an attempt to access the Internet through a friend fails."
+  },
+  "unableToGet": {
+    "description": "Title for popup that appears when an attempt to access the Internet through a friend fails.",
+    "message": "Impossible d'obtenir l'accès"
+  },
+  "unableToShare": {
+    "description": "Title for popup that appears when an attempt to share the Internet with a friend fails.",
+    "message": "Impossible de partager l'accès"
   },
   "analyzingNetwork": {
     "message": "réseau Analyse",

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -222,7 +222,7 @@
       </div>
 
       <div id='accountChooser' class='settingsContent' hidden?='{{ !accountChooserOpen }}'>
-        <span class='smalltext'>Connected Accounts</span>
+        <span class='smalltext'>{{ 'connectedAccounts' | $$ }}</span>
         <template repeat='{{ name in model.networkNames }}'>
           <div>
             <uproxy-network-in-settings name='{{ name }}'></uproxy-network-in-settings>

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -19,9 +19,9 @@ Polymer({
     this.analyzingNetwork = true;
     ui_context.core.getNatType().then((natType :string) => {
       this.natType = natType;
-      if (natType === 'SymmetricNAT') {
+      if (natType === 'symmetric NAT') {
         this.natImpact = ui.i18n_t('veryLikely');
-      } else if (natType === 'PortRestrictedCone') {
+      } else if (natType === 'port-restricted cone NAT') {
         this.natImpact = ui.i18n_t('possibly');
       } else {
         this.natImpact = ui.i18n_t('unlikely');


### PR DESCRIPTION
- Added translations for the troubleshoot dialog
- Edited the NAT types to be readable English
- Change the Farsi source to the one that was translated for us

![image](https://cloud.githubusercontent.com/assets/8723127/8232868/cb9de65e-15a0-11e5-855f-6fb65f5cb7e1.png)

Tested manually.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1657)
<!-- Reviewable:end -->
