### PR TITLE
Add copy+paste message for not sharing

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -147,6 +147,10 @@
     "description": "Message shown when a one-time connection ends.",
     "message": "You are no longer getting access. To request a connection, click the button below."
   },
+  "NO_LONGER_SHARING": {
+    "description": "Message shown when a one-time connection ends and the user was sharing.",
+    "message": "You are no longer sharing access.  Click the button below to request a connection or paste a request link from a friend to share access again."
+  },
   "START_NEW_CONNECTION": {
     "description": "Label for button that takes user back to the 'Start a one-time connection' page.",
     "message": "Start getting a new connection"

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -77,8 +77,12 @@
         <div vertical layout fit>
           <div id='wrapper' flex>
             <div id='nothing' hidden?='{{ ui.copyPasteState.localGettingFromRemote !== GettingState.NONE || ui.copyPasteState.localSharingWithRemote !== SharingState.NONE }}'>
-              <p>
+              <p hidden?='{{ lastState == STATE.SHARING }}'>
                 {{ 'NO_LONGER_GETTING' | $$ }}
+              </p>
+
+              <p hidden?='{{ lastState == STATE.GETTING }}'>
+                {{ 'NO_LONGER_SHARING' | $$ }}
               </p>
 
               <div class='centered'>

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -13,7 +13,13 @@ var ui = ui_context.ui;
 var core = ui_context.core;
 var model = ui_context.model;
 
+enum STATE {
+  GETTING,
+  SHARING,
+};
+
 Polymer({
+  STATE: STATE,
   init: function() {
     /* bring copyPaste to the front in get mode */
     ui.view = ui_constants.View.COPYPASTE;
@@ -22,7 +28,9 @@ Polymer({
       this.startGetting();
     }
   },
+  lastState: STATE.SHARING,
   startGetting: function() {
+    this.lastState = STATE.GETTING;
     this.gettingResponse = '';
 
     var doneStopping :Promise<void>;
@@ -106,6 +114,7 @@ Polymer({
     });
   },
   stopSharing: function() {
+    this.lastState = STATE.SHARING;
     return core.stopCopyPasteShare();
   },
   select: function(e :Event, d :Object, sender :HTMLInputElement) {


### PR DESCRIPTION
We now have a specialized message for when you are no longer sharing
access instead of just telling the user they are no longer getting
access.

This will not work across restarts, that's fine.

Tested manually

Fixes #1592

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1857)
<!-- Reviewable:end -->
