### PR TITLE
Mock probeProtocolSupport function for uproxy_core.spec.ts

### DIFF
--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -31,6 +31,10 @@ describe('Core', () => {
   user.notifyUI = () => {};
   user.getLocalInstanceId = () => { return 'fake/userpath'; };
   var alice = new remote_instance.RemoteInstance(user, 'instance-alice');
+  // Mock out the probeProtocolSupport function.
+  globals.portControl.probeProtocolSupport = () => {
+    return Promise.resolve({"natPmp": false, "pcp": false, "upnp": false});
+  };
   var core = new uproxy_core.uProxyCore();
 
   beforeEach(() => {


### PR DESCRIPTION
Running grunt test was giving this error:
     TypeError: 'undefined' is not a function (evaluating 'portControl.probeProtocolSupport()')

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1833)
<!-- Reviewable:end -->
