### PR TITLE
Make app-bar styles more specific

### DIFF
--- a/src/generic_ui/polymer/app-bar.html
+++ b/src/generic_ui/polymer/app-bar.html
@@ -3,12 +3,12 @@
 <polymer-element name='uproxy-app-bar' attributes='disableback'>
   <template>
     <style>
-    core-toolbar {
+    core-toolbar#app-bar-toolbar {
       height: 60px;
     }
-    #title {
+    #app-bar-title {
       font-size: 18px;
-      margin-left: 36px;
+      margin-left: 18px;
       white-space: nowrap;
       overflow: hidden;
     }
@@ -30,9 +30,9 @@
     }
     </style>
 
-    <core-toolbar>
+    <core-toolbar id='app-bar-toolbar'>
       <core-icon class='back {{ { disabled: disableback } | tokenList }}' icon="arrow-back" on-tap='{{ back }}'></core-icon>
-      <div id='title' flex>
+      <div id='app-bar-title' flex>
         <content></content>
       </div>
     </core-toolbar>


### PR DESCRIPTION
This makes the selectors for app-bar styles a lot more specific to get
around some errors we were seeing in Firefox.  In Firefox, we were
seeing styles from other elements jump scope and apply to the app-bar,
so we now make sure that will not happen.

Fixes #1845

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1851)
<!-- Reviewable:end -->
