### PR TITLE
add type and session id fields to feedback

### DIFF
--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -1,16 +1,24 @@
 /// <reference path='./context.d.ts' />
 
+import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+
 Polymer({
   email: '',
   feedback: '',
   logs: '',
+  feedbackType: '',
   close: function() {
     this.$.feedbackPanel.close();
   },
-  open: function(e :Event, detail :{ includeLogs: boolean }) {
-    if (detail && detail.includeLogs) {
+  open: function(e:Event, data?:{
+    includeLogs: boolean;
+    feedbackType: uproxy_core_api.UserFeedbackType;
+   }) {
+    if (data && data.includeLogs) {
       this.$.logCheckbox.checked = true;
     }
+    this.feedbackType = (data && data.feedbackType) ? data.feedbackType :
+        uproxy_core_api.UserFeedbackType.USER_INITIATED;
     this.$.feedbackPanel.open();
   },
   sendFeedback: function() {
@@ -19,7 +27,8 @@ Polymer({
       email: this.email,
       feedback: this.feedback,
       logs: this.$.logCheckbox.checked,
-      browserInfo: navigator.userAgent
+      browserInfo: navigator.userAgent,
+      feedbackType: this.feedbackType
     }).then(() => {
       // Reset the placeholders, which seem to be cleared after the
       // user types input in the input fields.

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -1,3 +1,5 @@
+import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+
 Polymer({
   analyzingNetwork: false,
   analyzedNetwork: false,
@@ -12,7 +14,12 @@ Polymer({
     this.$.troubleshootDialog.open();
   },
   submitFeedback: function() {
-    this.fire('core-signal', {name: 'open-feedback', data: {includeLogs: this.analyzedNetwork}});
+    this.fire('core-signal', {
+      name: 'open-feedback', data: {
+        includeLogs: this.analyzedNetwork,
+        feedbackType: uproxy_core_api.UserFeedbackType.PROXYING_FAILURE
+      }
+    });
     this.close();
   },
   getNatType: function() {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -180,6 +180,9 @@ export class UserInterface implements ui_constants.UiApi {
   public unableToGet :boolean = false;
   public unableToShare :boolean = false;
 
+  // ID of the most recent failed proxying attempt.
+  public proxyingId: string;
+
   // is a proxy currently set
   private proxySet_ :boolean = false;
   // Must be included in Chrome extension manifest's list of permissions.
@@ -349,6 +352,7 @@ export class UserInterface implements ui_constants.UiApi {
         name: info.name
       });
       this.unableToShare = true;
+      this.proxyingId = info.proxyingId;
     });
 
     core.onUpdate(uproxy_core_api.Update.FAILED_TO_GET,
@@ -360,6 +364,7 @@ export class UserInterface implements ui_constants.UiApi {
       });
       this.instanceTryingToGetAccessFrom = null;
       this.unableToGet = true;
+      this.proxyingId = info.proxyingId;
       this.bringUproxyToFront();
     });
 
@@ -921,11 +926,18 @@ export class UserInterface implements ui_constants.UiApi {
       logsPromise = Promise.resolve('');
     }
     return logsPromise.then((logs) => {
-      var payload = {
+      var payload :uproxy_core_api.UserFeedback = {
         email: feedback.email,
         feedback: feedback.feedback,
-        logs: logs
+        logs: logs,
+        feedbackType: feedback.feedbackType
       };
+
+      if (payload.feedbackType ===
+          uproxy_core_api.UserFeedbackType.PROXYING_FAILURE) {
+        payload.proxyingId = this.proxyingId;
+      }
+
       return this.postToCloudfrontSite(payload, 'submit-feedback');
     });
   }

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -8,10 +8,17 @@ import ui = require('./ui');
 // --- Core <--> UI Interfaces ---
 
 export interface UserFeedback {
-  email     :string;
-  feedback  :string;
-  logs      :boolean;
-  browserInfo :string;
+  email        :string;
+  feedback     :string;
+  logs         :string;
+  browserInfo  ?:string;
+  proxyingId   ?:string;
+  feedbackType ?:UserFeedbackType;
+}
+
+export enum UserFeedbackType {
+  USER_INITIATED = 0,
+  PROXYING_FAILURE = 1
 }
 
 // Object containing description so it can be saved to storage.


### PR DESCRIPTION
Related issue:
https://github.com/uProxy/uproxy/issues/1659

This adds two new fields to feedback:
 * `feedbackType`
 * `proxyingId`

These are set when the user submits feedback via the failed to give/get toast.

@lucyhe, does this look right to you in terms of making the website handle these new fields?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1710)
<!-- Reviewable:end -->
