### PR TITLE
Show a toast for all types of getter/sharer connection failure.

### DIFF
--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -330,18 +330,22 @@ import Persistent = require('../interfaces/persistent');
         log.warn('Timing out socksToRtc_ connection');
         // Tell the UI that sharing failed. It will show a toast.
         // TODO: have RemoteConnection do this
+
+        this.connection_.stopGet();
+      }, this.SOCKS_TO_RTC_TIMEOUT);
+
+      var startGetAttempt :Promise<net.Endpoint> = this.connection_
+          .startGet(this.messageVersion).then((endpoints :net.Endpoint) => {
+        clearTimeout(this.startSocksToRtcTimeout_);
+        return endpoints;
+      });
+      startGetAttempt.catch((e) => {
         ui.update(uproxy_core_api.Update.FAILED_TO_GET, {
           name: this.user.name,
           proxyingId: this.connection_.getProxyingId()
         });
-        this.connection_.stopGet();
-      }, this.SOCKS_TO_RTC_TIMEOUT);
-
-      return this.connection_.startGet(this.messageVersion).then(
-          (endpoints :net.Endpoint) => {
-        clearTimeout(this.startSocksToRtcTimeout_);
-        return endpoints;
       });
+      return startGetAttempt;
     }
 
     /**

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -285,12 +285,6 @@ import Persistent = require('../interfaces/persistent');
         // assumption that our peer failed to start getting access.
         this.startRtcToNetTimeout_ = setTimeout(() => {
           log.warn('Timing out rtcToNet_ connection');
-          // Tell the UI that sharing failed. It will show a toast.
-          // TODO: have RemoteConnection do this
-          ui.update(uproxy_core_api.Update.FAILED_TO_GIVE, {
-            name: this.user.name,
-            proxyingId: this.connection_.getProxyingId()
-          });
           this.stopShare();
         }, this.RTC_TO_NET_TIMEOUT);
 
@@ -299,6 +293,12 @@ import Persistent = require('../interfaces/persistent');
         }, () => {
           log.warn('Could not start sharing.');
           clearTimeout(this.startRtcToNetTimeout_);
+          // Tell the UI that sharing failed. It will show a toast.
+          // TODO: have RemoteConnection do this
+          ui.update(uproxy_core_api.Update.FAILED_TO_GIVE, {
+            name: this.user.name,
+            proxyingId: this.connection_.getProxyingId()
+          });
         });
       });
     }
@@ -328,9 +328,6 @@ import Persistent = require('../interfaces/persistent');
       // Cancel socksToRtc_ connection if start hasn't completed in 30 seconds.
       this.startSocksToRtcTimeout_ = setTimeout(() => {
         log.warn('Timing out socksToRtc_ connection');
-        // Tell the UI that sharing failed. It will show a toast.
-        // TODO: have RemoteConnection do this
-
         this.connection_.stopGet();
       }, this.SOCKS_TO_RTC_TIMEOUT);
 
@@ -340,6 +337,8 @@ import Persistent = require('../interfaces/persistent');
         return endpoints;
       });
       startGetAttempt.catch((e) => {
+        // Tell the UI that sharing failed. It will show a toast.
+        // TODO: have RemoteConnection do this
         ui.update(uproxy_core_api.Update.FAILED_TO_GET, {
           name: this.user.name,
           proxyingId: this.connection_.getProxyingId()

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -332,12 +332,11 @@ import Persistent = require('../interfaces/persistent');
         this.connection_.stopGet();
       }, this.SOCKS_TO_RTC_TIMEOUT);
 
-      var startGetAttempt :Promise<net.Endpoint> = this.connection_
-          .startGet(this.messageVersion).then((endpoints :net.Endpoint) => {
+      return this.connection_.startGet(this.messageVersion)
+          .then((endpoints :net.Endpoint) => {
         clearTimeout(this.startSocksToRtcTimeout_);
         return endpoints;
-      });
-      startGetAttempt.catch((e) => {
+      }).catch((e) => {
         // Tell the UI that sharing failed. It will show a toast.
         // TODO: Send this update from remote-connection.ts
         //       https://github.com/uProxy/uproxy/issues/1861
@@ -345,8 +344,8 @@ import Persistent = require('../interfaces/persistent');
           name: this.user.name,
           proxyingId: this.connection_.getProxyingId()
         });
+        return Promise.reject(e);
       });
-      return startGetAttempt;
     }
 
     /**

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -294,7 +294,8 @@ import Persistent = require('../interfaces/persistent');
           log.warn('Could not start sharing.');
           clearTimeout(this.startRtcToNetTimeout_);
           // Tell the UI that sharing failed. It will show a toast.
-          // TODO: have RemoteConnection do this
+          // TODO: Send this update from remote-connection.ts
+          //       https://github.com/uProxy/uproxy/issues/1861
           ui.update(uproxy_core_api.Update.FAILED_TO_GIVE, {
             name: this.user.name,
             proxyingId: this.connection_.getProxyingId()
@@ -338,7 +339,8 @@ import Persistent = require('../interfaces/persistent');
       });
       startGetAttempt.catch((e) => {
         // Tell the UI that sharing failed. It will show a toast.
-        // TODO: have RemoteConnection do this
+        // TODO: Send this update from remote-connection.ts
+        //       https://github.com/uProxy/uproxy/issues/1861
         ui.update(uproxy_core_api.Update.FAILED_TO_GET, {
           name: this.user.name,
           proxyingId: this.connection_.getProxyingId()

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -91,8 +91,8 @@ import Persistent = require('../interfaces/persistent');
     public RTC_TO_NET_TIMEOUT :number = this.SOCKS_TO_RTC_TIMEOUT + 15000;
     // Timeouts for when to abort starting up SocksToRtc and RtcToNet.
     // TODO: why are these not in remote-connection?
-    private startSocksToRtcTimeout_ :number = null;
-    private startRtcToNetTimeout_ :number = null;
+    private startSocksToRtcTimeout_ :NodeJS.Timer = null;
+    private startRtcToNetTimeout_ :NodeJS.Timer = null;
 
     private connection_ :remote_connection.RemoteConnection = null;
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -286,7 +286,7 @@ export function notifyUI(networkName :string, userId :string) {
     private onceLoggedIn_   :Promise<void>;
 
     // ID returned by setInterval call for monitoring.
-    private monitorIntervalId_ :number = null;
+    private monitorIntervalId_ :NodeJS.Timer = null;
 
     private fulfillLogout_ : () => void;
     private onceLoggedOut_ : Promise<void>;

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -366,7 +366,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   // the then() block of doNatProvoking ends up being called twice.
   // We keep track of the timeout that resets the NAT type to make sure
   // there is at most one timeout at a time.
-  private natResetTimeout_ :number;
+  private natResetTimeout_ :NodeJS.Timer;
 
   public getNatType = () :Promise<string> => {
     if (globals.natType === '') {
@@ -409,7 +409,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   // Sets this.portControlSupport_ and sends update message to UI
   public refreshPortControlSupport = () :Promise<void> => {
     this.portControlSupport_ = uproxy_core_api.PortControlSupport.PENDING;
-    ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS, 
+    ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS,
               uproxy_core_api.PortControlSupport.PENDING);
 
     return portControl.probeProtocolSupport().then(
@@ -417,7 +417,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         this.portControlSupport_ = (probe.natPmp || probe.pcp || probe.upnp) ?
                                    uproxy_core_api.PortControlSupport.TRUE :
                                    uproxy_core_api.PortControlSupport.FALSE;
-        ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS, 
+        ui.update(uproxy_core_api.Update.PORT_CONTROL_STATUS,
                   this.portControlSupport_);
     });
   }
@@ -455,11 +455,11 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       if (natInfo.errorMsg) {
         natInfoStr += natInfo.errorMsg + '\n';
       } else {
-        natInfoStr += 'NAT-PMP: ' + 
+        natInfoStr += 'NAT-PMP: ' +
                   (natInfo.pmpSupport ? 'Supported' : 'Not supported') + '\n';
-        natInfoStr += 'PCP: ' + 
+        natInfoStr += 'PCP: ' +
                   (natInfo.pcpSupport ? 'Supported' : 'Not supported') + '\n';
-        natInfoStr += 'UPnP IGD: ' + 
+        natInfoStr += 'UPnP IGD: ' +
                   (natInfo.upnpSupport ? 'Supported' : 'Not supported') + '\n';
       }
       return natInfoStr;


### PR DESCRIPTION
Resolving: https://github.com/uProxy/uproxy/issues/1788
Previously they were only shown for connections that timed out (e.g. which I saw with bad NAT configs b/w test machine and my mac). This will handle other errors too, e.g. if the peer connection fails to establish the control channel (which I saw in testing).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1862)
<!-- Reviewable:end -->
