### PR TITLE
Fix issues with core-icon styling

### DIFF
--- a/src/generic_ui/polymer/advanced-settings.html
+++ b/src/generic_ui/polymer/advanced-settings.html
@@ -86,7 +86,7 @@
       overflow: auto;
     }
     #portControlBox core-icon {
-      height: 15px;
+      height: 15px !important;
       color: grey;
       opacity: 0.6;
       margin-bottom: 2px;

--- a/src/generic_ui/polymer/avatar.html
+++ b/src/generic_ui/polymer/avatar.html
@@ -15,11 +15,11 @@
 
       #image core-icon {
         /* network icon */
-        position: absolute;
+        position: absolute !important;
         right: 0px;
         bottom: 0px;
-        height: 30%;
-        width: 30%;
+        height: 30% !important;
+        width: 30% !important;
       }
 
       #image core-icon.full {

--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -43,14 +43,15 @@
       margin: 0px 8px;
     }
     .nameRow .iconWrapper core-icon[icon=open-in-new] {
-      width: 16px;
-      height: 16px;
+      width: 16px !important;
+      height: 16px !important;
     }
     .nameRow:hover core-icon.expand {
       opacity: 1;
     }
     uproxy-avatar {
-      width: 40px; height: 40px;
+      width: 40px;
+      height: 40px;
       min-width: 40px;
       border: none;
       border-radius: 50%;
@@ -88,8 +89,8 @@
     core-icon[icon=query-builder],
     core-icon[icon=mail],
     core-icon[icon=check] {
-      height: 16px;
-      width: 16px;
+      height: 16px !important;
+      width: 16px !important;
       color: rgba(0,0,0,0.54);
       margin: 0px 4px 0px 0px;
     }

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -25,8 +25,8 @@
         cursor: pointer;
       }
       #savedDescription core-icon {
-        height: 16px;
-        width: 16px;
+        height: 16px !important;
+        width: 16px !important;
         margin: 0px 0px 4px 3px;
         opacity: 0.6;
         float: right;

--- a/src/generic_ui/polymer/feedback.html
+++ b/src/generic_ui/polymer/feedback.html
@@ -69,9 +69,8 @@
       background-color: #ffffff;
       text-transform: uppercase;
     }
-    core-icon[icon="launch"],
-    core-icon[icon="help"]{
-      height: 15px;
+    core-icon {
+      height: 15px !important;
       color: grey;
       opacity: 0.6;
       margin-bottom: 2px;
@@ -79,8 +78,7 @@
       -moz-transition: all 0.23s !important;
       transition: all 0.23s !important;
     }
-    core-icon[icon="launch"]:hover,
-    core-icon[icon="help"]:hover{
+    core-icon:hover {
       opacity: 1;
     }
     core-tooltip::shadow #tooltip {

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -24,8 +24,8 @@
       margin-bottom: 0;
     }
     core-icon[icon=query-builder] {
-      height: 16px;
-      width: 16px;
+      height: 16px !important;
+      width: 16px !important;
       color: rgba(0,0,0,0.54);
       margin-top: 2px;
       margin-right: 2px;

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -109,8 +109,8 @@
       core-toolbar core-icon.status {
         cursor: pointer;
         color: #006A5A;
-        height: 20px;
-        width: 20px;
+        height: 20px !important;
+        width: 20px !important;
       }
       #settings {
         top: 0;

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -37,8 +37,8 @@
       font-size: 17px;
     }
     .no-friends {
-      width: 150px;
-      height: 150px;
+      width: 150px !important;
+      height: 150px !important;
       color: #cbcbcb;
     }
     #noContactsFound {

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -69,8 +69,8 @@
       background-color: #fff;
     }
     .settingsContent core-icon {
-      height: 20px;
-      width: 20px;
+      height: 20px !important;
+      width: 20px !important;
     }
     .label {
       text-indent: 5px;
@@ -113,7 +113,7 @@
       padding: 0px 8px;
     }
     #metricsCheckbox core-icon[icon='help']{
-      height: 15px;
+      height: 15px !important;
       color: grey;
       opacity: 0.6;
       margin-bottom: 2px;

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -86,8 +86,8 @@
     }
     #logo {
       margin-bottom: 1em;
-      width: 114px;
-      height: 114px;
+      width: 114px !important;
+      height: 114px !important;
     }
     .prevArrow {
       position: absolute;
@@ -101,8 +101,8 @@
       height: 100%;
     }
     #languageLink core-icon {
-      height: 20px;
-      width: 20px;
+      height: 20px !important;
+      width: 20px !important;
     }
     #languageLink paper-item {
       font-size: 13px;

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -20,8 +20,8 @@
       float: right;
     }
     core-icon[icon="help"] {
-      height: 15px;
-      width: 15px;
+      height: 15px !important;
+      width: 15px !important;
     }
     core-icon[icon="help"],
     core-icon[icon="clear"] {


### PR DESCRIPTION
The Chrome handling of dependant styles got changed to give priority to
the parent scope
(https://code.google.com/p/chromium/issues/detail?id=487125) which
causes the styling for core-icon to no longer allow the changing of
height/width using the recommended method.  In order to get around this,
we now spceficy all height/width properties we want to set on a
core-icon as !important (along with some other properties).

Fixes some parts of #1858

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1881)
<!-- Reviewable:end -->
