### PR TITLE
If the user cancels proxying attempt, don't show "failed to get" toast.

### DIFF
--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -29,7 +29,12 @@ Polymer({
     });
   },
   stop: function() {
-    ui.stopUsingProxy();
+    if (this.instance.localGettingFromRemote ==
+        this.GettingState.TRYING_TO_GET_ACCESS) {
+      ui.stopUsingProxy(true);
+    } else {
+      ui.stopUsingProxy();
+    }
     ui.stopGettingFromInstance(this.instance.instanceId);
   }
 });

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -167,7 +167,7 @@ Polymer({
     }
   },
   revertProxySettings: function() {
-    this.ui.stopUsingProxy();
+    this.ui.stopUsingProxy(true);
   },
   restartProxying: function() {
     this.ui.restartProxying();


### PR DESCRIPTION
ran grunt test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1863)
<!-- Reviewable:end -->
