### PR TITLE
Update extension icon after getting initial state

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -959,6 +959,9 @@ export class UserInterface implements ui_constants.UiApi {
       this.view = ui_constants.View.ROSTER;
       this.updateSharingStatusBar_();
     }
+
+    // state of online networks may have changed, update it
+    this.updateIcon_();
   }
 
   private addOnlineNetwork_ = (networkState :social.NetworkState) => {


### PR DESCRIPTION
When we get a full state message, update the extension icon after
processing the state.  This ensures that if we previously had bad
information (e.g. thought we were offline) we will have correct
information after finishing this.  This does not fully fix issues with
the icon (we will still show it incorrectly after restarting the
extension before the panel is opened), but it is a step in the right
direction.

Fixes #1717

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1722)
<!-- Reviewable:end -->
