### PR TITLE
When opening a tab, focus that window

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -132,11 +132,12 @@ class ChromeBrowserApi implements BrowserAPI {
 
   public openTab = (url :string) => {
     if (url.indexOf(':') < 0) {
-      // We've been passed a relative URL. Get the full URL with getURL.
-      chrome.tabs.create({url: chrome.extension.getURL(url)});
-    } else {
-      chrome.tabs.create({url: url});
+      url = chrome.extension.getURL(url);
     }
+
+    chrome.tabs.create({url: url}, (tab) => {
+      chrome.windows.update(tab.windowId, {focused: true});
+    });
   }
 
   /**


### PR DESCRIPTION
Updating our behaviour to be consistent with what is described at
https://developer.chrome.com/extensions/tabs#method-create so the window
we open tabs in will be focused.  This fixes issues on Linux with not
seeing a FAQ tab opened.

Tested in Linux (using Notion WM) and on Mac (Mac behaviour does not
seem to change)

Fixes #1581

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1668)
<!-- Reviewable:end -->
