### PR TITLE
Switch to using uproxy-button

### DIFF
--- a/src/generic_ui/polymer/bubble.html
+++ b/src/generic_ui/polymer/bubble.html
@@ -1,5 +1,5 @@
 <link rel='import' href='../../bower/paper-icon-button/paper-icon-button.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 
 <!--
 uproxy-bubble will appear immediately below the previous element in the DOM.
@@ -62,7 +62,7 @@ uproxy-bubble::shadow #done {
     #actions {
       text-align: right;
     }
-    paper-button#done {
+    uproxy-button#done {
       background-color: #222;
     }
 
@@ -91,7 +91,7 @@ uproxy-bubble::shadow #done {
           <content></content>
 
           <div id='actions'>
-            <paper-button id='done' on-tap='{{ close }}'>{{ "DONE" | $$ }}</paper-button>
+            <uproxy-button id='done' on-tap='{{ close }}'>{{ "DONE" | $$ }}</uproxy-button>
           </div>
         </div>
       </div>

--- a/src/generic_ui/polymer/button.html
+++ b/src/generic_ui/polymer/button.html
@@ -1,0 +1,13 @@
+<link rel='import' href='../../bower/paper-button/paper-button.html'>
+
+<polymer-element name='uproxy-button' extends='paper-button' noscript>
+  <template>
+    <style>
+      :host {
+        background: #009688;  /* teal 500 */
+        color: white;
+      }
+    </style>
+    <shadow></shadow>
+  </template>
+</polymer-element>

--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -2,6 +2,7 @@
 <link rel='import' href='../../bower/core-icons/core-icons.html'>
 <link rel='import' href='../../bower/core-collapse/core-collapse.html'>
 <link rel='import' href='instance.html'>
+<link rel='import' href='button.html'>
 
 <polymer-element name='uproxy-contact' attributes='contact, isOnline'>
 
@@ -79,7 +80,7 @@
     .offline {
       opacity: 0.5;
     }
-    paper-button {
+    uproxy-button {
       font-size: 1em;
       margin: 14px 5px 5px 2px;
       padding-left: 1em;
@@ -170,24 +171,24 @@
           </p>
         </div>
         <p class='preButtonDetailedText'>{{ "WAITING_FOR_ACCESS" | $$({ name: contact.name }) }}</p>
-        <paper-button class='grey' raised on-tap='{{ cancelRequest }}'>{{ "CANCEL_REQUEST" | $$ }}</paper-button>
+        <uproxy-button class='grey' raised on-tap='{{ cancelRequest }}'>{{ "CANCEL_REQUEST" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.REMOTE_OFFERED_LOCAL_NO_ACTION }}'>
         <p class='preButtonText'>{{ "OFFERED_YOU_ACCESS" | $$ }}</p>
-        <paper-button raised on-tap='{{ request }}'>{{ "ACCEPT_OFFER" | $$ }}</paper-button>
-        <paper-button raised on-tap='{{ ignoreOffer }}'>{{ "IGNORE" | $$ }}</paper-button>
+        <uproxy-button raised on-tap='{{ request }}'>{{ "ACCEPT_OFFER" | $$ }}</uproxy-button>
+        <uproxy-button raised on-tap='{{ ignoreOffer }}'>{{ "IGNORE" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.REMOTE_OFFERED_LOCAL_IGNORED }}'>
         <p class='preButtonText'>{{ "OFFERED_YOU_ACCESS" | $$ }}</p>
-        <paper-button class='grey' raised on-tap='{{ unignoreOffer }}'>{{ "STOP_IGNORING_OFFERS" | $$ }}</paper-button>
+        <uproxy-button class='grey' raised on-tap='{{ unignoreOffer }}'>{{ "STOP_IGNORING_OFFERS" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.gettingConsentState != GettingConsentState.NO_OFFER_OR_REQUEST }}'>
-        <paper-button raised on-tap='{{ request }}'>
+        <uproxy-button raised on-tap='{{ request }}'>
           {{ "ASK_FOR_ACCESS" | $$ }}
-        </paper-button>
+        </uproxy-button>
       </div>
 
     </core-collapse> <!-- end of getControls -->
@@ -198,11 +199,11 @@
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.LOCAL_OFFERED_REMOTE_ACCEPTED }}'>
         <p class='preButtonText'>{{ "GRANTED_FRIEND_ACCESS" | $$ }}</p>
