### PR TITLE
Enable building uProxy as a Cordova Chrome App for Android

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -580,8 +580,6 @@ module.exports = (grunt) ->
 
               'generic_ui/scripts/copypaste.js'
               'generic_ui/scripts/get_logs.js'
-              'scripts/context.static.js'
-              'scripts/background.static.js'
               '!**/*spec*'
 
               'generic_ui/style/*.css'
@@ -613,11 +611,9 @@ module.exports = (grunt) ->
               '**/freedom-module.json'
               '!generic_core/freedom-module.json'
               '**/*.static.js'
-              '!**/*spec*'
 
               'icons/*'
               'fonts/*'
-              '_locales/**'
             ]
             dest: 'build/dist/cca'
           }

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -80,7 +80,6 @@ taskManager.add 'build_cca', [
   'copy:cca_additional'
   'vulcanize:ccaInline'
   'vulcanize:ccaCsp'
-  'copy:cca'
   'browserify:ccaMain'
   'browserify:ccaContext'
   'browserify:ccaVulcanized'
@@ -590,10 +589,7 @@ module.exports = (grunt) ->
               # extra components we use
               'generic_ui/fonts/*'
               'generic_ui/icons/*'
-              'icons/*'
-              '_locales/**'
 
-              # UI for not-connected
               # This is not browserified so we use .js instead of .static.js
               'polymer/vulcanized.{html,js}'
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -15,6 +15,7 @@ taskManager.add 'base', [
   'version_file'
   'browserify:chromeAppMain'
   'browserify:genericCoreFreedomModule'
+  'browserify:ccaMain'
 ]
 
 #
@@ -69,6 +70,44 @@ taskManager.add 'build_firefox', [
   'browserify:firefoxContext'
   'browserify:firefoxVulcanized'
   'browserify:firefoxLogsVulcanized'
+]
+
+# CCA build tasks.
+taskManager.add 'build_cca', [
+  'base'
+  'ts:cca'
+  'copy:cca'
+  'copy:cca_additional'
+  'vulcanize:ccaInline'
+  'vulcanize:ccaCsp'
+  'copy:cca'
+  'browserify:ccaMain'
+  'browserify:ccaContext'
+  'browserify:ccaVulcanized'
+  'browserify:ccaLogsVulcanized'
+  'string-replace:ccaVulcanized'
+  'string-replace:ccaLogsVulcanized'
+]
+
+# Mobile OS build tasks
+taskManager.add 'build_android', [
+  'exec:rmAndroidBuild'
+  'build_cca'
+  'exec:ccaCreate'
+  'exec:ccaBuildAndroid'
+]
+
+# Emulate the mobile client
+taskManager.add 'emulate_android', [
+ 'build_android'
+ 'exec:ccaEmulateAndroid'
+]
+
+taskManager.add 'build_ios', [
+  'exec:rmIosBuild'
+  'build_cca'
+  'exec:ccaCreateIos'
+  'exec:ccaBuildIos'
 ]
 
 # --- Testing tasks ---
@@ -126,6 +165,7 @@ taskManager.add 'test', [
 taskManager.add 'build', [
   'build_chrome'
   'build_firefox'
+  'build_cca'
 ]
 
 taskManager.add 'dist', [
@@ -166,7 +206,9 @@ Rule = new rules.Rule({
 chromeExtDevPath = path.join(devBuildPath, 'chrome/extension/')
 chromeAppDevPath = path.join(devBuildPath, 'chrome/app/')
 firefoxDevPath = path.join(devBuildPath, 'firefox/')
-
+ccaDevPath = path.join(devBuildPath, 'cca/app/')
+androidDevPath = path.join(devBuildPath, 'android/')
+iosDevPath = path.join(devBuildPath, 'ios/')
 
 #-------------------------------------------------------------------------
 browserifyIntegrationTest = (path) ->
@@ -175,6 +217,7 @@ browserifyIntegrationTest = (path) ->
   })
 
 #-------------------------------------------------------------------------
+ccaPath = path.dirname(require.resolve('cca/package.json'))
 freedomForChromePath = path.dirname(require.resolve('freedom-for-chrome/package.json'))
 uproxyLibPath = path.dirname(require.resolve('uproxy-lib/package.json'))
 
@@ -184,7 +227,7 @@ uproxyLibPath = path.dirname(require.resolve('uproxy-lib/package.json'))
 # uproxyObfuscatorsPath = path.dirname(require.resolve('utransformers/package.json'))
 # regex2dfaPath = path.dirname(require.resolve('regex2dfa/package.json'))
 # Cordova testing
-# ccaPath = path.dirname(require.resolve('cca/package.json'))
+# ccaPath = path.dirname(require.resolve('cca/app/package.json'))
 # pgpPath = path.dirname(require.resolve('freedom-pgp-e2e/package.json'))
 
 
@@ -289,6 +332,38 @@ module.exports = (grunt) ->
     clean: ['build/dev', 'build/dist', '.tscache']
 
     #-------------------------------------------------------------------------
+    # Import global names into config name space
+    ccaJsPath: path.join(ccaPath, 'src/cca.js')
+    androidDevPath: androidDevPath
+    ccaDevPath: ccaDevPath
+    iosDevPath: iosDevPath
+    exec: {
+      ccaCreate: {
+        command: '<%= ccaJsPath %> create <%= androidDevPath %> --link-to=<%= ccaDevPath %>'
+      }
+      ccaBuildAndroid: {
+        cwd: '<%= androidDevPath %>'
+        command: '<%= ccaJsPath %> build android'
+      }
+      ccaEmulateAndroid: {
+        cwd: '<%= androidDevPath %>'
+        command: '<%= ccaJsPath %> run android --emulator'
+      }
+      rmAndroidBuild: {
+        command: 'rm -rf <%= androidDevPath %>'
+      }
+      ccaCreateIos: {
+        command: '<%= ccaJsPath %> create <%= iosDevPath %> --link-to=<%= ccaDevPath %>'
+      }
+      ccaBuildIos: {
+        cwd: '<%= iosDevPath %>'
+        command: '<%= ccaJsPath %> build --webview=system ios'
+      }
+      rmIosBuild: {
+        command: 'rm -rf <%= iosDevPath %>'
+      }
+    }
+
     copy: {
       # Copy all needed third party libraries to appropriate locations.
       thirdParty:
@@ -489,6 +564,73 @@ module.exports = (grunt) ->
             src: ['*']
             dest: 'build/dist/firefox/data/generic_core/'
           }
+          { # CCA app
+            expand: true
+            cwd: ccaDevPath
+            src: [
+              'manifest.json'
+              '*.html'
+
+              'bower/webcomponentsjs/webcomponents.min.js'
+              'bower/polymer/polymer.js'
+
+              'generic_ui/*.html'
+              'generic_ui/polymer/vulcanized*.{html,js}'
+              '!generic_ui/polymer/vulcanized*inline.html'
+              '!generic_ui/polymer/vulcanized.js' # vulcanized.html uses vulcanized.static.js
+
+              'generic_ui/scripts/copypaste.js'
+              'generic_ui/scripts/get_logs.js'
+              'scripts/context.static.js'
+              'scripts/background.static.js'
+              '!**/*spec*'
+
+              'generic_ui/style/*.css'
+
+              # extra components we use
+              'generic_ui/fonts/*'
+              'generic_ui/icons/*'
+              'icons/*'
+              '_locales/**'
+
+              # UI for not-connected
+              # This is not browserified so we use .js instead of .static.js
+              'polymer/vulcanized.{html,js}'
+
+              # actual scripts that run things
+              'freedomjs-anonymized-metrics/anonmetrics.json'
+              'freedomjs-anonymized-metrics/metric.js'
+              'freedom-for-chrome/freedom-for-chrome.js'
+              'freedom-social-xmpp/social.google.json'
+              'freedom-social-xmpp/socialprovider.js'
+              'freedom-social-xmpp/vcardstore.js'
+              'freedom-social-xmpp/node-xmpp-browser.js'
+              'freedom-social-xmpp/google-auth.js'
+              'freedom-social-firebase/social.firebase-facebook.json'
+              'freedom-social-firebase/firebase-shims.js'
+              'freedom-social-firebase/firebase.js'
+              'freedom-social-firebase/firebase-social-provider.js'
+              'freedom-social-firebase/facebook-social-provider.js'
+              'freedom-port-control/port-control.js'
+              'freedom-port-control/port-control.json'
+
+              '**/freedom-module.json'
+              '!generic_core/freedom-module.json'
+              '**/*.static.js'
+              '!**/*spec*'
+
+              'icons/*'
+              'fonts/*'
+              '_locales/**'
+            ]
+            dest: 'build/dist/cca'
+          }
+          { # Chrome app freedom-module
+            expand: true
+            cwd: 'src/generic_core/dist_build/'
+            src: ['*']
+            dest: 'build/dist/cca/app/generic_core'
+          }
         ]
 
       chrome_extension:
@@ -638,6 +780,60 @@ module.exports = (grunt) ->
             dest: firefoxDevPath + '/data/generic_ui'
           }
         ]
