### PR TITLE
add a force_message_version advanced setting

### DIFF
--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -74,4 +74,10 @@ export var loadSettings :Promise<void> =
       log.info('No global settings loaded', e.message);
     });
 
+// Client version to run as, which is globals.MESSAGE_VERSION unless
+// overridden in advanced settings.
+export var effectiveMessageVersion = () : number => {
+  return settings.force_message_version || MESSAGE_VERSION;
+}
+
 export var metrics = new metrics_module.Metrics(storage);

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -42,7 +42,8 @@ export var settings :uproxy_core_api.GlobalSettings = {
   splashState: 0,
   statsReportingEnabled: false,
   consoleFilter: loggingTypes.Level.warn,
-  language: 'en'
+  language: 'en',
+  force_message_version: 0 // zero means "don't override"
 };
 
 export var natType :string = '';

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -275,8 +275,7 @@ var generateProxyingSessionId_ = (): string => {
 
       var pc: peerconnection.PeerConnection<Object>;
 
-      var localVersion = globals.settings.force_message_version ||
-          globals.MESSAGE_VERSION;
+      var localVersion = globals.effectiveMessageVersion();
       var commonVersion = Math.min(localVersion, remoteVersion);
       log.info('lowest shared client version is %1 (me: %2, peer: %3)',
           commonVersion, localVersion, remoteVersion);

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -277,10 +277,10 @@ var generateProxyingSessionId_ = (): string => {
 
       var localVersion = globals.settings.force_message_version ||
           globals.MESSAGE_VERSION;
-      var lcd = Math.min(localVersion, remoteVersion);
+      var commonVersion = Math.min(localVersion, remoteVersion);
       log.info('lowest shared client version is %1 (me: %2, peer: %3)',
-          lcd, localVersion, remoteVersion);
-      switch (lcd) {
+          commonVersion, localVersion, remoteVersion);
+      switch (commonVersion) {
         case 1:
           log.debug('using old peerconnection');
           pc = new peerconnection.PeerConnectionClass(

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -565,8 +565,7 @@ export function notifyUI(networkName :string, userId :string) {
       var versionedMessage :social.VersionedPeerMessage = {
         type: message.type,
         data: message.data,
-        version: globals.settings.force_message_version ||
-            globals.MESSAGE_VERSION
+        version: globals.effectiveMessageVersion()
       };
       var messageString = JSON.stringify(versionedMessage);
       log.info('sending message', {
@@ -686,8 +685,7 @@ export function notifyUI(networkName :string, userId :string) {
       var versionedMessage :social.VersionedPeerMessage = {
         type: message.type,
         data: message.data,
-        version: globals.settings.force_message_version ||
-            globals.MESSAGE_VERSION
+        version: globals.effectiveMessageVersion()
       };
       ui.update(uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE,
           versionedMessage);

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -565,7 +565,8 @@ export function notifyUI(networkName :string, userId :string) {
       var versionedMessage :social.VersionedPeerMessage = {
         type: message.type,
         data: message.data,
-        version: globals.MESSAGE_VERSION
+        version: globals.settings.force_message_version ||
+            globals.MESSAGE_VERSION
       };
       var messageString = JSON.stringify(versionedMessage);
       log.info('sending message', {
@@ -685,7 +686,8 @@ export function notifyUI(networkName :string, userId :string) {
       var versionedMessage :social.VersionedPeerMessage = {
         type: message.type,
         data: message.data,
-        version: globals.MESSAGE_VERSION
+        version: globals.settings.force_message_version ||
+            globals.MESSAGE_VERSION
       };
       ui.update(uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE,
           versionedMessage);

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -198,6 +198,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       loggingTypes.Destination.console,
       globals.settings.consoleFilter);
     globals.settings.language = newSettings.language;
+    globals.settings.force_message_version = newSettings.force_message_version;
   }
 
   public getFullState = () :Promise<uproxy_core_api.InitialState> => {
@@ -241,7 +242,8 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       remoteProxyInstance = null;
     }
 
-    return copyPasteConnection.startGet(globals.MESSAGE_VERSION);
+    return copyPasteConnection.startGet(globals.settings.force_message_version ||
+        globals.MESSAGE_VERSION);
   }
 
   public stopCopyPasteGet = () :Promise<void> => {
@@ -250,7 +252,8 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   public startCopyPasteShare = () => {
     this.copyPasteSharingMessages_ = [];
-    copyPasteConnection.startShare(globals.MESSAGE_VERSION);
+    copyPasteConnection.startShare(globals.settings.force_message_version ||
+        globals.MESSAGE_VERSION);
   }
 
   public stopCopyPasteShare = () :Promise<void> => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -242,8 +242,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       remoteProxyInstance = null;
     }
 
-    return copyPasteConnection.startGet(globals.settings.force_message_version ||
-        globals.MESSAGE_VERSION);
+    return copyPasteConnection.startGet(globals.effectiveMessageVersion());
   }
 
   public stopCopyPasteGet = () :Promise<void> => {
@@ -252,8 +251,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   public startCopyPasteShare = () => {
     this.copyPasteSharingMessages_ = [];
-    copyPasteConnection.startShare(globals.settings.force_message_version ||
-        globals.MESSAGE_VERSION);
+    copyPasteConnection.startShare(globals.effectiveMessageVersion());
   }
 
   public stopCopyPasteShare = () :Promise<void> => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -59,7 +59,8 @@ export class Model {
     allowNonUnicast: false,
     statsReportingEnabled: false,
     consoleFilter: 2, // loggingTypes.Level.warn
-    language: 'en'
+    language: 'en',
+    force_message_version: 0
   };
 
   public reconnecting = false;

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -27,6 +27,7 @@ export interface GlobalSettings {
   splashState : number;
   consoleFilter    :loggingTypes.Level;
   language         :string;
+  force_message_version :number;
 }
 export interface InitialState {
   networkNames :string[];


### PR DESCRIPTION
This was very useful to help solve this issue:
https://github.com/uProxy/uproxy/issues/1707

This adds a new advanced setting, `force_message_version`. When set, it affects the type of peerconnection offered by `RemoteConnection` (pre-obfuscation, obfuscation, holographic ICE, etc.).

Very very useful for debugging.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1712)
<!-- Reviewable:end -->
