### PR TITLE
Add better handling of app/extension updates in Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "arraybuffer-slice": "^0.1.2",
     "bower": "^1.4.1",
     "circular-json": "^0.1.6",
+    "compare-version": "^0.1.2",
     "crypto": "^0.0.3",
     "es6-promise": "^2.0.0",
     "freedom-for-chrome": "^0.4.11",

--- a/src/chrome/app/scripts/chrome_ui_connector.ts
+++ b/src/chrome/app/scripts/chrome_ui_connector.ts
@@ -26,7 +26,7 @@ class ChromeUIConnector {
     chrome.app.runtime.onLaunched.addListener(this.launchInstallIncompletePage_);
 
     chrome.runtime.onUpdateAvailable.addListener((details) => {
-      this.sendToCore_(uproxy_core_api.Command.HANDLE_UPDATE,
+      this.sendToCore_(uproxy_core_api.Command.HANDLE_CORE_UPDATE,
                        {version: details.version});
     });
   }

--- a/src/chrome/app/scripts/chrome_ui_connector.ts
+++ b/src/chrome/app/scripts/chrome_ui_connector.ts
@@ -24,6 +24,11 @@ class ChromeUIConnector {
     // Until the extension is connected, we assume uProxy installation is
     // incomplete.
     chrome.app.runtime.onLaunched.addListener(this.launchInstallIncompletePage_);
+
+    chrome.runtime.onUpdateAvailable.addListener((details) => {
+      this.sendToCore_(uproxy_core_api.Command.HANDLE_UPDATE,
+                       {version: details.version});
+    });
   }
 
   // Launch a popup instructing the user to install the extension.
@@ -86,7 +91,6 @@ class ChromeUIConnector {
   // This usually installs freedom handlers.
   private onExtMsg_ = (msg :browser_connector.Payload) => {
     console.log('[chrome ui connector] Extension message: ', uproxy_core_api.Command[msg.type]);
-    var msgType = '' + msg.type;
     // Pass 'emit's from the UI to Core.
     if ('emit' == msg.cmd) {
       if (msg.type == uproxy_core_api.Command.SEND_CREDENTIALS) {
@@ -95,25 +99,40 @@ class ChromeUIConnector {
       if (msg.type == uproxy_core_api.Command.RESTART) {
         chrome.runtime.reload();
       }
-      this.uProxyAppChannel_.emit(msgType,
-          {data: msg.data, promiseId: msg.promiseId});
+      this.sendToCore_(msg.type, msg.data, msg.promiseId);
 
     // Install onUpdate handlers by request from the UI.
     } else if ('on' == msg.cmd) {
       if (installedFreedomHooks.indexOf(msg.type) >= 0) {
-        console.error('[chrome ui connector] Freedom already has a hook for ' +
+        console.warn('[chrome ui connector] Freedom already has a hook for ' +
             uproxy_core_api.Command[msg.type]);
         return;
       }
       installedFreedomHooks.push(msg.type);
       // When it fires, send data back over Chrome App -> Extension port.
-      this.uProxyAppChannel_.on(msgType, (ret :string) => {
+      this.uProxyAppChannel_.on(msg.type.toString(), (ret :string) => {
         this.sendToUI(msg.type, ret);
       });
     }
   }
 
+  private sendToCore_ = (msgType :uproxy_core_api.Command, data :Object,
+                         promiseId?:Number) => {
+    if (typeof promiseId === 'undefined') {
+      // promiseId of 0 is used for commands with no associated promise
+      promiseId = 0;
+    }
+
+    this.uProxyAppChannel_.emit(msgType.toString(),
+                                {data: data, promiseId: promiseId});
+  }
+
   public sendToUI = (type :uproxy_core_api.Update, data?:Object) => {
+    if (!this.extPort_) {
+      console.error('Trying to send a message without the UI being connected');
+      return;
+    }
+
     this.extPort_.postMessage({
         cmd: 'fired',
         type: type,

--- a/src/chrome/app/scripts/main.core-env.ts
+++ b/src/chrome/app/scripts/main.core-env.ts
@@ -31,7 +31,9 @@ freedom('generic_core/freedom-module.json', {
   'oauth': [() => { return new Chrome_oauth(oauthOptions); }]
 }).then((uProxyModuleFactory:OnEmitModuleFactory) => {
   uProxyAppChannel = uProxyModuleFactory();
-  oauthOptions.connector = new ChromeUIConnector(uProxyAppChannel);
+  var chromeUIConnector = new ChromeUIConnector(uProxyAppChannel);
+
+  oauthOptions.connector = chromeUIConnector;
 });
 
 // Reply to pings from the uproxy website that are checking if the

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -63,8 +63,8 @@ chrome.runtime.onMessageExternal.addListener((request :any, sender :chrome.runti
 chrome.runtime.onUpdateAvailable.addListener((details) => {
   console.log('Update available');
 
-  core.getVersion().then(function(version :string) {
-    if (compareVersion(details.version, version) > 0) {
+  core.getVersion().then(function(versions) {
+    if (compareVersion(details.version, versions.version) > 0) {
       // Only update if the new version is the same as or older than the app
       // version.  If we are not able to update now, this will be taken care of
       // by restarting at the same time as the core update.

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -118,7 +118,7 @@ ui_connector.onPromiseCommand(
     uproxy_core_api.Command.GET_FULL_STATE,
     core.getFullState);
 
-ui_connector.onCommand(uproxy_core_api.Command.HANDLE_UPDATE,
+ui_connector.onCommand(uproxy_core_api.Command.HANDLE_CORE_UPDATE,
     core.handleUpdate);
 
 ui_connector.onPromiseCommand(uproxy_core_api.Command.GET_VERSION,

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -118,6 +118,12 @@ ui_connector.onPromiseCommand(
     uproxy_core_api.Command.GET_FULL_STATE,
     core.getFullState);
 
+ui_connector.onCommand(uproxy_core_api.Command.HANDLE_UPDATE,
+    core.handleUpdate);
+
+ui_connector.onPromiseCommand(uproxy_core_api.Command.GET_VERSION,
+    core.getVersion);
+
 var dailyMetricsReporter = new metrics_module.DailyMetricsReporter(
     globals.metrics, globals.storage, core.getNetworkInfoObj,
     (payload :any) => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -570,7 +570,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     });
   }
 
-  public getVersion = () :Promise<string> => {
+  public getVersion = () :Promise<{ version :string }> => {
     return Promise.resolve(version.UPROXY_VERSION);
   }
 

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -52,6 +52,9 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   private copyPasteSharingMessages_ :social.PeerMessage[] = [];
   private copyPasteGettingMessages_ :social.PeerMessage[] = [];
 
+  // this should be set iff an update to the core is available
+  private availableVersion_ :string = null;
+
   constructor() {
     log.debug('Preparing uProxy Core');
     copyPasteConnection = new remote_connection.RemoteConnection((update :uproxy_core_api.Update, message?:any) => {
@@ -207,6 +210,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         networkNames: Object.keys(social_network.networks),
         globalSettings: globals.settings,
         onlineNetworks: social_network.getOnlineNetworks(),
+        availableVersion: this.availableVersion_,
         copyPasteState: {
           connectionState: copyPasteConnection.getCurrentState(),
           endpoint: copyPasteConnection.activeEndpoint,
@@ -564,5 +568,14 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       var intervalId = setInterval(checkIfOnline, 5000);
       checkIfOnline();
     });
+  }
+
+  public getVersion = () :Promise<string> => {
+    return Promise.resolve(version.UPROXY_VERSION);
+  }
+
+  public handleUpdate = (details :{version :string}) => {
+    this.availableVersion_ = details.version;
+    ui.update(uproxy_core_api.Update.CORE_UPDATE_AVAILABLE, details);
   }
 }  // class uProxyCore

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -646,5 +646,13 @@
   "appMissingMessage": {
     "description": "Shown in Chrome to instruct the user to install part 2 of uProxy.",
     "message": "Download and enable part 2 of uProxy to get started."
+  },
+  "updateAvailable": {
+    "description": "What to show the user (on the bottom bar) when an update is available.  The actual update will not be done until they restart uProxy which we will prompt them to do with a link.",
+    "message": "An update is available, please restart uProxy to update."
+  },
+  "restartUproxyUpdate": {
+    "description": "A link the user can click on to restart uProxy and permorm an update",
+    "message": "Restart now"
   }
 }

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -649,10 +649,10 @@
   },
   "updateAvailable": {
     "description": "What to show the user (on the bottom bar) when an update is available.  The actual update will not be done until they restart uProxy which we will prompt them to do with a link.",
-    "message": "An update is available, please restart uProxy to update."
+    "message": "An update is available"
   },
   "restartUproxyUpdate": {
     "description": "A link the user can click on to restart uProxy and permorm an update",
-    "message": "Restart now"
+    "message": "Restart to update"
   }
 }

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -333,6 +333,14 @@
                   {{ui.sharingStatus}}
                 </div>
               </div>
+              <div class='statusRow' hidden?='{{!ui.availableVersion}}'>
+                <div class='statusText' horizontal layout>
+                  <span flex>
+                    {{ 'updateAvailable' | $$ }}
+                  </span>
+                  <a href='#' on-tap='{{ restart }}'>{{ 'restartUproxyUpdate' | $$ }}</a>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -232,6 +232,9 @@ Polymer({
       window.location.reload();
     }
   },
+  restart: function() {
+    core.restart();
+  },
   observe: {
     '$.mainPanel.selected' : 'drawerToggled',
     'ui.toastMessage': 'toastMessageChanged',

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -218,7 +218,7 @@ class CoreConnector implements uproxy_core_api.CoreApi {
         uproxy_core_api.Command.PING_UNTIL_ONLINE, pingUrl);
   }
 
-  getVersion = () :Promise<string> => {
+  getVersion = () :Promise<{ version :string }> => {
     return this.promiseCommand(uproxy_core_api.Command.GET_VERSION);
   }
 }  // class CoreConnector

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -217,6 +217,10 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(
         uproxy_core_api.Command.PING_UNTIL_ONLINE, pingUrl);
   }
+
+  getVersion = () :Promise<string> => {
+    return this.promiseCommand(uproxy_core_api.Command.GET_VERSION);
+  }
 }  // class CoreConnector
 
 export = CoreConnector;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -4,7 +4,6 @@
  * ui.ts
  *
  * Common User Interface state holder and changer.
- * TODO: firefox bindings.
  */
 
 import ui_constants = require('../../interfaces/ui');
@@ -211,6 +210,8 @@ export class UserInterface implements ui_constants.UiApi {
 
   public model = new Model();
 
+  public availableVersion :string = null;
+
   /**
    * UI must be constructed with hooks to Notifications and Core.
    * Upon construction, the UI installs update handlers on core.
@@ -384,6 +385,8 @@ export class UserInterface implements ui_constants.UiApi {
         (data :uproxy_core_api.CloudfrontPostData) => {
       this.postToCloudfrontSite(data.payload, data.cloudfrontPath);
     });
+
+    core.onUpdate(uproxy_core_api.Update.CORE_UPDATE_AVAILABLE, this.coreUpdateAvailable_);
 
     browserApi.on('urlData', this.handleUrlData);
     browserApi.on('notificationClicked', this.handleNotificationClick);
@@ -936,6 +939,7 @@ export class UserInterface implements ui_constants.UiApi {
   public updateInitialState = (state :uproxy_core_api.InitialState) => {
     console.log('Received uproxy_core_api.Update.INITIAL_STATE:', state);
     this.model.networkNames = state.networkNames;
+    this.availableVersion = state.availableVersion;
     if (state.globalSettings.language !== this.model.globalSettings.language) {
       this.i18n_setLng(state.globalSettings.language);
     }
@@ -987,6 +991,10 @@ export class UserInterface implements ui_constants.UiApi {
     for (var userId in networkState.roster) {
       this.syncUser(networkState.roster[userId]);
     }
+  }
+
+  private coreUpdateAvailable_ = (data :{version :string}) => {
+    this.availableVersion = data.version;
   }
 } // class UserInterface
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -96,7 +96,7 @@ export enum Command {
   PING_UNTIL_ONLINE = 1018,
   GET_FULL_STATE = 1019,
   GET_VERSION = 1020,
-  HANDLE_UPDATE = 1021,
+  HANDLE_CORE_UPDATE = 1021,
 }
 
 // Updates are sent from the Core to the UI, to update state that the UI must

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -227,7 +227,7 @@ export interface CoreApi {
   onUpdate(update :Update, handler :Function) :void;
 
   pingUntilOnline(pingUrl :string) : Promise<void>;
-  getVersion() :Promise<string>;
+  getVersion() :Promise<{ version :string }>;
 
 }
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -40,6 +40,7 @@ export interface InitialState {
   networkNames :string[];
   globalSettings :GlobalSettings;
   onlineNetworks :social.NetworkState[];
+  availableVersion :string;
   copyPasteState :CopyPasteState;
 }
 
@@ -93,7 +94,9 @@ export enum Command {
   GET_LOGS = 1016,
   GET_NAT_TYPE = 1017,
   PING_UNTIL_ONLINE = 1018,
-  GET_FULL_STATE = 1019
+  GET_FULL_STATE = 1019,
+  GET_VERSION = 1020,
+  HANDLE_UPDATE = 1021,
 }
 
 // Updates are sent from the Core to the UI, to update state that the UI must
@@ -125,7 +128,8 @@ export enum Update {
   FAILED_TO_GIVE = 2020,
   POST_TO_CLOUDFRONT = 2021,
   COPYPASTE_MESSAGE = 2022,
-  FAILED_TO_GET = 2023
+  FAILED_TO_GET = 2023,
+  CORE_UPDATE_AVAILABLE = 2024,
 }
 
 // Action taken by the user. These values are not on the wire. They are passed
@@ -223,5 +227,7 @@ export interface CoreApi {
   onUpdate(update :Update, handler :Function) :void;
 
   pingUntilOnline(pingUrl :string) : Promise<void>;
+  getVersion() :Promise<string>;
+
 }
 

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -49,6 +49,9 @@
     },
     "i18next/i18next.d.ts": {
       "commit": "dbf51fe545993d6c8ef06601edd65555b669a566"
+    },
+    "compare-version/compare-version.d.ts": {
+      "commit": "be03157bace6e6465e63f13073d7b68e8ea1303c"
     }
   }
 }


### PR DESCRIPTION
With our current split app/extension design in Chrome, we unfortunately
have to deal with the fact that the two may be of different versions.
In the past, this has been handled by the extension immediately updating
when there was a new version and the app updating whenever the browser
was closed.  This caused us to lose a lot of confidence in them working
together.  In order to fix this, we now handle update messages
ourselves.

When the app has an update available, it will be forwarded to the core
which will store the available version and then forward the information
to the UI.  At this point, the UI will display a notice that an update
is available.  Nothing will happen without user action.

When the extension can update, it will check what the version of the app
is.  If the app is older than the extension, nothing will happen (we
will just update the extension whenever the app updates).  If the app is
newer and we are not currently proxying, we will restart the extension
forcing an update.  This should be transparent to the user.

How could we still have problems?  If something in the Chrome store
messes up and the extension is deployed significantly before the time of
the new app, restarting the browser would still cause our versions to be
out of sync.

This has been tested, testing was painful and took over an hour, but things seem to be good!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1720)
<!-- Reviewable:end -->
