### PR TITLE
Feature tweaks for private mode.

### DIFF
--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -137,14 +137,15 @@ var lastUrlTime = 0;
 
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {
+      // If there are duplicate emits of this, consider the de-dupe logic used
+      // by the listener for copypaste links below.
       browserApi.emit('inviteUrlData', details.url);
-      // TODO: does this need the same timing logic as copy/paste?
-      // TODO: show something meaningful in the tab
       return {
+          // TODO: improve content of invite-received.html
+          //       https://github.com/uProxy/uproxy/issues/1873
           redirectUrl: chrome.extension.getURL('generic_ui/invite-received.html')
       };
     },
-    // TODO: need to do this for Firefox too
     { urls: ['https://www.uproxy.org/invite/*'] },
     ['blocking']
     );
@@ -161,7 +162,7 @@ chrome.webRequest.onBeforeRequest.addListener(
   function(details) {
     var url = details.url;
 
-    // Chome seems to sometimes send the same url to us twice, we never
+    // Chrome seems to sometimes send the same url to us twice, we never
     // should be receiving the exact same data twice so de-dupe any url
     // with the last one we received before processing it.  We also want
     // to allow a url to be pasted twice if there has been at least a second

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -88,7 +88,7 @@ ui_connector.onPromiseCommand(
     uproxy_core_api.Command.START_PROXYING,
     core.start);
 
-ui_connector.onCommand(
+ui_connector.onPromiseCommand(
     uproxy_core_api.Command.ADD_USER,
     core.addUser);
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -263,7 +263,7 @@ export function notifyUI(networkName :string, userId :string) {
       throw new Error('Operation not implemented');
     }
 
-    public addUserRequest = (networkData :string): void => {
+    public addUserRequest = (networkData :string): Promise<void> => {
       throw new Error('Operation not implemented');
     }
 
@@ -573,8 +573,8 @@ export function notifyUI(networkName :string, userId :string) {
       });
     }
 
-    public addUserRequest = (networkData :string): void => {
-      this.freedomApi_.acceptUserInvitation(networkData).catch((e) => {
+    public addUserRequest = (networkData :string): Promise<void> => {
+      return this.freedomApi_.acceptUserInvitation(networkData).catch((e) => {
         log.error('Error calling acceptUserInvitation: ' + networkData, e.message);
       });
     }

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -581,7 +581,11 @@ export function notifyUI(networkName :string, userId :string) {
 
     public getInviteUrl = () : Promise<string> => {
       return this.freedomApi_.inviteUser('').then((data: { networkData :string }) => {
-        var tokenObj = { networkName: this.name, networkData: data.networkData };
+        var tokenObj = {
+          networkName: this.name,
+          userName: this.myInstance.userName,
+          networkData: data.networkData
+        };
         return 'https://www.uproxy.org/invite/' + btoa(JSON.stringify(tokenObj));
       })
     }

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -48,7 +48,6 @@ import ui = ui_connector.connector;
       areAllContactsUproxy: true
     },
     'Facebook-Firebase-V2': {
-      displayName: 'Facebook',
       isFirebase: true,
       enableMonitoring: true,
       areAllContactsUproxy: true
@@ -153,17 +152,12 @@ export function notifyUI(networkName :string, userId :string) {
 
   var payload :social.NetworkMessage = {
     name: networkName,
-    displayName: getNetworkDisplayName(networkName),
     online: online,
     userId: userId,
     userName: userName,
     imageData: imageData
   };
   ui.update(uproxy_core_api.Update.NETWORK, payload);
-}
-
-export function getNetworkDisplayName(networkName :string) : string {
-  return NETWORK_OPTIONS[networkName].displayName || networkName;
 }
 
   // Implements those portions of the Network interface for which the logic is
@@ -278,7 +272,7 @@ export function getNetworkDisplayName(networkName :string) : string {
     }
 
     public sendEmail = (to: string, subject: string, body: string) : void => {
-      throw new Error('Operation not implemented'); 
+      throw new Error('Operation not implemented');
     }
 
     public getNetworkState = () :social.NetworkState => {
@@ -683,7 +677,6 @@ export function getNetworkDisplayName(networkName :string) : string {
 
       return {
         name: this.name,
-        displayName: getNetworkDisplayName(this.name),
         profile: this.myInstance.getUserProfile(),
         roster: rosterState
       };

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -244,7 +244,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   public getFullState = () :Promise<uproxy_core_api.InitialState> => {
     return globals.loadSettings.then(() => {
       return {
-        networkNames: Object.keys(social_network.networks),
+        networkKeys: Object.keys(social_network.networks),
         globalSettings: globals.settings,
         onlineNetworks: social_network.getOnlineNetworks(),
         availableVersion: this.availableVersion_,

--- a/src/generic_ui/polymer/accept-user-invite.ts
+++ b/src/generic_ui/polymer/accept-user-invite.ts
@@ -8,15 +8,25 @@ var core = ui_context.core;
 Polymer({
   addUser: function() {
     // TODO: handle errors
-    core.addUser(this.receivedInviteToken);
-    this.fire('open-dialog', {
-      heading: 'Friend Added', // TODO: translate
-      message: '',  // TODO:
-      buttons: [{
-        text: ui.i18n_t("OK")
-      }]
+    core.addUser(this.receivedInviteToken).then(() => {
+      this.fire('open-dialog', {
+        heading: 'Friend Added', // TODO: translate
+        message: '',  // TODO:
+        buttons: [{
+          text: ui.i18n_t("OK")
+        }]
+      });
+      this.closeAcceptUserInvitePanel();
+    }).catch(() => {
+      this.fire('open-dialog', {
+        heading: '', // TODO: translate
+        message: 'There was an error adding your friend.',  // TODO:
+        buttons: [{
+          text: ui.i18n_t("OK")
+        }]
+      });
+      console.log('There was an error adding your friend.');
     });
-    this.closeAcceptUserInvitePanel();
   },
   openAcceptUserInvitePanel: function() {
     this.$.acceptUserInvitePanel.open();

--- a/src/generic_ui/polymer/accept-user-invite.ts
+++ b/src/generic_ui/polymer/accept-user-invite.ts
@@ -7,7 +7,6 @@ var core = ui_context.core;
 
 Polymer({
   addUser: function() {
-    // TODO: handle errors
     core.addUser(this.receivedInviteToken).then(() => {
       this.fire('open-dialog', {
         heading: 'Friend Added', // TODO: translate

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -36,8 +36,8 @@
         <paper-dropdown-menu>
           <paper-dropdown class='dropdown'>
             <core-menu class='menu' selected='0' on-core-select='{{ onNetworkSelect }}' id='networkSelectMenu'>
-              <template repeat="{{ network in model.onlineNetworks }}">
-                <paper-item label='{{ network.name }}'>{{ network.displayName }}</paper-item>
+              <template repeat="{{ networkApi in model.networkApis }}">
+                <paper-item label='{{ networkApi.name }}'>{{ networkApi.name }}</paper-item>
               </template>
             </core-menu>
           </paper-dropdown>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -7,7 +7,7 @@ var core = ui_context.core;
 
 Polymer({
   sendToGMailFriend: function() {
-    // TODO: how to get userId of logged in  user?
+    // TODO: how to get userId of logged in user?
     var selectedNetwork =
         model.onlineNetworks[this.$.networkSelectMenu.selectedIndex];
     var selectedNetworkInfo = {
@@ -19,7 +19,7 @@ Polymer({
           networkInfo: selectedNetworkInfo,
           to: this.inviteUserEmail,
           subject: 'Join me on uProxy',
-          body: 'Click here to join me on uProxy' + inviteUrl
+          body: 'Click here to join me on uProxy ' + inviteUrl
       });
       this.fire('open-dialog', {
         heading: 'Invitation Email sent', // TODO: translate

--- a/src/generic_ui/polymer/network-in-settings.html
+++ b/src/generic_ui/polymer/network-in-settings.html
@@ -1,6 +1,6 @@
 <link rel='import' href='name-for-network.html'>
 
-<polymer-element name='uproxy-network-in-settings' attributes='name'>
+<polymer-element name='uproxy-network-in-settings' attributes='networkApi'>
   <template>
     <style>
       :host {
@@ -26,7 +26,7 @@
 
     <div>
       <div horizontal layout class='networkLine'>
-        <span class='networkName' flex><bdi>{{displayName}}</bdi></span>
+        <span class='networkName' flex><bdi>{{ networkName }}</bdi></span>
 
         <span class='action'>
           <a hidden?='{{ !signedIn }}' href='#' on-tap='{{ logout }}'>

--- a/src/generic_ui/polymer/network-in-settings.html
+++ b/src/generic_ui/polymer/network-in-settings.html
@@ -26,7 +26,7 @@
 
     <div>
       <div horizontal layout class='networkLine'>
-        <span class='networkName' flex><bdi>{{ networkName }}</bdi></span>
+        <span class='networkName' flex><bdi>{{ networkApi.name }}</bdi></span>
 
         <span class='action'>
           <a hidden?='{{ !signedIn }}' href='#' on-tap='{{ logout }}'>

--- a/src/generic_ui/polymer/network-in-settings.ts
+++ b/src/generic_ui/polymer/network-in-settings.ts
@@ -18,8 +18,7 @@ Polymer({
     if (this.networkApi.version) {
       networkApiStr = [networkApiStr, this.networkApi.version].join('-');
     }
-    ui.login(networkApiStr)
-        .catch((e :Error) => {
+    ui.login(networkApiStr).catch((e :Error) => {
       console.warn('Did not log in', e);
     });
   },

--- a/src/generic_ui/polymer/network-in-settings.ts
+++ b/src/generic_ui/polymer/network-in-settings.ts
@@ -14,7 +14,12 @@ Polymer({
     this.networkInfo = network ? network : null;
   },
   connect: function() {
-    ui.login(this.name).catch((e :Error) => {
+    var networkApiStr = this.networkApi.name;
+    if (this.networkApi.version) {
+      networkApiStr = [networkApiStr, this.networkApi.version].join('-');
+    }
+    ui.login(networkApiStr)
+        .catch((e :Error) => {
       console.warn('Did not log in', e);
     });
   },
@@ -30,7 +35,6 @@ Polymer({
   },
   ready: function() {
     this.model = model;
-    this.displayName = ui.getNetworkDisplayName(this.name);
   },
   observe: {
     'model.onlineNetworks': 'updateSignedIn'

--- a/src/generic_ui/polymer/network.html
+++ b/src/generic_ui/polymer/network.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../../bower/polymer/polymer.html">
 <link rel='import' href='../../bower/paper-button/paper-button.html'>
 
-<polymer-element name='uproxy-network' attributes='networkName'>
+<polymer-element name='uproxy-network' attributes='networkApi'>
   <template>
     <style>
       :host {
@@ -25,8 +25,8 @@
     <div class='network'>
       <span>
         <span>
-          <paper-button raised on-tap='{{connect}}' class='{{ displayName }}'>
-            {{ displayName }}
+          <paper-button raised on-tap='{{connect}}' class='{{ networkApi.name }}'>
+            {{ networkApi.name }}
           </button>
         </span>
       </span>

--- a/src/generic_ui/polymer/network.ts
+++ b/src/generic_ui/polymer/network.ts
@@ -9,8 +9,12 @@ var model = ui_context.model;
 
 Polymer({
   connect: function() {
-    ui.login(this.networkName).then(() => {
-      console.log('connected to ' + this.networkName);
+    var networkApiStr = this.networkApi.name;
+    if (this.networkApi.version) {
+      networkApiStr = [networkApiStr, this.networkApi.version].join('-');
+    }
+    ui.login(networkApiStr).then(() => {
+      console.log('connected to ' + this.networkApi);
       // Fire an update-view event, which root.ts listens for.
       this.fire('update-view', { view: ui_constants.View.ROSTER });
       ui.bringUproxyToFront();
@@ -19,6 +23,5 @@ Polymer({
     });
   },
   ready: function() {
-    this.displayName = ui.getNetworkDisplayName(this.networkName);
   },
 });

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -364,9 +364,10 @@
     <uproxy-action-dialog backdrop layered="false" heading="{{ dialog.heading }}" id="dialog">
       <p>{{ dialog.message }}</p>
       <template repeat='{{ button in dialog.buttons }}'>
-        <paper-button
-          affirmative?='{{ !button.dismissive }}' dismissive?='{{ button.dismissive }}'
-          class='dialogButton' on-tap='{{ dialogButtonClick }}' data-signal='{{ button.signal }}' data-callbackIndex='{{ button.callbackIndex }}'>
+        <paper-button affirmative?='{{ !button.dismissive }}'
+          dismissive?='{{ button.dismissive }}' class='dialogButton'
+          on-tap='{{ dialogButtonClick }}' data-signal='{{ button.signal }}'
+          data-callbackIndex='{{ button.callbackIndex }}'>
           {{button.text}}
         </paper-button>
       </template>

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -212,7 +212,8 @@
 
     <core-signals on-core-signal-close-settings="{{ closeSettings }}"></core-signals>
 
-    <core-signals on-core-signal-open-dialog="{{ openDialog }}"></core-signals> <!-- TODO: why is this needed? -->
+     <!-- Required for cases where an open-dialog signal is sent from the UI via ui.fireSignal -->
+    <core-signals on-core-signal-open-dialog="{{ openDialog }}"></core-signals>
 
     <div id='browserElementContainer' hidden?='{{ui_constants.View.BROWSER_ERROR !== ui.view}}'></div>
 

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -111,8 +111,9 @@ Polymer({
   dialogButtonClick: function(event :Event, detail :Object, target :HTMLElement) {
     // TODO: error checking, isNaN etc
     var callbackIndex = parseInt(target.getAttribute('data-callbackIndex'), 10);
+    var fulfill = (target.getAttribute('affirmative') != null);
     if (callbackIndex) {
-      ui.invokeConfirmationCallback(callbackIndex);
+      ui.invokeConfirmationCallback(callbackIndex, fulfill);
     }
     var signal = target.getAttribute('data-signal');
     if (signal) {

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -218,9 +218,9 @@
 
       <div id='accountChooser' class='settingsContent' hidden?='{{ !accountChooserOpen }}'>
         <span class='smalltext'>{{ "CONNECTED_ACCOUNTS" | $$ }}</span>
-        <template repeat='{{ name in model.networkNames }}'>
+        <template repeat='{{ networkApi in model.networkApis }}'>
           <div>
-            <uproxy-network-in-settings name='{{ name }}'></uproxy-network-in-settings>
+            <uproxy-network-in-settings networkApi='{{ networkApi }}'></uproxy-network-in-settings>
           </div>
         </template>
       </div>

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -154,8 +154,8 @@
       <div class='view' flex>
         <h1 class='sub'>{{ "WHICH_SOCIAL_NETWORK" | $$ }}</h1>
         <p>{{ "WHY_SOCIAL_NETWORK" | $$ }}</p>
-        <template repeat='{{ n in model.networkNames }}' vertical layout>
-          <uproxy-network networkName='{{n}}'></uproxy-network>
+        <template repeat='{{ networkApi in model.networkApis }}' vertical layout>
+          <uproxy-network networkApi='{{ networkApi }}'></uproxy-network>
         </template>
         <p id='oneTimeConnection'>
           <a href='#' on-tap='{{ copypaste }}'>{{ "SET_UP_ONE_TIME" | $$ }}</a>

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -205,8 +205,8 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.LOGOUT, networkInfo);
   }
 
-  addUser = (inviteUrl: string): void => {
-    this.sendCommand(uproxy_core_api.Command.ADD_USER, inviteUrl);
+  addUser = (inviteUrl: string): Promise<void> => {
+    return this.promiseCommand(uproxy_core_api.Command.ADD_USER, inviteUrl);
   }
 
   // TODO: this should probably take the network path, including userId

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -36,8 +36,8 @@ describe('UI.UserInterface', () => {
     (<jasmine.Spy>mockCore.connect).and.returnValue(Promise.resolve());
 
     (<jasmine.Spy>mockCore.getFullState).and.returnValue(Promise.resolve({
-      networkNames: [
-        'testNetwork'
+      networkApis: [
+        { name: 'testNetwork', version: '' }
       ],
       globalSettings: {
       }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -435,10 +435,14 @@ export class UserInterface implements ui_constants.UiApi {
     });
   }
 
-  public invokeConfirmationCallback = (index :number) => {
+  public invokeConfirmationCallback = (index :number, fulfill :boolean) => {
     this.confirmationCallbacks_[index]();
-    // TODO: also need to delete corresponding fulfill/reject
     delete this.confirmationCallbacks_[index];
+    if (fulfill) {
+      delete this.confirmationCallbacks_[index + 1];
+    } else {
+      delete this.confirmationCallbacks_[index - 1];
+    }
   }
 
   public showNotification = (text :string, data ?:NotificationData) => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -436,6 +436,11 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   public invokeConfirmationCallback = (index :number, fulfill :boolean) => {
+    if (index > this.confirmationCallbackIndex_) {
+      console.error('Confirmation callback not found: ' + index);
+      return;
+    }
+
     this.confirmationCallbacks_[index]();
     delete this.confirmationCallbacks_[index];
     if (fulfill) {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -561,9 +561,8 @@ export class UserInterface implements ui_constants.UiApi {
     var tokenObj = JSON.parse(atob(token));
     var networkName = tokenObj.networkName;
     if (!this.model.getNetwork(networkName)) {
-      this.getConfirmation('Login Required',
-          'You need to log into ' + this.getNetworkDisplayName(networkName))
-          .then(() => {
+      this.getConfirmation('Login Required', 'You need to log into ' +
+          this.getNetworkApiFromKey_(networkName).name).then(() => {
         this.login(networkName).then(() => {
           // Fire an update-view event, which root.ts listens for.
           // TODO: can this be done in ui.ts?
@@ -1169,12 +1168,6 @@ export class UserInterface implements ui_constants.UiApi {
   private setPortControlSupport_ = (support:uproxy_core_api.PortControlSupport) => {
     this.portControlSupport = support;
   }
-
-   public getNetworkDisplayName = (networkName :string) => {
-     // TODO: unhack this...  use same json..  ugg fuck all this
-     // TODO: stop passing displayName from core to UI
-     return networkName == 'Facebook-Firebase-V2' ? 'Facebook' : networkName;
-   }
 
   // this takes care of updating the view (given the assumuption that we are
   // connected to the core)

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -549,8 +549,11 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   private addUserWithConfirmation_ = (url: string) => {
-    // TODO: display friend name.
-    this.getConfirmation('', 'Would you like to add a friend').then(() => {
+    var token = url.substr(url.lastIndexOf('/') + 1);
+    var tokenObj = JSON.parse(atob(token));
+    var userName = tokenObj.userName;
+    this.getConfirmation('', 'Would you like to add ' + userName + '?')
+        .then(() => {
       this.core.addUser(url);
     });
   }
@@ -564,9 +567,6 @@ export class UserInterface implements ui_constants.UiApi {
       this.getConfirmation('Login Required', 'You need to log into ' +
           this.getNetworkApiFromKey_(networkName).name).then(() => {
         this.login(networkName).then(() => {
-          // Fire an update-view event, which root.ts listens for.
-          // TODO: can this be done in ui.ts?
-          // this.fire('update-view', { view: ui_constants.View.ROSTER });
           this.view = ui_constants.View.ROSTER;
           this.bringUproxyToFront();
           this.addUserWithConfirmation_(url);
@@ -1126,7 +1126,7 @@ export class UserInterface implements ui_constants.UiApi {
       return {
         name: networkKey,
         version: null
-      });
+      };
     }
   }
 

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -12,7 +12,7 @@ describe('UI.User', () => {
   beforeEach(() => {
     spyOn(console, 'log');
     ui = jasmine.createSpyObj<user_interface.UserInterface>('UserInterface', ['showNotification']);
-    var testNetwork :user_interface.Network = {name: 'testNetwork', displayName: 'testNetwork', userId: 'localUserId', roster: {}, logoutExpected: false};
+    var testNetwork :user_interface.Network = {name: 'testNetwork', userId: 'localUserId', roster: {}, logoutExpected: false};
     ui.model = new user_interface.Model();
     ui.model.onlineNetworks = [testNetwork];
 

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -84,10 +84,10 @@ export class User implements social.BaseUser {
         if (this.offeringInstances.length === 0 && payload.offeringInstances.length > 0) {
           if (payload.consent.localRequestsAccessFromRemote) {
             this.ui_.showNotification(i18n_t("GRANTED_ACCESS_NOTIFICATION", {name: profile.name}),
-                         { mode: 'get', network: this.network.displayName, user: this.userId });
+                         { mode: 'get', network: this.network.name, user: this.userId });
           } else {
             this.ui_.showNotification(i18n_t("OFFERED_ACCESS_NOTIFICATION", {name: profile.name}),
-                         { mode: 'get', network: this.network.displayName, user: this.userId });
+                         { mode: 'get', network: this.network.name, user: this.userId });
           }
         }
       }
@@ -97,10 +97,10 @@ export class User implements social.BaseUser {
         if (!this.consent_.remoteRequestsAccessFromLocal && payload.consent.remoteRequestsAccessFromLocal) {
           if (payload.consent.localGrantsAccessToRemote) {
             this.ui_.showNotification(i18n_t("ACCEPTED_OFFER_NOTIFICATION", {name: profile.name}),
-                         { mode: 'share', network: this.network.displayName, user: this.userId });
+                         { mode: 'share', network: this.network.name, user: this.userId });
           } else {
             this.ui_.showNotification(i18n_t("REQUESTING_ACCESS_NOTIFICATION", {name: profile.name}),
-                         { mode: 'share', network: this.network.displayName, user: this.userId });
+                         { mode: 'share', network: this.network.name, user: this.userId });
           }
         }
       }

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -272,7 +272,7 @@ export interface Network {
   /**
    * Ask the social network to add the user.
    */
-  addUserRequest: (networkData :string) => void;
+  addUserRequest: (networkData :string) => Promise<void>;
 
   /**
    * Generates an invite token

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -40,7 +40,6 @@ export interface LocalInstanceState {
 
 export interface NetworkMessage {
   name        :string;
-  displayName :string;
   online      :boolean;
   userId      :string;
   userName    :string;
@@ -84,7 +83,6 @@ export interface UserData {
 
 export interface NetworkState {
   name         :string;
-  displayName  :string;
   profile      :UserProfileMessage;
   // TODO: bad smell: UI data should not be
   roster       :{[userId :string] :UserData };
@@ -94,7 +92,6 @@ export interface NetworkOptions {
   isFirebase :boolean;
   enableMonitoring :boolean;
   areAllContactsUproxy :boolean;
-  displayName ?:string;
 }
 
 /**

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -37,7 +37,7 @@ export interface GlobalSettings {
   force_message_version :number;
 }
 export interface InitialState {
-  networkNames :string[];
+  networkKeys :string[];
   globalSettings :GlobalSettings;
   onlineNetworks :social.NetworkState[];
   availableVersion :string;


### PR DESCRIPTION
Passes grunt test, but I haven't been able to run this in Firefox.
Using jpm with Firefox 40 I get this error:
console.warn: Failed to load file resource://uproxy-firefox/data/uproxy-lib/loggingprovider/freedom-module.json: 200
console.error: 
  Policy Error Resolving resource://uproxy-firefox/data/uproxy-lib/loggingprovider/freedom-module.json
I've tried playing with the paths but am not sure why these files in data/ can't be found while others are

Done TODOs:
- remove displayName (instead, core reverts to original behaviour, and the UI will create NetworkApi objects (with a name and version) with the names passed from the core)
- add name to Add Friend confirmation
- delete corresponding fulfill/reject callbacks when confirmation callbacks
- make addUser a Promise // handle addUser errors
- show error if invite URL is bad

Remaining TODOs:
- rename freedom_social or social2 (todo is in social.ts)
- core_connector getInviteUrl and sendEmail should probably take the network path, including userId (although SocialNetworkInfo does seem to have userId already?)
- reconnect for multiple social networks seems to be broken -- I feel like we can put this in a new PR though
- localization

Remaining TODOs that seem resolved
- in invite-user.ts, this todo seems to be handled a few lines below
![image](https://cloud.githubusercontent.com/assets/8723127/9688181/98b9ea10-52fb-11e5-955a-3fff3b157f52.png)
- in root.ts, if (callbackIndex) should handle isNaN
![image](https://cloud.githubusercontent.com/assets/8723127/9688207/c1ed39c8-52fb-11e5-8a9a-051fe1551875.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1875)
<!-- Reviewable:end -->