### PR TITLE
Reduce complexity of copy+paste messages

### DIFF
--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -73,10 +73,10 @@
           {{ 'copyConnectionLink' | $$ }}
         </p>
 
-        <textarea readonly hidden?='{{ !ui.copyPasteGettingMessage.length }}'
-          class='message' on-tap='{{ select }}'>https://www.uproxy.org/request/{{ ui.copyPasteGettingMessage }}</textarea>
+        <textarea readonly hidden?='{{ !ui.copyPasteGettingMessages.length }}'
+          class='message' on-tap='{{ select }}'>https://www.uproxy.org/request/{{ ui.copyPasteGettingMessages | encodeMessage }}</textarea>
 
-        <span class='message-loading' hidden?='{{ ui.copyPasteGettingMessage.length }}'>{{ 'loading' | $$ }}</span>
+        <span class='message-loading' hidden?='{{ ui.copyPasteGettingMessages.length }}'>{{ 'loading' | $$ }}</span>
 
         <p>
           {{ 'friendNeedsToClick' | $$ }}
@@ -122,10 +122,10 @@
           {{ 'howToOfferOneTime' | $$ }}
         </p>
 
-        <textarea readonly hidden?='{{ !ui.copyPasteSharingMessage.length }}'
-          class='message' on-tap='{{ select }}'>https://www.uproxy.org/offer/{{ ui.copyPasteSharingMessage }}</textarea>
+        <textarea readonly hidden?='{{ !ui.copyPasteSharingMessages.length }}'
+          class='message' on-tap='{{ select }}'>https://www.uproxy.org/offer/{{ ui.copyPasteSharingMessages | encodeMessage }}</textarea>
 
-        <span class='message-loading' hidden?='{{ ui.copyPasteSharingMessage.length }}'>{{ 'loading' | $$ }}Loading...</span>
+        <span class='message-loading' hidden?='{{ ui.copyPasteSharingMessages.length }}'>{{ 'loading' | $$ }}Loading...</span>
 
         <div>
           <a href='#' on-tap='{{ switchToGetting }}'>{{ 'getOneTimeInstead' | $$ }}</a>

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -31,7 +31,7 @@ Polymer({
     }
 
     doneStopping.then(() => {
-      ui.copyPasteGettingMessage = '';
+      ui.copyPasteGettingMessages = [];
       ui.copyPasteError = ui_constants.CopyPasteError.NONE;
       ui.copyPastePendingEndpoint = null;
 
@@ -133,6 +133,9 @@ Polymer({
       // stopped the connection
       ui.view = ui_constants.View.SPLASH;
     })
+  },
+  encodeMessage: function(message :social.PeerMessageType) {
+    return encodeURIComponent(btoa(JSON.stringify(message)));
   },
   ready: function() {
     this.ui = ui;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -167,8 +167,8 @@ export class UserInterface implements ui_constants.UiApi {
   };
 
   public copyPasteError :ui_constants.CopyPasteError = ui_constants.CopyPasteError.NONE;
-  public copyPasteGettingMessage :string = '';
-  public copyPasteSharingMessage :string = '';
+  public copyPasteGettingMessages :social.PeerMessage[] = [];
+  public copyPasteSharingMessages :social.PeerMessage[] = [];
 
   public browser :string = '';
 
@@ -251,14 +251,14 @@ export class UserInterface implements ui_constants.UiApi {
       // TODO: Display the message in the 'manual network' UI.
     });
 
-    core.onUpdate(uproxy_core_api.Update.COPYPASTE_MESSAGE, (message :social.PeerMessage) => {
-
+    core.onUpdate(uproxy_core_api.Update.COPYPASTE_MESSAGE,
+        (message :uproxy_core_api.CopyPasteMessages) => {
       switch (message.type) {
         case social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER:
-          this.copyPasteGettingMessage = <string>message.data;
+          this.copyPasteGettingMessages = message.data;
           break;
         case social.PeerMessageType.SIGNAL_FROM_SERVER_PEER:
-          this.copyPasteSharingMessage = <string>message.data;
+          this.copyPasteSharingMessages = message.data;
           break;
       }
     });
@@ -489,7 +489,7 @@ export class UserInterface implements ui_constants.UiApi {
     switch (match[1]) {
       case 'request':
         expectedType = social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER;
-        this.copyPasteSharingMessage = '';
+        this.copyPasteSharingMessages = [];
         this.core.startCopyPasteShare();
         break;
       case 'offer':
@@ -946,8 +946,8 @@ export class UserInterface implements ui_constants.UiApi {
 
     // Maybe refactor this to be copyPasteState.
     this.copyPasteState = state.copyPasteState.connectionState;
-    this.copyPasteGettingMessage = state.copyPasteState.gettingMessage;
-    this.copyPasteSharingMessage = state.copyPasteState.sharingMessage;
+    this.copyPasteGettingMessages = state.copyPasteState.gettingMessages;
+    this.copyPasteSharingMessages = state.copyPasteState.sharingMessages;
     this.copyPastePendingEndpoint = state.copyPasteState.endpoint;
     if (this.copyPasteState.localGettingFromRemote !== social.GettingState.NONE ||
         this.copyPasteState.localSharingWithRemote !== social.SharingState.NONE) {

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -45,8 +45,13 @@ export interface ConnectionState {
 export interface CopyPasteState {
   connectionState :ConnectionState;
   endpoint :net.Endpoint;
-  gettingMessage :string;
-  sharingMessage :string;
+  gettingMessages :social.PeerMessage[];
+  sharingMessages :social.PeerMessage[];
+}
+
+export interface CopyPasteMessages {
+  type :social.PeerMessageType;
+  data :social.PeerMessage[];
 }
 
 // --- Communications ---


### PR DESCRIPTION
This aims to reduce the complexity of the copy+paste messages as well as
to reduce the computation necessary to process them.

First of all, this creates a new type for the COPYPASTE_MESSAGE message
data, CopyPasteMessage.  It was previously being treated as a
PeerMessage (type was actually {type :PeerMessageType, data :string}),
and with the other updates, the type is now
{type :PeerMessageType, data :PeerMessage[]}.  This removes the need for
us to do manual type casting.

Second, as alluded to above, we now send the peer messages to the UI as
an array of peer messages instead of doing the encoding within the core.
This, and storing them in this fashion within the UI, allows us the
convenience of only needing to pipe the messages through a filter in
order to get the correct output and reduces a bit of complexity there.

Finally, since we are sending the messages down as the array, we no
longer need to handle decoding them back into an object before we add
new messages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1681)
<!-- Reviewable:end -->
