### PR TITLE
Add auto-retry on connection failure.

### DIFF
--- a/src/chrome/extension/scripts/chrome_core_connector.spec.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.spec.ts
@@ -172,23 +172,23 @@ describe('core-connector', () => {
 
   it('show disconnect.html if user was proxying when app disconnects.', (done) => {
     var uiIsGettingAccessSpy = spyOn(ui, 'isGettingAccess');
-    var uiStopGettingInUiAndConfigSpy = spyOn(ui, 'stopGettingInUiAndConfig');
+    var uiStoppedGettingSpy = spyOn(ui, 'stoppedGetting');
     connectToApp().then(() => {
       spyOn(chromeCoreConnector, 'connect').and.callFake(() => { done(); });
       uiIsGettingAccessSpy.and.callFake(() => { return true; });
       disconnect();
-      expect(uiStopGettingInUiAndConfigSpy).toHaveBeenCalled();
+      expect(uiStoppedGettingSpy).toHaveBeenCalled();
     });
   });
 
   it('do not show disconnect.html if user was not proxying when app disconnects.', (done) => {
     var uiIsGettingAccessSpy = spyOn(ui, 'isGettingAccess');
-    var uiStopGettingInUiAndConfigSpy = spyOn(ui, 'stopGettingInUiAndConfig');
+    var uiStoppedGettingSpy = spyOn(ui, 'stoppedGetting');
     connectToApp().then(() => {
       spyOn(chromeCoreConnector, 'connect').and.callFake(() => { done(); });
       uiIsGettingAccessSpy.and.callFake(() => { return false; });
       disconnect();
-      expect(uiStopGettingInUiAndConfigSpy).not.toHaveBeenCalled();
+      expect(uiStoppedGettingSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -389,11 +389,11 @@
   },
   "DISCONNECTED_TITLE": {
     "description": "Title for error that appears when the user was getting access to the Internet through their friend, but that connection was terminated.",
-    "message": "Oops! You've been disconnected from your friend."
+    "message": "Oops! You've been disconnected from your friend.  Reconnecting..."
   },
   "DISCONNECTED_MESSAGE": {
-    "description": "Instruction informing the user that to continue browsing the Internet, the user will need to use their local (potentially unsafe and/or censored) connection.",
-    "message": "Please proceed with caution. Your web traffic will no longer be routed through your friend. You may want to close any sensitive windows you have open, before proceeding."
+    "description": "Instruction informing the user that if they want to browse the Internet and stop waiting for reconnection, the user will need to use their local (potentially unsafe and/or censored) connection.",
+    "message": "If you disable the proxy, your web traffic will no longer be routed through your friend. You may want to close any sensitive pages you have open, before proceeding."
   },
   "CONTINUE_BROWSING": {
     "description": "Label for button that will change the users Internet settings back to using the user's local connection (i.e. not their friend's Internet).",
@@ -674,10 +674,6 @@
   "APP_MISSING_MESSAGE": {
     "description": "Shown in Chrome to instruct the user to install part 2 of uProxy.",
     "message": "Download and enable part 2 of uProxy to get started."
-  },
-  "RESTART_PROXYING": {
-    "description": "If proxy connection gets disconnected restart the connection",
-    "message": "Reconnect"
   },
   "UPDATE_AVAILABLE": {
     "description": "What to show the user (on the bottom bar) when an update is available.  The actual update will not be done until they restart uProxy which we will prompt them to do with a link.",

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -389,7 +389,7 @@
   },
   "DISCONNECTED_TITLE": {
     "description": "Title for error that appears when the user was getting access to the Internet through their friend, but that connection was terminated.",
-    "message": "Oops! You've been disconnected from your friend.  Reconnecting..."
+    "message": "Oops! You've been disconnected from your friend."
   },
   "DISCONNECTED_MESSAGE": {
     "description": "Instruction informing the user that if they want to browse the Internet and stop waiting for reconnection, the user will need to use their local (potentially unsafe and/or censored) connection.",
@@ -674,6 +674,18 @@
   "APP_MISSING_MESSAGE": {
     "description": "Shown in Chrome to instruct the user to install part 2 of uProxy.",
     "message": "Download and enable part 2 of uProxy to get started."
+  },
+  "RECONNECTING": {
+    "description": "Indicate that uProxy is attempting to reconnect automatically after a failure.  A progress indicator is also visible.",
+    "message": "Reconnecting..."
+  },
+  "RECONNECT_FAILED": {
+    "description": "Indicate that uProxy attempted to reconnect automatically but it failed.",
+    "message": "Reconnect failed"
+  },
+  "RESTART_PROXYING": {
+    "description": "Displayed on a button next to the RECONNECT_FAILED message",
+    "message": "Try again"
   },
   "UPDATE_AVAILABLE": {
     "description": "What to show the user (on the bottom bar) when an update is available.  The actual update will not be done until they restart uProxy which we will prompt them to do with a link.",

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -29,6 +29,7 @@ Polymer({
     });
   },
   stop: function() {
+    ui.stopUsingProxy();
     ui.stopGettingFromInstance(this.instance.instanceId);
   }
 });

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -378,7 +378,16 @@
       <img src='../icons/128_error.png'>
       <div id="disconnectDialogText">
         <h1>{{ "DISCONNECTED_TITLE" | $$ }}</h1>
-        <div id='progressWrapper'><paper-progress indeterminate='true'></paper-progress></div>
+        <div id='progressWrapper'>
+          <div hidden?='{{ !ui.instanceTryingToGetAccessFrom }}'>
+            <h2>{{ 'RECONNECTING' | $$ }}</h2>
+            <paper-progress indeterminate='true'></paper-progress>
+          </div>
+          <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}' >
+            <strong>{{ 'RECONNECT_FAILED' | $$ }}</strong>
+            <paper-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$ }}</paper-button>
+          </div>
+        </div>
         <p>
           {{ "DISCONNECTED_MESSAGE" | $$ }}
         </p>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -190,6 +190,9 @@
       #disconnectDialog paper-button {
         font-size: 12px;
       }
+      #progressWrapper {
+        text-align: center;
+      }
       paper-toast {
         position: fixed;
         left: 12px;
@@ -375,12 +378,12 @@
       <img src='../icons/128_error.png'>
       <div id="disconnectDialogText">
         <h1>{{ "DISCONNECTED_TITLE" | $$ }}</h1>
+        <div id='progressWrapper'><paper-progress indeterminate='true'></paper-progress></div>
         <p>
           {{ "DISCONNECTED_MESSAGE" | $$ }}
         </p>
       </div>
       <paper-button class='dialogButton' on-tap='{{ revertProxySettings }}'>{{ "CONTINUE_BROWSING" | $$ }}</paper-button>
-      <paper-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$ }}</paper-button>
     </uproxy-action-dialog>
 
     <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -380,7 +380,7 @@
         <h1>{{ "DISCONNECTED_TITLE" | $$ }}</h1>
         <div id='progressWrapper'>
           <div hidden?='{{ !ui.instanceTryingToGetAccessFrom }}'>
