### PR TITLE
Tweaks to reconnect behaviour

### DIFF
--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -376,6 +376,13 @@ import Persistent = require('../interfaces/persistent');
     private updateConsentFromWire_ = (bits :social.ConsentWireState) => {
       var userConsent = this.user.consent;
 
+      if (!bits.isOffering &&
+          this.connection_.localGettingFromRemote === social.GettingState.TRYING_TO_GET_ACCESS) {
+        // if we lose the ability to get, cancel any pending gets
+        clearTimeout(this.startSocksToRtcTimeout_);
+        this.connection_.stopGet();
+      }
+
       // Update this remoteInstance.
       this.wireConsentFromRemote = bits;
       this.user.updateRemoteRequestsAccessFromLocal();

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -379,12 +379,12 @@
       <img src='../icons/128_error.png'>
       <div id="disconnectDialogText">
         <h1>{{ "DISCONNECTED_TITLE" | $$ }}</h1>
-        <div id='progressWrapper'>
+        <div id='progressWrapper' hidden?='{{ !ui.mapInstanceIdToUser_[core.disconnectedWhileProxying] }}'>
           <div hidden?='{{ !ui.instanceTryingToGetAccessFrom }}'>
             <strong>{{ 'RECONNECTING' | $$ }}</strong>
             <paper-progress indeterminate='true'></paper-progress>
           </div>
-          <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}' >
+          <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}'>
             <strong>{{ 'RECONNECT_FAILED' | $$ }}</strong>
             <uproxy-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$ }}</uproxy-button>
           </div>


### PR DESCRIPTION
This is in two parts: the first makes it so that we will immediately abort an attempt to connect if we lose access (instead of waiting until we time out).  The second part of this makes it so that we will not show the reconnect error in the case where there was no user to reconnect to (i.e. copy+paste).

I wanted to make changes so that the reconnect dialog would show better contextual information about whether you had access to reconnect, however, that does not seem to be possible without reworking a large amount of code for both Core <-> UI communications and the actual UI state storage.  A project for another day :(

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1904)
<!-- Reviewable:end -->
