### PR TITLE
Undo Firefox changes for JPM

### DIFF
--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -5,8 +5,8 @@
  * for proxy setting and setiing a main icon.
  */
 
-var proxyConfig = require('lib/firefox_proxy_config.js').proxyConfig;
-var xhr = require('lib/firefox_xhr.js').xhr;
+var proxyConfig = require('firefox_proxy_config.js').proxyConfig;
+var xhr = require('firefox_xhr.js').xhr;
 
 // TODO: rename uproxy.js/ts to uproxy-enums.js/ts
 var uproxy_core_api = require('./interfaces/uproxy_core_api.js');

--- a/src/firefox/lib/main.js
+++ b/src/firefox/lib/main.js
@@ -36,8 +36,8 @@ var init = freedom(manifest, {
   })
 
   // Set up connection between freedom and content script.
-  require('lib/glue.js').setUpConnection(new uproxy(), panel, button);
-  require('lib/url-handler.js').setup(panel, button);
+  require('glue.js').setUpConnection(new uproxy(), panel, button);
+  require('url-handler.js').setup(panel, button);
 });
 
 

--- a/src/firefox/package.json
+++ b/src/firefox/package.json
@@ -3,6 +3,7 @@
   "title": "uProxy Alpha",
   "description": "This is the alpha version of uProxy.",
   "author": "uProxy Team <info@uproxy.org>",
+  "id": "jid1-uTe1Bgrsb76jSA",
   "license": "Apache 2.0",
   "version": "0.8.23",
   "permissions": {


### PR DESCRIPTION
Undo Firefox changes for jpm, as they were breaking the dist build.

Entered https://github.com/uProxy/uproxy/issues/1909 to re-add JPM changes later on once we know how to make them support both dev + dist

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1910)
<!-- Reviewable:end -->