-            <h2>{{ 'RECONNECTING' | $$ }}</h2>
+            <strong>{{ 'RECONNECTING' | $$ }}</strong>
             <paper-progress indeterminate='true'></paper-progress>
           </div>
           <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}' >

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -374,7 +374,7 @@
     </uproxy-action-dialog>
 
     <uproxy-action-dialog id='disconnectDialog' backdrop layered="false"
-        opened="{{ core.disconnectedWhileProxying }}" autoCloseDisabled>
+        opened="{{ !!core.disconnectedWhileProxying }}" autoCloseDisabled>
       <img src='../icons/128_error.png'>
       <div id="disconnectDialogText">
         <h1>{{ "DISCONNECTED_TITLE" | $$ }}</h1>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -168,7 +168,6 @@ Polymer({
   },
   revertProxySettings: function() {
     this.ui.stopUsingProxy();
-    this.ui.stopGettingInUiAndConfig({instanceId: null, error: false});
   },
   restartProxying: function() {
     this.ui.restartProxying();

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -167,6 +167,7 @@ Polymer({
     }
   },
   revertProxySettings: function() {
+    this.ui.stopUsingProxy();
     this.ui.stopGettingInUiAndConfig({instanceId: null, error: false});
   },
   restartProxying: function() {

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -30,7 +30,9 @@ class CoreConnector implements uproxy_core_api.CoreApi {
   private mapPromiseIdToFulfillAndReject_ :{[id :number] : FullfillAndReject} =
       {};
 
-  public disconnectedWhileProxying = false;
+  // If non-null, the ID of the instance from which we are presently
+  // disconnected.
+  public disconnectedWhileProxying :string = null;
 
   constructor(private browserConnector_ :browser_connector.CoreBrowserConnector) {
     this.browserConnector_.onUpdate(uproxy_core_api.Update.COMMAND_FULFILLED,

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -22,7 +22,15 @@ describe('UI.UserInterface', () => {
     // Create a fresh UI object before each test.
     mockCore = jasmine.createSpyObj(
         'core',
-        ['reset', 'onUpdate', 'sendCommand', 'on', 'connect', 'getFullState']);
+        [
+          'reset',
+          'onUpdate',
+          'sendCommand',
+          'on',
+          'connect',
+          'getFullState',
+          'stop'
+        ]);
 
     // assume connect always resolves immediately
     (<jasmine.Spy>mockCore.connect).and.returnValue(Promise.resolve());
@@ -248,7 +256,7 @@ describe('UI.UserInterface', () => {
           'testInstanceId', { address : 'testAddress' , port : 0 });
       expect(mockBrowserApi.setIcon)
           .toHaveBeenCalledWith(Constants.GETTING_ICON);
-      ui.stopGettingInUiAndConfig({instanceId: null, error: false});
+      ui.stoppedGetting({instanceId: null, error: false});
     });
 
     it('Extension icon changes when you stop getting access', () => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -589,6 +589,10 @@ export class UserInterface implements ui_constants.UiApi {
     if (data.error) {
       this.bringUproxyToFront();
       this.core.disconnectedWhileProxying = true;
+      if (this.instanceGettingAccessFrom_) {
+        // Auto-retry.
+        this.restartProxying();
+      }
     } else {
       this.core.disconnectedWhileProxying = false;
       if (data.instanceId === null ||


### PR DESCRIPTION
Partially fixes #1825 

Looks like this:
![retrying](https://cloud.githubusercontent.com/assets/191945/9418357/696f5f68-4821-11e5-81b4-ab728837acf5.png)
![reconnect_failed](https://cloud.githubusercontent.com/assets/191945/9397665/02a48380-476d-11e5-9403-88662a0269c0.png)


@lucyhe @jpevarnek

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1836)
<!-- Reviewable:end -->
