### PR TITLE
Stop pinning webcomponentsjs version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,9 @@
     "core-drawer-panel": "Polymer/core-drawer-panel#^0.5.6",
     "core-overlay": "Polymer/core-overlay#^0.5.6",
     "paper-toast": "Polymer/paper-toast#^0.5.6",
-    "paper-dropdown": "Polymer/paper-dropdown#~0.5.6",
-    "webcomponentsjs": "0.6.1"
+    "paper-dropdown": "Polymer/paper-dropdown#~0.5.6"
   },
   "resolutions": {
-    "webcomponentsjs": "0.6.1"
+    "webcomponentsjs": "^0.6.0"
   }
 }


### PR DESCRIPTION
Polymer seems to have made a mistake in releasing webcomponentsjs v0.6.2
and has released v0.6.3 which is identical to v0.6.1.  We no longer need
to pin our version at v0.6.1.

Fixes #1585

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1658)
<!-- Reviewable:end -->
