### PR TITLE
uProxy build script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ modify (`/usr/local`) to being editable by your user (sudo chown -R $USER /usr/l
 
  1. In the root uProxy directory, run:
    * In OS X or Linux, run `./setup.sh install` - this will set up build tools and third-party dependencies.
-   * In Windows, run `setup.cmd install` instead.
+   * In Windows, run `.\setup.cmd install` instead (in cmd or PowerShell).
    * Then run `grunt` - this will build everything, including uProxy for Chrome and Firefox.
 
 Note that if any local dependencies have changed (i.e. changes to bower dependencies, updates to FreeDOM), you will have to run `./setup.sh install` to update these dependencies, then rerun `grunt`

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ modify (`/usr/local`) to being editable by your user (sudo chown -R $USER /usr/l
     - To run binaries from globally-installed npm packages without
       fully-qualifying paths, make sure you have added your npm bin directory to your path (e.g. `export PATH=$PATH:/usr/local/share/npm/bin/grunt`).
 
+    - On Windows, you can download the installer from the [NodeJS Website](http://nodejs.org/).
+
 - [Grunt](http://gruntjs.com/): Install globally with `npm install -g grunt-cli`
 
 ### Building uProxy from source
@@ -58,8 +60,9 @@ modify (`/usr/local`) to being editable by your user (sudo chown -R $USER /usr/l
  1. Clone uProxy and its submodules (and its submodules' submodules...): `git clone https://github.com/uProxy/uProxy.git` or `git clone git@github.com:uProxy/uproxy.git` if you have your ssh access to github set up (useful if you use 2-step auth for github, which you should do).
 
  1. In the root uProxy directory, run:
-   * `./setup.sh install` - this will set up build tools and third-party dependencies.
-   * `grunt` - this will build everything, including uProxy for Chrome and Firefox.
+   * In OS X or Linux, run `./setup.sh install` - this will set up build tools and third-party dependencies.
+   * In Windows, run `setup.cmd install` instead.
+   * Then run `grunt` - this will build everything, including uProxy for Chrome and Firefox.
 
 Note that if any local dependencies have changed (i.e. changes to bower dependencies, updates to FreeDOM), you will have to run `./setup.sh install` to update these dependencies, then rerun `grunt`
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ipaddr.js": "^0.1.3",
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
-    "tsd": "^0.5.7",
+    "tsd": "^0.6.3",
     "uproxy-lib": "^29.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"

--- a/setup.cmd
+++ b/setup.cmd
@@ -65,7 +65,7 @@ goto:eof
 
 :installThirdParty
 	call :runAndAssertCmd "%NPM_BIN_DIR%bower install --allow-root"
-	call :runAndAssertCmd "%NPM_BIN_DIR%tsd reinstall --config ./third_party/tsd.json"
+	call :runAndAssertCmd "%NPM_BIN_DIR%tsd reinstall --config .\third_party\tsd.json"
 	call :runAndAssertCmd "%NPM_BIN_DIR%grunt copy:thirdParty"
 goto:eof
 

--- a/setup.cmd
+++ b/setup.cmd
@@ -1,0 +1,76 @@
+@echo off
+
+:: Get the directory where this script is and set ROOT_DIR to that path. This
+:: allows script to be run from different directories but always act on the
+:: directory of the project (which is where this script is located).
+for %%F in (%0) do set ROOT_DIR=%%~dpF
+set NPM_BIN_DIR=%ROOT_DIR%node_modules\.bin\
+cd %ROOT_DIR%
+
+if "%1" == "install" (
+	call :installDevDependencies
+	exit /b 0
+)
+if "%1" == "tools" (
+	call :installTools
+	exit /b 0
+)
+if "%1" == "third_party" (
+	call :installThirdParty
+	exit /b 0
+)
+if "%1" == "clean" (
+	call :clean
+	exit /b 0
+)
+if "%1" NEQ "install" if "%1" NEQ "tools" ^
+if "%1" NEQ "third_party" if "%1" NEQ "clean" (
+	echo Usage: setup.sh [install^|tools^|third_party^|clean]
+	echo   install       Installs 'node_modules' and 'build/third_party'
+	echo   tools         Installs build tools into 'build/tools'
+	echo   third_party   Installs 'build/third_party'
+	echo   clean         Removes all dependencies installed by this script.
+	exit /b 0
+)
+
+:: runCmd will run built-in DOS commands, and ignore errors
+:runCmd
+	echo Running: %1
+	%~1
+goto:eof
+
+:: On Windows, npm, bower, tsd, and grunt are batch files
+:: So we have to explicitly call then with "call"
+:: These also happen to be the commands that we want to assert, 
+:: or exit on failure for, so there is an additional "exit /b"
+:runAndAssertCmd
+	echo Running: %1
+	call %~1 || exit /b
+goto:eof
+
+:: We use robocopy to delete these folders since they (esp. node_modules)
+:: may have path lengths greater than 260 characters
+:clean
+	call :runCmd "mkdir empty_dir"
+	call :runCmd "robocopy empty_dir node_modules /mir > nul 2>&1"
+	call :runCmd "robocopy empty_dir build /mir > nul 2>&1"
+	call :runCmd "robocopy empty_dir .tscache /mir > nul 2>&1"
+	call :runCmd "rmdir empty_dir node_modules build .tscache /s /q"
+goto:eof
+
+:installTools
+	call :runCmd "mkdir build\tools"
+	call :runCmd "copy node_modules\uproxy-lib\build\tools\* build\tools\"
+goto:eof
+
+:installThirdParty
+	call :runAndAssertCmd "%NPM_BIN_DIR%bower install --allow-root"
+	call :runAndAssertCmd "%NPM_BIN_DIR%tsd reinstall --config ./third_party/tsd.json"
+	call :runAndAssertCmd "%NPM_BIN_DIR%grunt copy:thirdParty"
+goto:eof
+
+:installDevDependencies
+	call :runAndAssertCmd "npm install"
+	call :installTools
+	call :installThirdParty
+goto:eof

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ elif [ "$1" == 'third_party' ]; then
 elif [ "$1" == 'clean' ]; then
   clean
 else
-  echo "Useage: setup.sh [install|tools|third_party|clean]"
+  echo "Usage: setup.sh [install|tools|third_party|clean]"
   echo "  install       Installs 'node_modules' and 'build/third_party'"
   echo "  tools         Installs build tools into 'build/tools'"
   echo "  third_party   Installs 'build/third_party'"


### PR DESCRIPTION
`setup.sh` has been translated to the batch file `setup.cmd`, which has the exact same interface and functionality, but will run in Windows (using cmd or PowerShell).

The dependency `tsd` has also been updated from `0.5.7` to `0.6.3`, since the new version removes an (optional) dependency on Python 2.7, which would error on vanilla Windows.

Last, the readme has been updated accordingly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1793)
<!-- Reviewable:end -->
