### PR TITLE
Support automatic reconnect to Facebook, using background tabs in Chrome

### DIFF
--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -34,7 +34,8 @@ class ChromeTabAuth {
       }
     };
 
-    chrome.tabs.create({url: url},
+    var isActive = !user_interface.model.reconnecting;
+    chrome.tabs.create({url: url, active: isActive},
                        function(tab: chrome.tabs.Tab) {
       chrome.windows.update(tab.windowId, {focused: true});
       chrome.tabs.onUpdated.addListener(onTabChange);

--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -37,7 +37,7 @@ class ChromeTabAuth {
     var isActive = !user_interface.model.reconnecting;
     chrome.tabs.create({url: url, active: isActive},
                        function(tab: chrome.tabs.Tab) {
-      chrome.windows.update(tab.windowId, {focused: true});
+      chrome.windows.update(tab.windowId, {focused: isActive});
       chrome.tabs.onUpdated.addListener(onTabChange);
     }.bind(this));
   }

--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -37,7 +37,9 @@ class ChromeTabAuth {
     var isActive = !user_interface.model.reconnecting;
     chrome.tabs.create({url: url, active: isActive},
                        function(tab: chrome.tabs.Tab) {
-      chrome.windows.update(tab.windowId, {focused: isActive});
+      if (isActive) {
+        chrome.windows.update(tab.windowId, {focused: true});
+      }
       chrome.tabs.onUpdated.addListener(onTabChange);
     }.bind(this));
   }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -735,7 +735,8 @@ export class UserInterface implements ui_constants.UiApi {
         }
         model.removeNetwork(networkMsg.name);
 
-        if (!existingNetwork.logoutExpected && networkMsg.name === 'Google' &&
+        if (!existingNetwork.logoutExpected &&
+            (networkMsg.name === 'Google' || networkMsg.name === 'Facebook') &&
             !this.disconnectedWhileProxying && !this.instanceGettingAccessFrom_) {
           console.warn('Unexpected logout, reconnecting to ' + networkMsg.name);
           this.reconnect(networkMsg.name);


### PR DESCRIPTION
Support automatic reconnect to Facebook, using background tabs in Chrome.

Facebook unfortunately only supports refresh tokens (called long-lived-tokens) for server-side apps (otherwise we would leak our app-secret).  However Facebook login typically opens a tab which immediately closes, assuming the user is still logged into Facebook (if they are not, they will have to login on that tab).  We can take advantage of this by just performing the typical Facebook login on reconnect.

2 additional changes remain to be done that will make this a slightly better experience:
1. Attempt to re-use the previous Facebook auth token before requesting a new one if interactive==false in the loginOpts for FacebookSocialProvider.login.  This will mean that when a user attempts to reconnect after having only been logged in for less than an hour (token expiration time) they won't see the login tab open+close.  This should be done in freedom-social-firebase
2. Firefox tabs currently open in the foreground, rather than background.  Because uProxy doesn't override a core.oauth provider for Firefox (only Chrome), we can't easily make these background tabs in uProxy code.  Instead we should either change the core.oauth API to supply an option for opening the tab in the background, or alternatively override the core.oauth provider for Firefox in uProxy similar to Chrome.

Tested in Firefox and Chrome, re-ran grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1670)
<!-- Reviewable:end -->
