### PR TITLE
Enable transparent DNS proxying in Firefox.

### DIFF
--- a/src/firefox/lib/firefox_proxy_config.js
+++ b/src/firefox/lib/firefox_proxy_config.js
@@ -24,11 +24,13 @@ var filter = {
   }
 }
 
+var flags = Ci.nsIProxyInfo.TRANSPARENT_PROXY_RESOLVES_HOST;
+
 var proxyConfig = {
   startUsingProxy: function(endpoint) {
     if (!running) {
       running = true;
-      proxyinfo = pps.newProxyInfo('socks', endpoint.address, endpoint.port, 0, 0, null);
+      proxyinfo = pps.newProxyInfo('socks', endpoint.address, endpoint.port, flags, 0, null);
       pps.registerFilter(filter, 0);
     }
   },


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/1772

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1774)
<!-- Reviewable:end -->