+      cca:
+        Rule.copyLibs
+          npmLibNames: [
+            'freedom-for-chrome'
+          ]
+          pathsFromDevBuild: [
+            'generic_core'
+            'generic_ui'
+            'interfaces'
+            'icons'
+            'fonts'
+          ]
+          pathsFromThirdPartyBuild: [
+            'bower'
+            'sha1'
+            'uproxy-lib/loggingprovider'
+            'uproxy-lib/churn-pipe'
+          ]
+          files: [
+            {
+              expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/',
+              src: ['anonmetrics.json', 'metric.js']
+              dest: ccaDevPath + '/freedomjs-anonymized-metrics'
+            },
+            {
+              expand: true, cwd: 'node_modules/freedom-social-xmpp/dist/',
+              src: ['**']
+              dest: ccaDevPath + '/freedom-social-xmpp'
+            },
+            {
+              expand: true, cwd: 'node_modules/freedom-social-firebase/dist/',
+              src: ['**']
+              dest: ccaDevPath + '/freedom-social-firebase'
+            },
+            {
+              expand: true, cwd: 'node_modules/freedom-port-control/dist/',
+              src: ['**']
+              dest: ccaDevPath + '/freedom-port-control'
+            },
+            { # uProxy Icons and fonts
+              expand: true, cwd: 'src/'
+              src: ['icons/128_online.png', 'fonts/*']
+              dest: ccaDevPath
+            }
+          ]
+          localDestPath: 'cca/app/'
+      cca_additional:
+        files: [
+          { # copy chrome extension panel components from the background
+            expand: true, cwd: ccaDevPath
+            src: ['polymer/*', 'scripts/*', 'icons/*', 'fonts/*', '*.html']
+            dest: ccaDevPath + '/generic_ui'
+          }
+        ]
 
 
 
