### PR TITLE
Show the "Failed to get" toast for all types of getter failure.

### DIFF
--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -330,18 +330,22 @@ import Persistent = require('../interfaces/persistent');
         log.warn('Timing out socksToRtc_ connection');
         // Tell the UI that sharing failed. It will show a toast.
         // TODO: have RemoteConnection do this
+
+        this.connection_.stopGet();
+      }, this.SOCKS_TO_RTC_TIMEOUT);
+
+      var startGetAttempt :Promise<net.Endpoint> = this.connection_
+          .startGet(this.messageVersion).then((endpoints :net.Endpoint) => {
+        clearTimeout(this.startSocksToRtcTimeout_);
+        return endpoints;
+      });
+      startGetAttempt.catch((e) => {
         ui.update(uproxy_core_api.Update.FAILED_TO_GET, {
           name: this.user.name,
           proxyingId: this.connection_.getProxyingId()
         });
-        this.connection_.stopGet();
-      }, this.SOCKS_TO_RTC_TIMEOUT);
-
-      return this.connection_.startGet(this.messageVersion).then(
-          (endpoints :net.Endpoint) => {
-        clearTimeout(this.startSocksToRtcTimeout_);
-        return endpoints;
       });
+      return startGetAttempt;
     }
 
     /**


### PR DESCRIPTION
Addressing the "getter" part of https://github.com/uProxy/uproxy/issues/1788

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1860)
<!-- Reviewable:end -->