-        <paper-button class='grey' raised on-tap='{{ cancelOffer }}'>{{ "REVOKE_ACCESS" | $$ }}</paper-button>
+        <uproxy-button class='grey' raised on-tap='{{ cancelOffer }}'>{{ "REVOKE_ACCESS" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.LOCAL_OFFERED_REMOTE_NO_ACTION }}'>
-        <paper-button class='grey' raised on-tap='{{ cancelOffer }}'>{{ "CANCEL_OFFER" | $$ }}</paper-button>
+        <uproxy-button class='grey' raised on-tap='{{ cancelOffer }}'>{{ "CANCEL_OFFER" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.REMOTE_REQUESTED_LOCAL_NO_ACTION }}'>
@@ -212,18 +213,18 @@
             {{ "FRIEND_REQUESTS_ACCESS" | $$({ name: contact.name }) }}
           </p>
         </div>
-        <paper-button raised on-tap='{{ offer }}'>{{ "GRANT" | $$ }}</paper-button>
-        <paper-button raised on-tap='{{ ignoreRequest }}'>{{ "IGNORE" | $$ }}</paper-button>
+        <uproxy-button raised on-tap='{{ offer }}'>{{ "GRANT" | $$ }}</uproxy-button>
+        <uproxy-button raised on-tap='{{ ignoreRequest }}'>{{ "IGNORE" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.REMOTE_REQUESTED_LOCAL_IGNORED }}'>
         <p class='preButtonText'>{{ "FRIEND_REQUESTED_ACCESS" | $$ }}</p>
-        <paper-button class='grey' raised on-tap='{{ unignoreRequest }}'>{{ "STOP_IGNORING_REQUESTS" | $$ }}</paper-button>
+        <uproxy-button class='grey' raised on-tap='{{ unignoreRequest }}'>{{ "STOP_IGNORING_REQUESTS" | $$ }}</uproxy-button>
       </div>
 
       <div hidden?='{{ contact.sharingConsentState != SharingConsentState.NO_OFFER_OR_REQUEST }}'>
         <p class='preButtonText'>{{ "ACCESS_NOT_GRANTED" | $$ }}</p>
-        <paper-button raised on-tap='{{ offer }}'>{{ "OFFER_ACCESS" | $$ }}</paper-button>
+        <uproxy-button raised on-tap='{{ offer }}'>{{ "OFFER_ACCESS" | $$ }}</uproxy-button>
       </div>
     </core-collapse> <!-- end of shareControls -->
 

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -1,4 +1,4 @@
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='bubble.html'>
 <link rel='import' href='app-bar.html'>
@@ -86,9 +86,9 @@
               </p>
 
               <div class='centered'>
-                <paper-button on-tap='{{ startGetting }}'>
+                <uproxy-button on-tap='{{ startGetting }}'>
                   {{ 'START_NEW_CONNECTION' | $$ }}
-                </paper-button>
+                </uproxy-button>
               </div>
 
               <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.FAILED }}' on-closed='{{ dismissError }}' class='error'>
@@ -120,10 +120,10 @@
                     <input is='core-input' value='{{ gettingResponse }}' />
                   </paper-input-decorator>
 
-                  <paper-button raised on-tap='{{ submitGettingLink }}'
+                  <uproxy-button raised on-tap='{{ submitGettingLink }}'
                       hidden?='{{ !showGettingSubmit }}'>
                     {{ 'SUBMIT_ONE_TIME_LINK' | $$ }}
-                  </paper-button>
+                  </uproxy-button>
                 </div>
 
               </div>
@@ -141,15 +141,15 @@
                 </p>
 
                 <div class='centered'>
-                  <paper-button raised on-tap='{{ startProxying }}'
+                  <uproxy-button raised on-tap='{{ startProxying }}'
                       hidden?='{{ ui.copyPastePendingEndpoint === null }}'>
                     {{ 'START_GETTING' | $$ }}
-                  </paper-button>
+                  </uproxy-button>
 
-                  <paper-button raised class='grey' on-tap='{{ stopGetting }}'
+                  <uproxy-button raised class='grey' on-tap='{{ stopGetting }}'
                       hidden?='{{ ui.copyPastePendingEndpoint !== null }}'>
                     {{ 'STOP_GETTING' | $$ }}
-                  </paper-button>
+                  </uproxy-button>
                 </div>
 
                 <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}'>
@@ -195,7 +195,7 @@
 
                 <p>{{ 'ONE_TIME_SHARING_STOP_DIRECTIONS' | $$ }}</p>
 
