### PR TITLE
compression for one-time connection URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "devDependencies": {
     "arraybuffer-slice": "^0.1.2",
+    "browserify-zlib": "^0.1.4",
     "bower": "^1.4.1",
     "cca": "^0.7.1",
     "circular-json": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^31.0.0",
+    "uproxy-lib": "^32.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -262,6 +262,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   }
 
   // Resets the copy/paste signal batcher.
+  // TODO: enable compression
   private resetBatcher_ = () : void => {
     this.batcher_ = new onetime.SignalBatcher<social.PeerMessage>((signal:string) => {
       ui.update(uproxy_core_api.Update.COPYPASTE_MESSAGE, signal);
@@ -272,7 +273,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       // returns true.
       return signal.data && (<any>signal.data).signals &&
         bridge.isTerminatingSignal(<bridge.SignallingMessage>signal.data);
-    });
+    }, false);
   }
 
   public startCopyPasteGet = () : Promise<net.Endpoint> => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -265,7 +265,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   // TODO: enable compression
   private resetBatcher_ = () : void => {
     this.batcher_ = new onetime.SignalBatcher<social.PeerMessage>((signal:string) => {
-      ui.update(uproxy_core_api.Update.COPYPASTE_MESSAGE, signal);
+      ui.update(uproxy_core_api.Update.ONETIME_MESSAGE, signal);
     }, (signal:social.PeerMessage) => {
       // This is a terminating message iff signal.data is an instance
       // bridge.SignallingMessage (which we can detect by the presence

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -5,6 +5,8 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
 import loggingTypes = require('../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 import nat_probe = require('../../../third_party/uproxy-lib/nat/probe');
 import net = require('../../../third_party/uproxy-lib/net/net.types');
+import bridge = require('../../../third_party/uproxy-lib/bridge/bridge');
+import onetime = require('../../../third_party/uproxy-lib/bridge/onetime');
 import remote_connection = require('./remote-connection');
 import remote_instance = require('./remote-instance');
 import social = require('../interfaces/social');
@@ -44,8 +46,7 @@ var portControl = globals.portControl;
  */
 export class uProxyCore implements uproxy_core_api.CoreApi {
 
-  private copyPasteSharingMessages_ :social.PeerMessage[] = [];
-  private copyPasteGettingMessages_ :social.PeerMessage[] = [];
+  private batcher_ : onetime.SignalBatcher<social.PeerMessage>;
 
   // this should be set iff an update to the core is available
   private availableVersion_ :string = null;
@@ -54,27 +55,13 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   constructor() {
     log.debug('Preparing uProxy Core');
-    copyPasteConnection = new remote_connection.RemoteConnection((update :uproxy_core_api.Update, message?:any) => {
+    copyPasteConnection = new remote_connection.RemoteConnection(
+        (update:uproxy_core_api.Update, message?:social.PeerMessage) => {
       if (update !== uproxy_core_api.Update.SIGNALLING_MESSAGE) {
         ui.update(update, message);
-        return;
+      } else {
+        this.batcher_.addToBatch(message);
       }
-
-      var data :social.PeerMessage[];
-      switch (message.type) {
-        case social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER:
-          data = this.copyPasteGettingMessages_;
-          break;
-        case social.PeerMessageType.SIGNAL_FROM_SERVER_PEER:
-          data = this.copyPasteSharingMessages_;
-          break;
-      }
-      data.push(message);
-
-      ui.update(uproxy_core_api.Update.COPYPASTE_MESSAGE, {
-        type: message.type,
-        data: data
-      });
     }, undefined, portControl);
 
     this.refreshPortControlSupport();
@@ -250,9 +237,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         availableVersion: this.availableVersion_,
         copyPasteState: {
           connectionState: copyPasteConnection.getCurrentState(),
-          endpoint: copyPasteConnection.activeEndpoint,
-          gettingMessages: this.copyPasteGettingMessages_,
-          sharingMessages: this.copyPasteSharingMessages_
+          endpoint: copyPasteConnection.activeEndpoint
         },
         portControlSupport: this.portControlSupport_,
       };
@@ -276,8 +261,22 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     user.modifyConsent(command.action);
   }
 
+  // Resets the copy/paste signal batcher.
+  private resetBatcher_ = () : void => {
+    this.batcher_ = new onetime.SignalBatcher<social.PeerMessage>((signal:string) => {
+      ui.update(uproxy_core_api.Update.COPYPASTE_MESSAGE, signal);
+    }, (signal:social.PeerMessage) => {
+      // This is a terminating message iff signal.data is an instance
+      // bridge.SignallingMessage (which we can detect by the presence
+      // of a signals field) for which bridge.isTerminatingSignal
+      // returns true.
+      return signal.data && (<any>signal.data).signals &&
+        bridge.isTerminatingSignal(<bridge.SignallingMessage>signal.data);
+    });
+  }
+
   public startCopyPasteGet = () : Promise<net.Endpoint> => {
-    this.copyPasteGettingMessages_ = [];
+    this.resetBatcher_();
     return copyPasteConnection.startGet(globals.effectiveMessageVersion());
   }
 
@@ -286,7 +285,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   }
 
   public startCopyPasteShare = () => {
-    this.copyPasteSharingMessages_ = [];
+    this.resetBatcher_();
     copyPasteConnection.startShare(globals.effectiveMessageVersion());
   }
 
@@ -294,8 +293,9 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     return copyPasteConnection.stopShare();
   }
 
-  public sendCopyPasteSignal = (signal :social.PeerMessage) => {
-    copyPasteConnection.handleSignal(signal);
+  public sendCopyPasteSignal = (signal:string) => {
+    var decodedSignals = <social.PeerMessage[]>onetime.decode(signal);
+    decodedSignals.forEach(copyPasteConnection.handleSignal);
   }
 
   /**

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -107,7 +107,7 @@
                   </p>
 
                   <paper-input-decorator label="{{ 'LOADING' | $$ }}" layout vertical>
-                    <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/request/{{ ui.copyPasteGettingMessages | encodeMessage }}' />
+                    <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/request/{{ ui.copyPasteMessage | encodeMessage }}' />
                   </paper-input-decorator>
                 </div>
 
@@ -171,7 +171,7 @@
 
 
                 <paper-input-decorator label="{{ 'LOADING' | $$ }}" layout vertical>
-                  <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/offer/{{ ui.copyPasteSharingMessages | encodeMessage }}' />
+                  <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/offer/{{ ui.copyPasteMessage | encodeMessage }}' />
                 </paper-input-decorator>
 
                 <div>

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -42,7 +42,7 @@ Polymer({
     }
 
     doneStopping.then(() => {
-      ui.copyPasteGettingMessages = [];
+      ui.copyPasteMessage = '';
       ui.copyPasteError = ui_constants.CopyPasteError.NONE;
       ui.copyPastePendingEndpoint = null;
 
@@ -141,8 +141,8 @@ Polymer({
       ui.view = ui_constants.View.SPLASH;
     })
   },
-  encodeMessage: function(message :social.PeerMessageType) {
-    return encodeURIComponent(btoa(JSON.stringify(message)));
+  encodeMessage: function(message:string) {
+    return encodeURIComponent(message);
   },
   gettingResponse: '',
   gettingLinkError: false,

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -171,7 +171,7 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.STOP_PROXYING_COPYPASTE_SHARE);
   }
 
-  sendCopyPasteSignal = (signal :social.PeerMessage) => {
+  sendCopyPasteSignal = (signal:string) => {
     this.sendCommand(uproxy_core_api.Command.COPYPASTE_SIGNALLING_MESSAGE, signal);
   }
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -256,7 +256,7 @@ export class UserInterface implements ui_constants.UiApi {
       // TODO: Display the message in the 'manual network' UI.
     });
 
-    core.onUpdate(uproxy_core_api.Update.COPYPASTE_MESSAGE, (message:string) => {
+    core.onUpdate(uproxy_core_api.Update.ONETIME_MESSAGE, (message:string) => {
       this.copyPasteMessage = message;
     });
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -55,13 +55,6 @@ export interface ConnectionState {
 export interface CopyPasteState {
   connectionState :ConnectionState;
   endpoint :net.Endpoint;
-  gettingMessages :social.PeerMessage[];
-  sharingMessages :social.PeerMessage[];
-}
-
-export interface CopyPasteMessages {
-  type :social.PeerMessageType;
-  data :social.PeerMessage[];
 }
 
 // --- Communications ---
@@ -130,6 +123,7 @@ export enum Update {
   STATE = 2019,
   FAILED_TO_GIVE = 2020,
   POST_TO_CLOUDFRONT = 2021,
+  // Payload is a string, obtained from the SignalBatcher in uproxy-lib.
   COPYPASTE_MESSAGE = 2022,
   FAILED_TO_GET = 2023,
   CORE_UPDATE_AVAILABLE = 2024,
@@ -222,7 +216,9 @@ export interface CoreApi {
    */
   stopCopyPasteShare() :Promise<void>;
 
-  sendCopyPasteSignal(signal :social.PeerMessage) :void;
+  // Decodes an encoded batch of signalling messages and forwards each signal
+  // to the RemoteConnection.
+  sendCopyPasteSignal(signal:string) :void;
 
   // Using peer as a proxy.
   start(instancePath :social.InstancePath) : Promise<net.Endpoint>;

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -123,11 +123,13 @@ export enum Update {
   STATE = 2019,
   FAILED_TO_GIVE = 2020,
   POST_TO_CLOUDFRONT = 2021,
-  // Payload is a string, obtained from the SignalBatcher in uproxy-lib.
+  // Legacy one-time connection string. Unused, do not send.
   COPYPASTE_MESSAGE = 2022,
   FAILED_TO_GET = 2023,
   CORE_UPDATE_AVAILABLE = 2024,
   PORT_CONTROL_STATUS = 2025,
+  // Payload is a string, obtained from the SignalBatcher in uproxy-lib.
+  ONETIME_MESSAGE = 2026
 }
 
 // Action taken by the user. These values are not on the wire. They are passed


### PR DESCRIPTION
This uses the new-fangled gzip compression stuff in uproxy-lib on one-time connection URLs. I also tried to simplify a few things along the way.

One thing to note is that this *doesn't* support older clients. I think it would be pretty straightforward to add, at the cost of pretty ugly code. I'm not sure how important support for older clients is.

Depends on:
https://github.com/uProxy/uproxy-lib/pull/283

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1880)
<!-- Reviewable:end -->
