### PR TITLE
Update how uProxy informs (approved) pages that it is installed.

### DIFF
--- a/src/chrome/app/scripts/main.core-env.ts
+++ b/src/chrome/app/scripts/main.core-env.ts
@@ -39,10 +39,10 @@ freedom('generic_core/freedom-module.json', {
 // Reply to pings from the uproxy website that are checking if the
 // application is installed.
 chrome.runtime.onMessageExternal.addListener(
-    (request:Object, sender:Object,
-     sendResponse:(r:{message:string}) => void) => {
-        if (request) {
-          sendResponse({message: "Application installed."});
+    (request:{checkIfInstalled:boolean}, sender:Object,
+     sendResponse:(r:{appInstalled:boolean}) => void) => {
+        if (request && request.checkIfInstalled) {
+          sendResponse({ appInstalled: true });
         }
         return true;
     });

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -54,8 +54,11 @@ chrome.runtime.onMessage.addListener((request :any, sender: chrome.runtime.Messa
 chrome.runtime.onMessageExternal.addListener((request :any, sender :chrome.runtime.MessageSender, sendResponse :Function) => {
   // Reply to pings from the uproxy website that are checking if the
   // extension is installed.
-  if (request) {
-    sendResponse({ message: 'Extension installed.' });
+  if (request.message === "checkIfInstalled") {
+    sendResponse({ message: 'extensionInstalled' });
+  } else if (request.message === "launchUproxy") {
+    browserApi.bringUproxyToFront();
+    sendResponse({ message: 'launchedUproxy' });
   }
   return true;
 });

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -54,11 +54,11 @@ chrome.runtime.onMessage.addListener((request :any, sender: chrome.runtime.Messa
 chrome.runtime.onMessageExternal.addListener((request :any, sender :chrome.runtime.MessageSender, sendResponse :Function) => {
   // Reply to pings from the uproxy website that are checking if the
   // extension is installed.
-  if (request.message === "checkIfInstalled") {
-    sendResponse({ message: 'extensionInstalled' });
-  } else if (request.message === "launchUproxy") {
+  if (request && request.checkIfInstalled) {
+    sendResponse({ extensionInstalled: true });
+  } else if (request && request.openWindow) {
     browserApi.bringUproxyToFront();
-    sendResponse({ message: 'launchedUproxy' });
+    sendResponse({ launchedUproxy: true });
   }
   return true;
 });

--- a/src/firefox/data/scripts/content-proxy.ts
+++ b/src/firefox/data/scripts/content-proxy.ts
@@ -33,3 +33,7 @@ window.addEventListener('message', function(event) {
     self.port.emit('getLogs', event.data);
   }
 }, false);
+
+// Let the page which has loaded this content script know that uProxy is
+// installed.
+window.postMessage({ installed : true, data: false }, '*');

--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -136,7 +136,7 @@ function setUpConnection(freedom, panel, button) {
 
   /* Allow any pages in the addon to send messages to the UI or the core */
   pagemod.PageMod({
-    include: self.data.url('*'),
+    include: ["https://test-dot-uproxysite.appspot.com/*", self.data.url('*')],
     contentScriptFile: self.data.url('scripts/content-proxy.js'),
     onAttach: function(worker) {
       worker.port.on('update', function(data) {

--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -138,9 +138,11 @@ function setUpConnection(freedom, panel, button) {
   // when required by registering messages that initiate async behaviour.
   onPromiseEmit('frontedPost', post);
 
-  /* Allow any pages in the addon to send messages to the UI or the core */
+  /* Allow pages in the addon and uproxy.org to send messages to the UI or the core */
   pagemod.PageMod({
-    include: ["https://test-dot-uproxysite.appspot.com/*", self.data.url('*')],
+    include: [ self.data.url('*'),
+               "https://www.uproxy.org/*",
+               "https://test-dot-uproxysite.appspot.com/*"],
     contentScriptFile: self.data.url('scripts/content-proxy.js'),
     onAttach: function(worker) {
       worker.port.on('update', function(data) {


### PR DESCRIPTION
Tested manually for Chrome/FF.

With this change, viewing the test site will show "Launch" instead of "Install"
https://test-dot-uproxysite.appspot.com/

Addressing https://github.com/uProxy/uproxy/issues/1547

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1794)
<!-- Reviewable:end -->