-                <paper-button raised class='grey' on-tap='{{ stopSharing }}'>{{ 'STOP_ONE_TIME_SHARING' | $$ }}</paper-button>
+                <uproxy-button raised class='grey' on-tap='{{ stopSharing }}'>{{ 'STOP_ONE_TIME_SHARING' | $$ }}</uproxy-button>
 
                 <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}' class='error'>
                   <p>{{ 'ONE_TIME_SHARING' | $$ }}</p>

--- a/src/generic_ui/polymer/description.html
+++ b/src/generic_ui/polymer/description.html
@@ -1,6 +1,6 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 <link rel='import' href='../../bower/core-icons/core-icons.html'>
 
 <polymer-element name='uproxy-description' attributes=''>
@@ -12,7 +12,7 @@
         margin-bottom: 5px;
         color: rgb(112, 112, 112);
       }
-      paper-button {
+      uproxy-button {
         width: 70px;
         margin-left: 0px;
         margin-right: 5px;
@@ -40,8 +40,8 @@
       <paper-input-decorator label='{{ "DESCRIPTION" | $$ }}'>
         <input is="core-input" value='{{ descriptionInput }}'>
       </paper-input-decorator>
-      <paper-button raised on-tap="{{ saveDescription }}">{{ "SAVE" | $$ }}</paper-button>
-      <paper-button raised on-tap="{{ cancelEditing }}">{{ "CANCEL" | $$ }}</paper-button>
+      <uproxy-button raised on-tap="{{ saveDescription }}">{{ "SAVE" | $$ }}</uproxy-button>
+      <uproxy-button raised on-tap="{{ cancelEditing }}">{{ "CANCEL" | $$ }}</uproxy-button>
     </div>
     <div id='savedDescription' hidden?='{{ editing }}' on-tap='{{ editDescription }}'>
       {{ showDescription(model.globalSettings.description) }}

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../../bower/polymer/polymer.html">
 <link rel='import' href='../../bower/core-icons/core-icons.html'>
-<link rel="import" href="../../bower/paper-button/paper-button.html">
+<link rel="import" href="button.html">
 
 <polymer-element name='uproxy-instance' attributes='user, instance, network'>
   <template>
@@ -8,7 +8,7 @@
     #wrapper.offline {
       opacity: 0.5;
     }
-    paper-button {
+    uproxy-button {
       font-size: 1em;
       margin: 14px 5px 5px 2px;
       padding-left: 1em;
@@ -44,23 +44,23 @@
 
       <!-- not getting or trying to get access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
-        <paper-button raised on-tap='{{ start }}' disabled?='{{ !ui.browserApi.canProxy }}'>
+        <uproxy-button raised on-tap='{{ start }}' disabled?='{{ !ui.browserApi.canProxy }}'>
           {{ "START_GETTING" | $$ }}
-        </paper-button>
+        </uproxy-button>
       </div>
 
       <!-- trying to get access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.TRYING_TO_GET_ACCESS }}'>
-        <paper-button class='grey' raised on-tap='{{ stop }}'>
+        <uproxy-button class='grey' raised on-tap='{{ stop }}'>
           {{ "CANCEL" | $$ }}
-        </paper-button>
+        </uproxy-button>
       </div>
 
       <!-- currently getting access -->
       <div hidden?='{{ instance.localGettingFromRemote != GettingState.GETTING_ACCESS }}'>
-        <paper-button class='grey' raised on-tap='{{ stop }}'>
+        <uproxy-button class='grey' raised on-tap='{{ stop }}'>
           {{ "STOP_GETTING" | $$ }}
-        </paper-button>
+        </uproxy-button>
       </div>
 
     </div> <!-- end of wrapper -->

--- a/src/generic_ui/polymer/network.html
+++ b/src/generic_ui/polymer/network.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../../bower/polymer/polymer.html">
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 
 <polymer-element name='uproxy-network' attributes='networkName'>
   <template>
@@ -8,13 +8,13 @@
         display: block;
         box-sizing: border-box;
       }
