### PR TITLE
Fix a bug with core-input sizes

### DIFF
--- a/src/generic_ui/style/global.css
+++ b/src/generic_ui/style/global.css
@@ -37,3 +37,10 @@ body /deep/ core-toolbar {
   background-color: #009688;
   color: white;
 }
+
+/* get around a bug in polymer styling */
+body /deep/ paper-input-decorator input[is="core-input"] {
+  padding: 0;
+  margin: 0.5em 0 0.25em;
+  width: 100%;
+}


### PR DESCRIPTION
Due to a Chrome change, all core-input elements were force-styled to be
20em wide.  This looked incredibly strange when used with a
paper-input-decorator (as is all over in the code).  This changes the
styling for core-ipnut element below paper-input-decorators so that they
will have the correct size.

Fixes #1878

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1884)
<!-- Reviewable:end -->
