### PR TITLE
migrate to uproxy-lib v28

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^27.2.5",
+    "uproxy-lib": "^28.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },

--- a/src/mocks/rtc-to-net.ts
+++ b/src/mocks/rtc-to-net.ts
@@ -34,6 +34,4 @@ export class RtcToNetMock { // TODO implements rtc_to_net.RtcToNet {
 
   public toString = () => {
   }
-
-  public startFromConfig = () => {}
 }


### PR DESCRIPTION
We only bumped the major version number for a tiny API change which uProxy doesn't even really use.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1726)
<!-- Reviewable:end -->