-      paper-button {
+      uproxy-button {
         width: 150px;
       }
-      paper-button.Google {
+      uproxy-button.Google {
         background: #dd4b39;
       }
-      paper-button.Facebook {
+      uproxy-button.Facebook {
         background: #3b5998;
       }
     </style>
@@ -22,7 +22,7 @@
     <div class='network'>
       <span>
         <span>
-          <paper-button raised on-tap='{{connect}}' class='{{ networkName }}'>
+          <uproxy-button raised on-tap='{{connect}}' class='{{ networkName }}'>
             {{ networkName }}
           </button>
         </span>

--- a/src/generic_ui/polymer/reconnect.html
+++ b/src/generic_ui/polymer/reconnect.html
@@ -1,5 +1,5 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 <link rel='import' href='../../bower/paper-progress/paper-progress.html'>
 <link rel='import' href='dialog.html'>
 
@@ -10,7 +10,7 @@
       text-align: center;
       font-color: #009688;  /* dark green */
     }
-    paper-button {
+    uproxy-button {
       margin: 10px 2px 3px 2px;
       font-size: 12px;
     }
@@ -29,7 +29,7 @@
       <div>
         <p>{{ "ATTEMPTING_RECONNECT" | $$ }}</p>
         <paper-progress indeterminate='true'></paper-progress>
-        <paper-button on-tap='{{ logout }}'>{{ "LOGOUT" | $$ }}</paper-button>
+        <uproxy-button on-tap='{{ logout }}'>{{ "LOGOUT" | $$ }}</uproxy-button>
       </div>
     </uproxy-dialog>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -22,6 +22,7 @@
 <link rel='import' href='browser-elements.html'>
 <link rel='import' href='icons.html'>
 <link rel='import' href='proxy-error.html'>
+<link rel='import' href='button.html'>
 
 <polymer-element name='uproxy-root' attributes='model' on-update-view='{{ updateView }}' on-open-dialog='{{ openDialog }}'>
 
@@ -167,7 +168,7 @@
       .core-overlay-backdrop {
         z-index: 1001;
       }
-      uproxy-action-dialog paper-button {
+      uproxy-action-dialog uproxy-button {
         margin-bottom: 3px;
       }
       uproxy-faq-link .linkText {
@@ -187,7 +188,7 @@
       #disconnectDialog #disconnectDialogText {
         text-align: start;
       }
-      #disconnectDialog paper-button {
+      #disconnectDialog uproxy-button {
         font-size: 12px;
       }
       #progressWrapper {
@@ -353,11 +354,11 @@
     <uproxy-action-dialog backdrop layered="false" heading="{{ dialog.heading }}" id="dialog">
       <p>{{ dialog.message }}</p>
       <template repeat='{{ button in dialog.buttons }}'>
-        <paper-button
+        <uproxy-button
           affirmative?='{{ !button.dismissive }}' dismissive?='{{ button.dismissive }}'
           class='dialogButton' on-tap='{{ dialogButtonClick }}' data-signal='{{ button.signal }}'>
           {{button.text}}
-        </paper-button>
+        </uproxy-button>
       </template>
     </uproxy-action-dialog>
 
@@ -369,8 +370,8 @@
         </uproxy-faq-link>{{ "CHANGE_STATS_CHOICE" | $$ }}
       </p>
       <p>{{ "ENABLE_METRICS" | $$ }}</p>
-      <paper-button affirmative class='dialogButton' on-tap='{{ enableStats }}'>{{ "IM_IN" | $$ }}</paper-button>
-      <paper-button dismissive class='dialogButton' on-tap='{{ disableStats }}'>{{ "NO_THANKS" | $$ }}</paper-button>
+      <uproxy-button affirmative class='dialogButton' on-tap='{{ enableStats }}'>{{ "IM_IN" | $$ }}</uproxy-button>
+      <uproxy-button dismissive class='dialogButton' on-tap='{{ disableStats }}'>{{ "NO_THANKS" | $$ }}</uproxy-button>
     </uproxy-action-dialog>
 
     <uproxy-action-dialog id='disconnectDialog' backdrop layered="false"
@@ -385,14 +386,14 @@
           </div>
           <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}' >
             <strong>{{ 'RECONNECT_FAILED' | $$ }}</strong>
-            <paper-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$ }}</paper-button>
+            <uproxy-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$ }}</uproxy-button>
           </div>
         </div>
         <p>
           {{ "DISCONNECTED_MESSAGE" | $$ }}
         </p>
       </div>
