### PR TITLE
Actually revert proxy settings when finishing copy+paste session

### DIFF
--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -78,6 +78,7 @@ Polymer({
     });
   },
   stopGetting: function() {
+    ui.stopUsingProxy();
     return core.stopCopyPasteGet().then(() => {
       // clean up the pending endpoint in case we got here from going back
       ui.copyPastePendingEndpoint = null;


### PR DESCRIPTION
Fixes #1855

Copy+paste did not get updated at the same time tha the other disconnect
routes did, this fixes that.

Tested manually.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1856)
<!-- Reviewable:end -->
