### PR TITLE
define MESSAGE_VERSION 4, to use holographic ICE

### DIFF
--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -15,7 +15,8 @@ export var STORAGE_VERSION = 1;
 // 1: initial release
 // 2: uproxy-lib v27, move to bridge but no obfuscation yet
 // 3: offer basicObfuscation
-export var MESSAGE_VERSION = 3;
+// 4: holographic ICE
+export var MESSAGE_VERSION = 4;
 
 export var DEFAULT_STUN_SERVERS = [
   {urls: ['stun:stun.l.google.com:19302']},

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -224,9 +224,12 @@ import tcp = require('../../../third_party/uproxy-lib/net/tcp');
       } else if (remoteVersion === 2) {
         log.debug('peer is running client version 2, using bridge without obfuscation');
         pc = bridge.preObfuscation('sockstortc', config);
-      } else {
-        log.debug('peer is running client version >2, using bridge with basicObfuscation');
+      } else if (remoteVersion === 3) {
+        log.debug('peer is running client version 3, using bridge with basicObfuscation');
         pc = bridge.basicObfuscation('sockstortc', config);
+      } else {
+        log.debug('peer is running client version >=4, using holographic ICE');
+        pc = bridge.best('sockstortc', config);
       }
 
       return this.socksToRtc_.start(tcpServer, pc).then(


### PR DESCRIPTION
This `MESSAGE_VERSION` indicates that a client has support for holographic ICE.

Tested in Chrome on my desktop.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1696)
<!-- Reviewable:end -->