-      <paper-button class='dialogButton' on-tap='{{ revertProxySettings }}'>{{ "CONTINUE_BROWSING" | $$ }}</paper-button>
+      <uproxy-button class='dialogButton' on-tap='{{ revertProxySettings }}'>{{ "CONTINUE_BROWSING" | $$ }}</uproxy-button>
     </uproxy-action-dialog>
 
     <uproxy-troubleshoot titleText='{{ troubleshootTitle }}'></uproxy-troubleshoot>

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -1,5 +1,4 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
 <link rel='import' href='../../bower/paper-checkbox/paper-checkbox.html'>
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/core-icons/core-icons.html'>
@@ -89,12 +88,6 @@
     paper-input-decorator {
       padding: 0;
       margin-bottom: 5px;
-    }
-    paper-button {
-      width: 70px;
-      margin-left: 0px;
-      margin-right: 5px;
-      font-size: 10px;
     }
     paper-checkbox::shadow #checkboxContainer {
       margin-left: 1px;

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -1,9 +1,9 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
 <link rel='import' href='../../bower/paper-item/paper-item.html'>
 <link rel="import" href="../../bower/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../../bower/paper-dropdown/paper-dropdown.html">
 <link rel="import" href="../../bower/core-menu/core-menu.html">
+<link rel='import' href='button.html'>
 <link rel='import' href='faq-link.html'>
 <link rel='import' href='network.html'>
 
@@ -59,7 +59,7 @@
       opacity: 0;
       z-index: -1;
     }
-    paper-button {
+    uproxy-button {
       width: 150px;
     }
     uproxy-network {
@@ -127,7 +127,7 @@
         </p>
 
         <div id='nextWrapper'>
-          <paper-button raised on-tap='{{next}}'>{{ "NEXT" | $$ }}</paper-button>
+          <uproxy-button raised on-tap='{{next}}'>{{ "NEXT" | $$ }}</uproxy-button>
         </div>
         <div id='languageLink'>
           <core-icon icon='language'></core-icon>

--- a/src/generic_ui/polymer/troubleshoot.html
+++ b/src/generic_ui/polymer/troubleshoot.html
@@ -1,5 +1,5 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
-<link rel='import' href='../../bower/paper-button/paper-button.html'>
+<link rel='import' href='button.html'>
 <link rel='import' href='../../bower/core-tooltip/core-tooltip.html'>
 <link rel='import' href='../../bower/core-icons/core-icons.html'>
 <link rel='import' href='../../bower/core-signals/core-signals.html'>
@@ -39,7 +39,7 @@
     core-icon.button {
       cursor: pointer;
     }
-    paper-button {
+    uproxy-button {
       margin: 10px 2px 3px 2px;
       font-size: 12px;
     }
@@ -86,12 +86,12 @@
             <core-icon icon="help"></core-icon>
           </uproxy-faq-link><br>
         </p>
-        <paper-button on-tap='{{ getNatType }}'>
+        <uproxy-button on-tap='{{ getNatType }}'>
           {{ "YES" | $$ }}
-        </paper-button>
-        <paper-button on-tap='{{ close }}'>
+        </uproxy-button>
+        <uproxy-button on-tap='{{ close }}'>
           {{ "NO" | $$ }}
-        </paper-button>
+        </uproxy-button>
       </div>
 
       <!-- Second screen in dialog shows a loading bar as we get NAT type. -->
@@ -112,12 +112,12 @@
         </uproxy-faq-link>
         <br>
         <div id='analyzedNetworkButtons'>
-          <paper-button on-tap='{{ submitFeedback }}'>
+          <uproxy-button on-tap='{{ submitFeedback }}'>
             {{ "YES" | $$ }}
-          </paper-button>
-          <paper-button on-tap='{{ close }}'>
+          </uproxy-button>
+          <uproxy-button on-tap='{{ close }}'>
             {{ "NO" | $$ }}
-          </paper-button>
+          </uproxy-button>
         </div>
       </div>
 

--- a/src/generic_ui/style/global.css
+++ b/src/generic_ui/style/global.css
@@ -1,9 +1,3 @@
-/* add simple classes to buttons for green and grey */
-body /deep/ paper-button {
-  background: #009688;  /* teal 500 */
-  color: white;
-}
-
 body /deep/ paper-button[disabled] {
   background: #4DB6AC;  /* teal 300 */
   color: white;


### PR DESCRIPTION
One of the downsides of the Chrome rule changes is /deep/ rules will
pretty much universally tend to override other styles on elements.  In
order to get around this, we switch from trying to style all
paper-buttons at a global scope and now have a uproxy-button (that has
styling) and override the styling for that the way we had before where
necessary.

Fixes #1877

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1882)
<!-- Reviewable:end -->
