### PR TITLE
Enable early start in Chrome

### DIFF
--- a/src/chrome/extension/manifest.json
+++ b/src/chrome/extension/manifest.json
@@ -22,6 +22,7 @@
     "default_title": "__MSG_extTitle__"
   },
   "permissions": [
+    "background",
     "tabs",
     "proxy",
     "notifications",


### PR DESCRIPTION
Fixes #1723.  uProxy now continues to run even after all Chrome windows are closed, and runs on startup.  This means that sharers, once they log in (and set persistent login permissions), will not have to login again to be available for sharing.

The main user-visible difference is this notification during installation:
![btmnmxm](https://cloud.githubusercontent.com/assets/191945/9476839/eed29ec2-4b3c-11e5-92b1-b13dd1439648.png)

Tested on Windows, using a profile that does not have any other background apps.  After logging into Facebook once, the user was not logged out when closing Chrome, only when logging out of Windows.  Upon logging back into Windows, uProxy reconnected to Facebook but did not display any user interface (apart from a Chrome tray icon).  This only worked if the user checked the "Keep me logged in" checkbox on the Facebook login page.

@jpevarnek @gwpenn

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1852)
<!-- Reviewable:end -->