@@ -684,6 +880,11 @@ module.exports = (grunt) ->
       firefoxLogsVulcanized:
         finishVulcanized(firefoxDevPath + '/data/generic_ui', 'vulcanized-view-logs')
 
+      ccaVulcanized:
+        finishVulcanized(ccaDevPath + '/generic_ui', 'vulcanized')
+
+      ccaLogsVulcanized:
+        finishVulcanized(ccaDevPath + '/generic_ui', 'vulcanized-view-logs')
     #-------------------------------------------------------------------------
     # All typescript compiles to locations in `build/`
     # Typescript compilation rules
@@ -713,6 +914,10 @@ module.exports = (grunt) ->
 
       firefox: compileTypescript [
         devBuildPath + '/firefox/**/*.ts'
+      ]
+
+      cca: compileTypescript [
+        devBuildPath + '/cca/**/*.ts'
       ]
 
       integration_specs: compileTypescript [
@@ -747,6 +952,17 @@ module.exports = (grunt) ->
             standalone: 'ui_context'
       firefoxVulcanized: Rule.browserify('firefox/data/generic_ui/polymer/vulcanized', {})# no exports from this
       firefoxLogsVulcanized: Rule.browserify('firefox/data/generic_ui/polymer/vulcanized-view-logs', {})
+
+      ccaMain: Rule.browserify('cca/app/scripts/main.core-env',
+        browserifyOptions:
+          standalone: 'ui_context'
+      )
+      ccaContext: Rule.browserify('cca/app/scripts/context',
+        browserifyOptions:
+          standalone: 'ui_context'
+      )
+      ccaVulcanized: Rule.browserify('cca/app/generic_ui/polymer/vulcanized', {})# no exports from this
+      ccaLogsVulcanized: Rule.browserify('cca/app/generic_ui/polymer/vulcanized-view-logs', {})
 
       chromeExtensionCoreConnector: Rule.browserify 'chrome/extension/scripts/chrome_core_connector'
       chromeExtensionCoreConnectorSpec: Rule.browserifySpec 'chrome/extension/scripts/chrome_core_connector'
@@ -832,6 +1048,18 @@ module.exports = (grunt) ->
         vulcanizeCsp(
             firefoxDevPath + '/data/generic_ui/polymer/vulcanized-inline.html',
             firefoxDevPath + '/data/generic_ui/polymer/vulcanized.html')
+      ccaInline:
+        vulcanizeInline(
+            ccaDevPath + '/generic_ui/polymer/root.html',
+            ccaDevPath + '/generic_ui/polymer/vulcanized-inline.html',
+            ccaDevPath + '/polymer/ext-missing.html',
+            ccaDevPath + '/polymer/vulcanized-inline.html')
+      ccaCsp:
+        vulcanizeCsp(
+            ccaDevPath + '/generic_ui/polymer/vulcanized-inline.html',
+            ccaDevPath + '/generic_ui/polymer/vulcanized.html',
+            ccaDevPath + '/polymer/vulcanized-inline.html',
+            ccaDevPath + '/polymer/vulcanized.html')
       chromeViewLogsInline:
         vulcanizeInline(
             chromeExtDevPath + '/generic_ui/polymer/logs.html',
@@ -855,6 +1083,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-jasmine'
+  grunt.loadNpmTasks 'grunt-exec'
   grunt.loadNpmTasks 'grunt-gitinfo'
   grunt.loadNpmTasks 'grunt-jasmine-chromeapp'
   grunt.loadNpmTasks 'grunt-mozilla-addon-sdk'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
     "bower": "^1.4.1",
+    "cca": "^0.7.1",
     "circular-json": "^0.1.6",
     "compare-version": "^0.1.2",
     "crypto": "^0.0.3",
@@ -36,6 +37,7 @@
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-jasmine": "^0.8.0",
+    "grunt-exec": "^0.4.6",
     "grunt-gitinfo": "^0.1.7",
     "grunt-jasmine-chromeapp": "git://github.com/uproxy/grunt-jasmine-chromeapp",
     "grunt-mozilla-addon-sdk": "^0.4.0",

--- a/src/cca/app/index.html
+++ b/src/cca/app/index.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>uProxy</title>
+  <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
+  <!-- This version of index.html is only loaded in Chrome (Crosswalk), so the shim is not needed -->
+  <!-- TODO: Will we need to reintroduce the shim to support iOS? -->
+  <!-- <script src='../bower/webcomponentsjs/webcomponents.min.js'></script> -->
+
+  <script src='scripts/context.static.js'></script>
+
+  <!-- The vulcanized code will be loaded asynchronously by context.static.js -->
+  <!-- <link rel='import' href='polymer/vulcanized.html'> -->
+  <link href='generic_ui/fonts/Roboto.css' rel='stylesheet' type='text/css'>
+  <link href='generic_ui/style/global.css' rel='stylesheet' shim-shadowdom>
+
+  <style>
+    @font-face {
+      font-family: Quicksand;
+      src: url(generic_ui/fonts/Quicksand-Regular.ttf);
+    }
+    @font-face {
+      font-family: Quicksand;
+      src: url(generic_ui/fonts/Quicksand-Bold.ttf);
+      font-weight: 700;
+    }
+    html {
+      height: 100%;
+      position: relative;
+    }
+    body {
+      display: block;
+      text-align: center;
+      margin: 0;
+      font-family: Roboto, sans-serif;
+      font-size: 13px;
+      background-color: white;
+      height: 100%;
+    }
+  </style>
+</head>
+
+<body unresolved touch-action='auto'>
+  <!-- uproxy-root will be loaded after polymer is loaded -->
+  <!-- <uproxy-root></uproxy-root> -->
+</body>
+
+</html>

--- a/src/cca/app/manifest.json
+++ b/src/cca/app/manifest.json
@@ -1,0 +1,34 @@
+{
+  "manifest_version": 2,
+  "name": "uProxy for Sharers",
+  "description": "test",
+  "minimum_chrome_version": "41.0.2272.63",
+  "version": "0.0",
+  "icons": {
+      "128": "icons/128_online.png"
+  },
+  "app": {
+    "background": {
+      "scripts": [
+        "freedom-for-chrome/freedom-for-chrome.js",
+        "scripts/main.core-env.static.js"
+      ]
+    }
+  },
+  "permissions": [
+    "identity",
+    "storage",
+    "http://*/",
+    "https://*/",
+    "notifications"
+  ],
+  "sockets": {
+    "tcp": { "connect" : "" },
+    "tcpServer": { "listen": "" },
+    "udp": { "send": "", "bind": "" }
+  },
+  "externally_connectable": {
+    "matches" : ["*://*.uproxy.org/*", "*://uproxysite.appspot.com/*", "*://test-dot-uproxysite.appspot.com/*", "*://beta-dot-uproxysite.appspot.com/*"]
+  },
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk6KrQptZchMYwQN8CsbRVmhV/COoR0lxansERcz+OrkPctUBSTQVYJw3t17+6JyMPnKYR2DMKCTeYQGrmXzm2U0KpujEKN3WSTtZI4ynTzKbGhWIYo6exaHufcslJngEG91ua/q1fJz3e5Mla8+tIsT9bVdVf4NLfODNbky/Uo0M6KpOLO9r2zJoiO0yg4ThBH+TkNwH8icvHJbt2LzZVRSZtQ1Wl1uT15vnwJPOEYVQkpnEMY5yMBPxyOZ1AmUx714YAas80pSZ7+BlM9ReIirYB7lxeY6hAqs4u8iP5SDh5bg6YFXeYecwQyvnKglLdHq6djy9QyVLKUKxFzMH/wIDAQAB"
+}

--- a/src/cca/app/polymer/browser-elements.html
+++ b/src/cca/app/polymer/browser-elements.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<!-- Imports for all Chrome-specific Polymer elements. This ensures that the elements will be vulcanized along with the generic UI Polymer elements. -->
+

--- a/src/cca/app/scripts/context.ts
+++ b/src/cca/app/scripts/context.ts
@@ -1,0 +1,33 @@
+/// <reference path='../../../../../third_party/typings/chrome/chrome.d.ts' />
+/// <reference path='../../../generic_ui/polymer/context.d.ts' />
+
+import user_interface = require('../../../generic_ui/scripts/ui');
+import CoreConnector = require('../../../generic_ui/scripts/core_connector');
+import CordovaCoreConnector = require('./cordova_core_connector');
+
+var ui_context :UiGlobals;
+export var browserConnector = new CordovaCoreConnector({
+  name: 'uproxy-ui-to-core-connector'
+});
+export var core = new CoreConnector(browserConnector);
+export var ui :user_interface.UserInterface;
+export var model :user_interface.Model;
+
+chrome.runtime.getBackgroundPage((bgPage) => {
+  ui_context = (<any>bgPage).ui_context;
+  ui = new user_interface.UserInterface(core, ui_context.browserApi);
+  model = ui.model;
+  console.log('Got references from background page; importing vulcanized');
+
+  var link = document.createElement('link');
+  link.rel = 'import';
+  link.href = 'generic_ui/polymer/vulcanized.html'
+  link.onload = function(e) {
+    document.body.innerHTML = '<uproxy-root></uproxy-root>';
+  };
+  link.onerror = function(e) {
+    console.log('Error while loading polymer/vulcanized.html:', e);
+  };
+  document.head.appendChild(link);
+});
+

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -1,0 +1,143 @@
+/**
+ * cordova_browser_api.ts
+ *
+ * Cordova-specific implementation of the Browser API.
+ * Derived from chrome_browser_api.ts
+ */
+
+import browser_api = require('../../../interfaces/browser_api');
+import BrowserAPI = browser_api.BrowserAPI;
+import net = require('../../../../../third_party/uproxy-lib/net/net.types');
+import Constants = require('../../../generic_ui/scripts/constants');
+
+/// <reference path='../../../../third_party/typings/chrome/chrome-app.d.ts'/>
+/// <reference path='../../../../networking-typings/communications.d.ts' />
+
+enum PopupState {
+    NOT_LAUNCHED,
+    LAUNCHING,
+    LAUNCHED
+}
+
+declare var Notification :any; //TODO remove this
+
+class CordovaBrowserApi implements BrowserAPI {
+
+  public browserSpecificElement = "";
+
+  public canProxy = true;
+
+  public setIcon = (iconFile :string) : void => {
+  }
+
+  public ui :chrome.app.window.AppWindow;
+
+  // The URL for the page that renders the UI.  For terminological consistency,
+  // the UI is referred to as the "popup", even though it is persistent and
+  // full-screen.
+  private POPUP_URL = "index.html";
+  // When we tried to create UI.
+  private popupCreationStartTime_ = Date.now();
+
+  private popupState_ = PopupState.NOT_LAUNCHED;
+
+  public handlePopupLaunch :() => void;
+  private onceLaunched_ :Promise<void>;
+
+  constructor() {
+  }
+
+  public startUsingProxy = (endpoint:net.Endpoint) => {
+    // TODO: Implement getter support, possibly using "redsocks".
+  };
+
+  public stopUsingProxy = () => {
+  };
+
+  // Other.
+
+  public openTab = (url :string) => {
+    // TODO: Figure out what this means in Cordova.
+  }
+
+  public launchTabIfNotOpen = (relativeUrl :string) => {
+    // TODO: Figure out what this means in Cordova.
+  }
+
+  public bringUproxyToFront = () : Promise<void> => {
+    if (this.popupState_ == PopupState.NOT_LAUNCHED) {
+      this.popupState_ = PopupState.LAUNCHING;
+      this.popupCreationStartTime_ = Date.now();
+      // If neither popup nor Chrome window are open (e.g. if uProxy is launched
+      // after webstore installation), then allow the popup to open at a default
+      // location.
+      this.onceLaunched_ = new Promise<void>((F, R) => {
+        this.handlePopupLaunch = F;
+      });
+      console.log('Creating window');
+      chrome.app.window.create(this.POPUP_URL, {}, 
+          this.newPopupCreated_);
+      return this.onceLaunched_;
+    } else if (this.popupState_ == PopupState.LAUNCHED) {
+      // If the popup is already open, simply focus on it.
+      //chrome.windows.update(this.popupWindowId_, {focused: true});
+      return Promise.resolve<void>();
+    } else {
+      return this.onceLaunched_;
+      console.log("Waiting for popup to launch...");
+    }
+  }
+
+  /**
+    * Callback passed to chrome.app.window.create.
+    */
+  private newPopupCreated_ = (popup :chrome.app.window.AppWindow) => {
+    console.log("Time between browser icon click and popup launch (ms): " +
+        (Date.now() - this.popupCreationStartTime_));
+    this.ui = popup;
+    this.popupState_ = PopupState.LAUNCHED;
+    this.handlePopupLaunch();
+  }
+
+  public showNotification = (text :string, tag :string) => {
+    var notification =
+        new Notification('uProxy', {
+          body: text,
+          icon: 'icons/38_' + Constants.DEFAULT_ICON,
+          tag: tag
+        });
+    notification.onclick = () => {
+      this.emit_('notificationClicked', tag);
+    };
+    setTimeout(function() {
+      notification.close();
+    }, 5000);
+  }
+
+  public setBadgeNotification = (notification:string) :void => {
+    // TODO: is there a sensible way to handle this on Android.
+  }
+
+  private events_ :{[name :string] :Function} = {};
+
+  public on = (name :string, callback :Function) => {
+    this.events_[name] = callback;
+  }
+
+  private emit_ = (name :string, ...args :Object[]) => {
+    if (name in this.events_) {
+      this.events_[name].apply(null, args);
+    } else {
+      console.error('Attempted to trigger an unknown event', name);
+    }
+  }
+
+  public frontedPost = (data :any,
+                        externalDomain :string,
+                        cloudfrontDomain :string,
+                        cloudfrontPath = "") : Promise<void> => {
+    return Promise.reject(new Error('TODO: Fronted post in Cordova'));
+  }
+}
+
+export = CordovaBrowserApi;

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -52,8 +52,6 @@ class CordovaBrowserApi implements BrowserAPI {
   public stopUsingProxy = () => {
   };
 
-  // Other.
-
   public openTab = (url :string) => {
     // TODO: Figure out what this means in Cordova.
   }
@@ -63,7 +61,10 @@ class CordovaBrowserApi implements BrowserAPI {
   }
 
   public bringUproxyToFront = () : Promise<void> => {
-    if (this.popupState_ == PopupState.NOT_LAUNCHED) {
+    // In Cordova, this function is badly misnamed.  Rather than bringing the
+    // window to front, it actually creates the window the first time it is
+    // called, and otherwise has no effect.
+    if (this.popupState_ === PopupState.NOT_LAUNCHED) {
       this.popupState_ = PopupState.LAUNCHING;
       this.popupCreationStartTime_ = Date.now();
       // If neither popup nor Chrome window are open (e.g. if uProxy is launched
@@ -76,11 +77,9 @@ class CordovaBrowserApi implements BrowserAPI {
       chrome.app.window.create(this.POPUP_URL, {}, 
           this.newPopupCreated_);
       return this.onceLaunched_;
-    } else if (this.popupState_ == PopupState.LAUNCHED) {
-      // If the popup is already open, simply focus on it.
-      //chrome.windows.update(this.popupWindowId_, {focused: true});
-      return Promise.resolve<void>();
     } else {
+      // Once the app has started, all subsequent calls to bringUproxyToFront
+      // are no-ops.
       return this.onceLaunched_;
       console.log("Waiting for popup to launch...");
     }

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -30,8 +30,6 @@ class CordovaBrowserApi implements BrowserAPI {
   public setIcon = (iconFile :string) : void => {
   }
 
-  public ui :chrome.app.window.AppWindow;
-
   // The URL for the page that renders the UI.  For terminological consistency,
   // the UI is referred to as the "popup", even though it is persistent and
   // full-screen.
@@ -94,7 +92,6 @@ class CordovaBrowserApi implements BrowserAPI {
   private newPopupCreated_ = (popup :chrome.app.window.AppWindow) => {
     console.log("Time between browser icon click and popup launch (ms): " +
         (Date.now() - this.popupCreationStartTime_));
-    this.ui = popup;
     this.popupState_ = PopupState.LAUNCHED;
     this.handlePopupLaunch();
   }

--- a/src/cca/app/scripts/cordova_core_connector.ts
+++ b/src/cca/app/scripts/cordova_core_connector.ts
@@ -20,8 +20,6 @@ class CordovaCoreConnector implements browser_connector.CoreBrowserConnector {
   // Status object indicating whether we're connected to the app.
   public status :browser_connector.StatusObject;
 
-  public waitingForAppInstall :boolean = false;
-
   private fulfillConnect_ :Function;
   public onceConnected :Promise<void> = new Promise<void>((F, R) => {
     this.fulfillConnect_ = F;

--- a/src/cca/app/scripts/cordova_core_connector.ts
+++ b/src/cca/app/scripts/cordova_core_connector.ts
@@ -1,0 +1,123 @@
+/**
+ * cordova_core_connector.ts
+ *
+ * Runs in the UI context, proxying on() and emit() calls to the Freedom app in the
+ * core context.
+ */
+/// <reference path='../../../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../../../third_party/typings/chrome/chrome.d.ts' />
+import browser_connector = require('../../../interfaces/browser_connector');
+import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
+
+import user_interface = require('../../../generic_ui/scripts/ui');
+
+import freedom_types = require('freedom.types');
+
+class CordovaCoreConnector implements browser_connector.CoreBrowserConnector {
+
+  private appChannel_ :freedom_types.OnAndEmit<any,any>;
+
+  // Status object indicating whether we're connected to the app.
+  public status :browser_connector.StatusObject;
+
+  public waitingForAppInstall :boolean = false;
+
+  private fulfillConnect_ :Function;
+  public onceConnected :Promise<void> = new Promise<void>((F, R) => {
+    this.fulfillConnect_ = F;
+  });
+
+  constructor(private options_ ?:chrome.runtime.ConnectInfo) {
+    this.status = { connected: false };
+    this.appChannel_ = null;
+  }
+
+
+  // --- Connectivity methods ---
+
+  /**
+   * Connect the UI to the Freedom module.
+   *
+   * Returns a promise fulfilled upon connection.
+   */
+  public connect = () : Promise<void> => {
+    console.log('trying to connect to app');
+    if (this.status.connected) {
+      console.warn('Already connected.');
+      return Promise.resolve<void>();
+    }
+
+    return this.connect_().then(() => {
+      this.fulfillConnect_();
+      this.emit('core_connect');
+    });
+  }
+
+  /**
+   * Promise internal implementation of the connection sequence.
+   * This relies on ui_context.uProxyAppChannel being created in the core
+   * context before connect() is called here in the UI context.
+   */
+  private connect_ = () : Promise<void> => {
+    return new Promise<void>((F,R) => {
+      chrome.runtime.getBackgroundPage((bgPage) => {
+        (<any>bgPage).ui_context.uProxyAppChannel.then((channel:any) => {
+          this.appChannel_ = channel;
+          F();
+        });
+      });
+    });
+  }
+
+  // --- Communication ---
+  /**
+   * Attach handlers for updates emitted from the uProxy Core.
+   */
+  public onUpdate = (update :uproxy_core_api.Update,
+      handler :(eventData:any) => void) => {
+    this.onceConnected.then(() => {
+      var type = '' + update;
+      this.appChannel_.on(type, handler);
+    });
+  }
+
+  /**
+   * Send a payload to the Chrome app.  Only "emit" messages are allowed.
+   * If currently connected to the App, immediately send. Otherwise, queue
+   * the message until connection completes.
+   * If skipQueue==true, payloads will not be enqueued disconnected.
+   */
+  public send = (payload :browser_connector.Payload,
+                 skipQueue :Boolean = false) => {
+    if (payload.cmd !== 'emit') {
+       throw new Error('send can only be used for emit');
+    }
+    if (skipQueue && !this.appChannel_) {
+      return;
+    }
+    this.onceConnected.then(() => {
+      this.appChannel_.emit('' + payload.type,
+          {data: payload.data, promiseId: payload.promiseId});
+    });
+  }
+
+  public flushQueue = () => {
+  }
+
+  public restart() {
+  }
+
+  private events_ :{[name :string] :Function} = {};
+
+  public on = (name :string, callback :Function) => {
+    this.events_[name] = callback;
+  }
+
+  private emit = (name :string, ...args :Object[]) => {
+    if (name in this.events_) {
+      this.events_[name].apply(null, args);
+    }
+  }
+}  // class CordovaCoreConnector
+
+export = CordovaCoreConnector

--- a/src/cca/app/scripts/main.core-env.ts
+++ b/src/cca/app/scripts/main.core-env.ts
@@ -1,0 +1,49 @@
+/**
+ * background.ts
+ *
+ * This file must be included *after* the freedom script and manifest are
+ * loaded.
+ */
+
+/// <reference path='../../../../../third_party/freedom-typings/freedom-core-env.d.ts' />
+/// <reference path='../../../../../third_party/typings/chrome/chrome-app.d.ts'/>
+
+import freedom_types = require('freedom.types');
+
+import CordovaBrowserApi = require('./cordova_browser_api');
+
+import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
+
+export interface OnEmitModule extends freedom_types.OnAndEmit<any,any> {};
+export interface OnEmitModuleFactory extends
+  freedom_types.FreedomModuleFactoryManager<OnEmitModule> {};
+
+// Remember which handlers freedom has installed.
+var haveAppChannel :Function;
+export var uProxyAppChannel :Promise<freedom_types.OnAndEmit<any,any>> =
+    new Promise((F, R) => {
+  haveAppChannel = F;
+});
+
+export var moduleName = 'uProxy App Top Level';
+export var browserApi :CordovaBrowserApi = new CordovaBrowserApi();
+
+console.log('Instantiating UI');
+// This instantiation, before the core has even started, should reduce the
+// apparent startup time, but runs the risk of leaving the UI non-responsive
+// until the core catches up.
+// TODO: Add a loading screen, for slow systems.
+browserApi.bringUproxyToFront().then(() => {
+  console.log('UI instantiation complete');
+});
+
+console.log('Loading core');
+freedom('generic_core/freedom-module.json', {
+  'logger': 'uproxy-lib/loggingprovider/freedom-module.json',
+  'debug': 'debug',
+  'portType': 'worker'
+}).then((uProxyModuleFactory:OnEmitModuleFactory) => {
+  console.log('Core loading complete');
+  haveAppChannel(uProxyModuleFactory());
+});
+

--- a/src/chrome/extension/scripts/chrome_core_connector.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.ts
@@ -48,11 +48,6 @@ class ChromeCoreConnector implements browser_connector.CoreBrowserConnector {
   // TODO: Replace with Core -> UI specified update API.
   private listeners_ :{[type :string] : Function};
 
-  // Whether waiting for app installation is blocking the extension-app
-  // connection. If this is true, the uProxy popup should automatically
-  // be brought to the front after installation.
-  public waitingForAppInstall :boolean = false;
-
   private fulfillConnect_ :Function;
   public onceConnected :Promise<void> = new Promise<void>((F, R) => {
     this.fulfillConnect_ = F;


### PR DESCRIPTION
Currently the getter functionality is present but nonfunctional,
so the app is titled "uProxy for Sharers".  The Google social network
is also not working, possibly due to STARTTLS issues in the TCP
socket API bindings.

This is the first part of a solution to https://github.com/uProxy/uproxy/issues/586

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1809)
<!-- Reviewable:end -->
