### PR TITLE
Rename fulfillLaunched to handlePopupLaunch

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -57,7 +57,7 @@ class ChromeBrowserApi implements BrowserAPI {
 
   private popupState_ = PopupState.NOT_LAUNCHED;
 
-  public fulfillLaunched : () => void;
+  public handlePopupLaunch :() => void;
   private onceLaunched_ :Promise<void>;
 
   constructor() {
@@ -169,7 +169,7 @@ class ChromeBrowserApi implements BrowserAPI {
       // after webstore installation), then allow the popup to open at a default
       // location.
       this.onceLaunched_ = new Promise<void>((F, R) => {
-        this.fulfillLaunched = F;
+        this.handlePopupLaunch = F;
       });
       chrome.windows.create({url: this.POPUP_URL,
                      type: "popup",

--- a/src/chrome/extension/scripts/chrome_core_connector.spec.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.spec.ts
@@ -39,7 +39,8 @@ describe('core-connector', () => {
   chromeBrowserApi = jasmine.createSpyObj('ChromeBrowserApi',
     ['bringUproxyToFront',
      'showNotification',
-     'on']);
+     'on',
+    'handlePopupLaunch']);
 
 
 

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -33,9 +33,8 @@ class FirefoxBrowserApi implements BrowserAPI {
     port.on('emitRejected', this.handleEmitRejected_);
   }
 
-  // Firefox doesn't ever need to wait for popup to open,
-  // We don't have onceLaunched promise, so fulfillLaunched is empty.
-  public fulfillLaunched = () => {
+  // Firefox has no work to do on initial launch
+  public handlePopupLaunch = () => {
   }
 
   public setIcon = (iconFile :string) : void => {

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -43,7 +43,7 @@ describe('UI.UserInterface', () => {
     });
 
     mockBrowserApi = jasmine.createSpyObj('browserApi',
-        ['setIcon', 'startUsingProxy', 'stopUsingProxy', 'openTab', 'showNotification', 'on']);
+        ['setIcon', 'startUsingProxy', 'stopUsingProxy', 'openTab', 'showNotification', 'on', 'handlePopupLaunch']);
     ui = new user_interface.UserInterface(mockCore, mockBrowserApi);
     spyOn(console, 'log');
   });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -359,7 +359,9 @@ export class UserInterface implements ui_constants.UiApi {
     browserApi.on('notificationClicked', this.handleNotificationClick);
     browserApi.on('proxyDisconnected', this.proxyDisconnected);
 
-    core.getFullState().then(this.updateInitialState);
+    core.getFullState()
+        .then(this.updateInitialState)
+        .then(this.browserApi.handlePopupLaunch);
   }
 
   // Because of an observer (in root.ts) watching the value of
@@ -954,8 +956,6 @@ export class UserInterface implements ui_constants.UiApi {
       // This means we had active copy-paste flow.
       this.view = ui_constants.View.COPYPASTE;
     }
-
-    this.browserApi.fulfillLaunched();
 
     while(model.onlineNetworks.length > 0) {
       model.onlineNetworks.pop();

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -43,5 +43,6 @@ export interface BrowserAPI {
   on(name :'notificationClicked', callback :(tag :string) => void) :void;
   on(name :'proxyDisconnected', callback :Function) :void;
 
-  fulfillLaunched() :void;
+  // should be called when popup is launched and ready for use
+  handlePopupLaunch() :void;
 }


### PR DESCRIPTION
The name fulfillLaunched was exposing too much information about the
implimentation a single platform (Chrome) had for what to do when a
popup was launched.  This renames that to handlePopupLaunch and defines
that it should be called once the popup is done registering callback.

The time where it is called is moved from whenever the popup receives
a full state update to calling it as soon as all callbacks have been
registered.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1683)
<!-- Reviewable:end -->
