### PR TITLE
Use singleton freedom-port-control to optimize addMapping()

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^29.0.0",
+    "uproxy-lib": "^29.0.7",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^29.0.7",
+    "uproxy-lib": "^30.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -77,3 +77,5 @@ export var effectiveMessageVersion = () : number => {
 }
 
 export var metrics = new metrics_module.Metrics(storage);
+
+export var portControl = freedom['portControl']();

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -5,6 +5,8 @@
  * It handles the signaling channel between two peers, regardless of permission.
  */
 
+/// <reference path='../../../third_party/freedom-typings/port-control.d.ts' />
+
 import globals = require('./globals');
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
 import net = require('../../../third_party/uproxy-lib/net/net.types');
@@ -70,7 +72,8 @@ var generateProxyingSessionId_ = (): string => {
 
     constructor(
       sendUpdate :(x :uproxy_core_api.Update, data?:Object) => void,
-      private userId_?:string
+      private userId_?:string,
+      private portControl_?:freedom_PortControl.PortControl
     ) {
       this.sendUpdate_ = sendUpdate;
       this.resetSharerCreated();
@@ -140,7 +143,7 @@ var generateProxyingSessionId_ = (): string => {
           'rtctonet');
       } else {
         log.debug('peer is running client version >1, using bridge');
-        pc = bridge.best('rtctonet', config);
+        pc = bridge.best('rtctonet', config, this.portControl_);
       }
 
       this.rtcToNet_ = new rtc_to_net.RtcToNet(this.userId_);
@@ -288,15 +291,15 @@ var generateProxyingSessionId_ = (): string => {
           break;
         case 2:
           log.debug('using bridge without obfuscation');
-          pc = bridge.preObfuscation('sockstortc', config);
+          pc = bridge.preObfuscation('sockstortc', config, this.portControl_);
           break;
         case 3:
           log.debug('using bridge with basicObfuscation');
-          pc = bridge.basicObfuscation('sockstortc', config);
+          pc = bridge.basicObfuscation('sockstortc', config, this.portControl_);
           break;
         default:
           log.debug('using holographic ICE');
-          pc = bridge.best('sockstortc', config);
+          pc = bridge.best('sockstortc', config, this.portControl_);
         }
 
       return this.socksToRtc_.start(tcpServer, pc).then(

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -105,7 +105,7 @@ import Persistent = require('../interfaces/persistent');
         public user :remote_user.User,
         public instanceId :string) {
       this.connection_ = new remote_connection.RemoteConnection(
-          this.handleConnectionUpdate_, this.user.userId);
+          this.handleConnectionUpdate_, this.user.userId, globals.portControl);
 
       storage.load<RemoteInstanceState>(this.getStorePath())
           .then((state:RemoteInstanceState) => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -35,8 +35,6 @@ loggingController.setDefaultFilter(
     loggingTypes.Destination.buffered,
     loggingTypes.Level.debug);
 
-var portControl = freedom['portControl']();
-
 /**
  * Primary uProxy backend. Handles which social networks one is connected to,
  * sends updates to the UI, and handles commands from the UI.
@@ -48,6 +46,8 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   // this should be set iff an update to the core is available
   private availableVersion_ :string = null;
+
+  public portControl :freedom_PortControl.PortControl;
 
   constructor() {
     log.debug('Preparing uProxy Core');
@@ -76,6 +76,8 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         data: data
       });
     });
+    this.portControl = freedom['portControl']();
+    this.refreshPortControlSupport();
   }
 
   // sendInstanceHandshakeMessage = (clientId :string) => {
@@ -370,7 +372,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS, 
               uproxy_core_api.PortControlSupport.PENDING);
 
-    return portControl.probeProtocolSupport().then(
+    return this.portControl.probeProtocolSupport().then(
       (probe:freedom_PortControl.ProtocolSupport) => {
         this.portControlSupport_ = (probe.natPmp || probe.pcp || probe.upnp) ?
                                    uproxy_core_api.PortControlSupport.TRUE :
@@ -392,7 +394,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
     return this.getNatType().then((natType:string) => {
       natInfo.natType = natType;
-      return portControl.probeProtocolSupport().then(
+      return this.portControl.probeProtocolSupport().then(
         (probe:freedom_PortControl.ProtocolSupport) => {
           natInfo.pmpSupport = probe.natPmp;
           natInfo.pcpSupport = probe.pcp;

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -35,6 +35,8 @@ loggingController.setDefaultFilter(
     loggingTypes.Destination.buffered,
     loggingTypes.Level.debug);
 
+var portControl = globals.portControl;
+
 /**
  * Primary uProxy backend. Handles which social networks one is connected to,
  * sends updates to the UI, and handles commands from the UI.
@@ -46,8 +48,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   // this should be set iff an update to the core is available
   private availableVersion_ :string = null;
-
-  public portControl :freedom_PortControl.PortControl;
 
   constructor() {
     log.debug('Preparing uProxy Core');
@@ -75,8 +75,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         type: message.type,
         data: data
       });
-    });
-    this.portControl = freedom['portControl']();
+    }, undefined, portControl);
     this.refreshPortControlSupport();
   }
 
@@ -372,7 +371,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS, 
               uproxy_core_api.PortControlSupport.PENDING);
 
-    return this.portControl.probeProtocolSupport().then(
+    return portControl.probeProtocolSupport().then(
       (probe:freedom_PortControl.ProtocolSupport) => {
         this.portControlSupport_ = (probe.natPmp || probe.pcp || probe.upnp) ?
                                    uproxy_core_api.PortControlSupport.TRUE :
@@ -394,7 +393,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
     return this.getNatType().then((natType:string) => {
       natInfo.natType = natType;
-      return this.portControl.probeProtocolSupport().then(
+      return portControl.probeProtocolSupport().then(
         (probe:freedom_PortControl.ProtocolSupport) => {
           natInfo.pmpSupport = probe.natPmp;
           natInfo.pcpSupport = probe.pcp;

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -69,7 +69,6 @@ Polymer({
   ready: function() {
     this.ui = ui;
     this.uproxy_core_api = uproxy_core_api;
-    this.refreshPortControl();
   },
   refreshPortControl: function() {
     core.refreshPortControlSupport();


### PR DESCRIPTION
This is the uproxy side change for https://github.com/uProxy/uproxy-lib/pull/245.

Now, we use one instance of the `freedom-port-control` module everywhere (stored in the core globals), and probe the router only when uProxy starts up (when uproxy core gets loaded). These two changes should make `portControl.addMapping()` much faster, since we're now keeping track of which protocol has previously succeeded inside the module.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1817)
<!-- Reviewable:end -->
