### PR TITLE
Show the number of notifications in a badge over uProxy extension icon.

### DIFF
--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -271,6 +271,10 @@ class ChromeBrowserApi implements BrowserAPI {
       xhr.send(params);
     }).then(removeSendHeaderListener, removeSendHeaderListener);
   }
+
+  public setBadgeNotification = (notification :string) => {
+    chrome.browserAction.setBadgeText({text: notification});
+  }
 }
 
 export = ChromeBrowserApi;

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -100,6 +100,8 @@ class ChromeBrowserApi implements BrowserAPI {
         this.popupState_ = PopupState.NOT_LAUNCHED;
       }
     });
+
+    chrome.browserAction.setBadgeBackgroundColor({color: "#009968"});
   }
 
   private canControlProxy_ = (level :string) :boolean => {

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -141,6 +141,10 @@ class FirefoxBrowserApi implements BrowserAPI {
       console.warn('Firefox promise reject not found ' + promiseId);
     }
   }
+
+  public setBadgeNotification = (notification :string) => {
+    port.emit('setBadgeNotification', notification);
+  }
 }
 
 export = FirefoxBrowserApi;

--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -86,6 +86,10 @@ function setUpConnection(freedom, panel, button) {
     });
   });
 
+  panel.port.on('setBadgeNotification', function(notification) {
+    button.badge = notification;
+  });
+
   /**
    * Install a handler for promise emits received from the panel.
    * Promise emits return an ack or error to the panel.

--- a/src/firefox/lib/main.js
+++ b/src/firefox/lib/main.js
@@ -13,7 +13,8 @@ var button = buttons.ActionButton({
     "18": "./icons/19_offline.gif",
     "36": "./icons/38_offline.gif"
   },
-  onClick: start
+  onClick: start,
+  badgeColor: "#009968"
 });
 
 var panel;

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -235,15 +235,6 @@ Polymer({
   restart: function() {
     core.restart();
   },
-  setBadgeNotification: function() {
-    var numOfNotifications = model.contacts.getAccessContacts.pending.length +
-        model.contacts.shareAccessContacts.pending.length;
-    if (numOfNotifications === 0) {
-      ui.browserApi.setBadgeNotification('');
-    } else {
-      ui.browserApi.setBadgeNotification(numOfNotifications.toString());
-    }
-  },
   observe: {
     '$.mainPanel.selected' : 'drawerToggled',
     'ui.toastMessage': 'toastMessageChanged',
@@ -255,8 +246,6 @@ Polymer({
     'model.contacts.shareAccessContacts.trustedUproxy':
         'updateIsSharingEnabledWithOthers',
     'ui.signalToFire': 'signalToFireChanged',
-    'model.globalSettings.language': 'languageChanged',
-    'model.contacts.getAccessContacts.pending.length' : 'setBadgeNotification',
-    'model.contacts.shareAccessContacts.pending.length' : 'setBadgeNotification'
+    'model.globalSettings.language': 'languageChanged'
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -235,6 +235,15 @@ Polymer({
   restart: function() {
     core.restart();
   },
+  setBadgeNotification: function() {
+    var numOfNotifications = model.contacts.getAccessContacts.pending.length +
+        model.contacts.shareAccessContacts.pending.length;
+    if (numOfNotifications === 0) {
+      ui.browserApi.setBadgeNotification('');
+    } else {
+      ui.browserApi.setBadgeNotification(numOfNotifications.toString());
+    }
+  },
   observe: {
     '$.mainPanel.selected' : 'drawerToggled',
     'ui.toastMessage': 'toastMessageChanged',
@@ -246,6 +255,8 @@ Polymer({
     'model.contacts.shareAccessContacts.trustedUproxy':
         'updateIsSharingEnabledWithOthers',
     'ui.signalToFire': 'signalToFireChanged',
-    'model.globalSettings.language': 'languageChanged'
+    'model.globalSettings.language': 'languageChanged',
+    'model.contacts.getAccessContacts.pending.length' : 'setBadgeNotification',
+    'model.contacts.shareAccessContacts.pending.length' : 'setBadgeNotification'
   }
 });

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -50,7 +50,8 @@ describe('UI.UserInterface', () => {
          'showNotification',
          'on',
          'handlePopupLaunch',
-         'bringUproxyToFront'
+         'bringUproxyToFront',
+         'setBadgeNotification'
          ]);
     ui = new user_interface.UserInterface(mockCore, mockBrowserApi);
     spyOn(console, 'log');

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -637,6 +637,7 @@ export class UserInterface implements ui_constants.UiApi {
 
   public startGettingInUi = () => {
     this.updateIcon_(true);
+    this.updateBadgeNotification_();
   }
 
   /**
@@ -668,6 +669,7 @@ export class UserInterface implements ui_constants.UiApi {
     */
   public startGivingInUi = () => {
     this.updateIcon_(null, true);
+    this.updateBadgeNotification_();
   }
 
   private updateIcon_ = (isGetting?:boolean, isGiving?:boolean) => {
@@ -822,6 +824,7 @@ export class UserInterface implements ui_constants.UiApi {
         oldUserCategories.getTab, newUserCategories.getTab);
     categorizeUser(user, this.model.contacts.shareAccessContacts,
         oldUserCategories.shareTab, newUserCategories.shareTab);
+    this.updateBadgeNotification_();
 
     console.log('Synchronized user.', user);
   };
