### PR TITLE
Try to detect core before the popup opens.

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -168,3 +168,4 @@ chrome.webRequest.onBeforeRequest.addListener(
   ['blocking']
 );
 
+core.connect();


### PR DESCRIPTION
Current logic for detecting uProxy chrome install:
- in extension background: if we receive an onInstalled event, call the onInstalled callback
- in the onInstalled callback: once we connect to the core, turn the icon green

However right now, the extension doesn't try to connect to the core until the popup is opened (which does not happen automatically if the user is installing from uproxy.org)

Adding core.connect to the background will make sure the extension can detect that the app has been installed, without needing the popup to be opened.

Tested by locally loading the new extension, and installing the app from uproxy.org

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1850)
<!-- Reviewable:end -->