@@ -1008,6 +1011,22 @@ export class UserInterface implements ui_constants.UiApi {
 
   private coreUpdateAvailable_ = (data :{version :string}) => {
     this.availableVersion = data.version;
+  }
+
+  private updateBadgeNotification_ = () => {
+    // Don't show notifications if the user is giving or getting access.
+    if (this.isGivingAccess() || this.isGettingAccess()) {
+      this.browserApi.setBadgeNotification('');
+      return;
+    }
+
+    var numOfNotifications = this.model.contacts.getAccessContacts.pending.length +
+        this.model.contacts.shareAccessContacts.pending.length;
+    if (numOfNotifications === 0) {
+      this.browserApi.setBadgeNotification('');
+    } else {
+      this.browserApi.setBadgeNotification(numOfNotifications.toString());
+    }
   }
 } // class UserInterface
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1038,6 +1038,7 @@ export class UserInterface implements ui_constants.UiApi {
     } else {
       this.browserApi.setBadgeNotification(numOfNotifications.toString());
     }
+  }
 
   private setPortControlSupport_ = (support:uproxy_core_api.PortControlSupport) => {
     this.portControlSupport = support;

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -45,5 +45,8 @@ export interface BrowserAPI {
 
   // should be called when popup is launched and ready for use
   handlePopupLaunch() :void;
+
+  // Overlay the given text as a "badge" over the uProxy extension icon.
+  // The notification can be up to 4 characters.
   setBadgeNotification(notification :string) :void;
 }

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -45,4 +45,5 @@ export interface BrowserAPI {
 
   // should be called when popup is launched and ready for use
   handlePopupLaunch() :void;
+  setBadgeNotification(notification :string) :void;
 }


### PR DESCRIPTION
Addressing https://github.com/uProxy/uproxy/issues/1547, new icons will be added in another pull request.
Tested manually in C/FF.

Notifications:
(Chrome on top, FF bottom)
![image](https://cloud.githubusercontent.com/assets/8723127/8991125/7d5df854-36c4-11e5-9d04-12baeed80cc5.png)

Notifications with proxying state:
![image](https://cloud.githubusercontent.com/assets/8723127/8991210/2d75534a-36c5-11e5-853c-b47c04a15ae0.png)
I think this actually looks good with Firefox, but should we remove the proxying state for both?
Unfortunately the Chrome badge can not be repositioned.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1776)
<!-- Reviewable:end -->
