### PR TITLE
Translate invite UI

### DIFF
--- a/src/chrome/extension/invite-received.html
+++ b/src/chrome/extension/invite-received.html
@@ -7,6 +7,7 @@
 </head>
 
 <body>
+  <!-- TODO: translate -->
   <h1>Invite received.</h1>
 
   <p>

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -734,5 +734,81 @@
   "LEARN_MORE": {
     "description": "Generic label for links to FAQ.",
     "message": "Learn more"
+  },
+  "FRIEND_ADDED": {
+    "description": "Confirmation message after adding a friend to the roster.",
+    "message": "Friend added"
+  },
+  "FRIEND_ADD_ERROR": {
+    "description": "Error message when a friend cannot be added to the roster.",
+    "message": "There was an error adding your friend."
+  },
+  "INVITE_EMAIL_SENT": {
+    "description": "Confirmation message after an invite email has been sent",
+    "message": "Invitation email sent."
+  },
+  "ENTER_INVITE_CODE": {
+    "description": "Title for screen where user enters an invite code",
+    "message": "Enter an invite code"
+  },
+  "ENTER_INVITE_CODE_DESCRIPTION": {
+    "description": "Instructions for user to enter an invite code",
+    "message": "If you've received an invitation from a friend you'd like to use uProxy with, paste it here:"
+  },
+  "SUBMIT_BUTTON_TEXT": {
+    "description": "Button that submits some data entered by the user, e.g. entering a friend invite",
+    "message": "Submit"
+  },
+  "INVITE_LINK_FROM_ACCEPT_PAGE": {
+    "description": "Link to send an invite if the user is already on the accept-invite page.",
+    "message": "Click here if you would like to send an invitation to a friend"
+  },
+  "INVITE_A_FRIEND": {
+    "description": "Title for screen where user invites a friend to uProxy",
+    "message": "Invite a friend"
+  },
+  "HOW_TO_INVITE_FRIENDS": {
+    "description": "Question above network select dropdown on invite screen",
+    "message": "How would you like to invite to your friends?"
+  },
+  "FACEBOOK_INVITE_INSTRUCTIONS": {
+    "description": "Invite instructions for Facebook",
+    "message": "Click below to send a uProxy invite to your Facebook friends.  When they open this link with uProxy, they will appear in your uProxy contact list."
+  },
+  "GMAIL_INVITE_INSTRUCTIONS": {
+    "description": "Invite instructions for GMail",
+    "message": "Enter your friend's email address to send them a friend request by email.  When they accept the invitation, they will appear on your contact list."
+  },
+  "SEND_INVITATION": {
+    "description": "Button text to initiate sending an invitation",
+    "message": "Send invitation"
+  },
+  "ACCEPT_LINK_FROM_INVITE_PAGE": {
+    "description": "Link to accept an invite if the user is already on the send an invite page",
+    "message": "Click here if you have an invitation from a friend that you would like to use."
+  },
+  "ACCEPT_INVITE_CONFIRMATION": {
+    "description": "Confirmation message when accepting an invite.",
+    "message": "Would you like to add __name__?"
+  },
+  "LOGIN_REQUIRED_TITLE": {
+    "description": "Title for confirmation that the user must login to a network to accept an invitation",
+    "message": "Login Required"
+  },
+  "LOGIN_REQUIRED_MESSAGE": {
+    "description": "Message for confirmation that the user must login to a network to accept an invitation",
+    "message": "To accept this invitation, you will need to log into __network__."
+  },
+  "INVITE_URL_ERROR": {
+    "description": "Error message shown for invalid invite URLs",
+    "message": "There was an error with your invite URL."
+  },
+  "INVITE_EMAIL_SUBJECT": {
+    "description": "Default email subject for sending an uProxy invite",
+    "message": "Join me on uProxy"
+  },
+  "INVITE_EMAIL_BODY": {
+    "description": "Default email body for sending an uProxy invite",
+    "message": "Hi, I'd like to invite you to uProxy.  Click here to join me: __url__"
   }
 }

--- a/src/generic_ui/polymer/accept-user-invite.html
+++ b/src/generic_ui/polymer/accept-user-invite.html
@@ -4,6 +4,7 @@
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/polymer/polymer.html'>
 <link rel='import' href='button.html'>
+<link rel="import" href="i18n-filter.html">
 
 <polymer-element name='uproxy-accept-user-invite'>
   <template>
@@ -12,38 +13,41 @@
         height: 100%;
         width: 100%;
         background-color: white;
-        text-align: center;
       }
       .section {
-        padding: 2em;
+        padding-left: 2em;
+        padding-right: 2em;
+        padding-top: 1em;
+        padding-bottom: 1em;
       }
       a {
         cursor: pointer;
+        text-decoration: underline;
       }
     </style>
-    <!-- TODO: localization -->
 
     <core-signals on-core-signal-open-accept-user-invite-dialog='{{ openAcceptUserInvitePanel }}'></core-signals>
 
     <core-overlay id='acceptUserInvitePanel'>
       <uproxy-app-bar on-go-back='{{ closeAcceptUserInvitePanel }}'>
-        Use an invitation
+        {{ "ENTER_INVITE_CODE" | $$ }}
       </uproxy-app-bar>
 
       <div class='section'>
-        <p>If you have a uProxy token or link from your friend, you can paste it below to add them.</p>
+        <p>{{ "ENTER_INVITE_CODE_DESCRIPTION" | $$ }}</p>
 
         <div id='addFriend'>
-          <paper-input-decorator label="Add friend by URL">
+          <paper-input-decorator label="{{ 'ENTER_INVITE_CODE' | $$ }}">
             <input is='core-input' value='{{ receivedInviteToken }}'>
           </paper-input-decorator>
-          <uproxy-button affirmative autofocus on-tap='{{ addUser }}'>Add Friend</uproxy-button>
+          <uproxy-button affirmative autofocus on-tap='{{ addUser }}'>
+            {{ 'SUBMIT_BUTTON_TEXT' | $$ }}
+          </uproxy-button>
         </div>
       </div>
 
       <div class='section'>
-        If you would like to send an invitation to a friend, you can do so
-        <a on-tap='{{ showInviteUser }}'>here</a>
+        <a on-tap='{{ showInviteUser }}'>{{ 'INVITE_LINK_FROM_ACCEPT_PAGE' | $$ }}</a>
       </div>
 
     </core-overlay>

--- a/src/generic_ui/polymer/accept-user-invite.html
+++ b/src/generic_ui/polymer/accept-user-invite.html
@@ -22,7 +22,6 @@
       }
       a {
         cursor: pointer;
-        text-decoration: underline;
       }
     </style>
 

--- a/src/generic_ui/polymer/accept-user-invite.ts
+++ b/src/generic_ui/polymer/accept-user-invite.ts
@@ -9,8 +9,8 @@ Polymer({
   addUser: function() {
     core.addUser(this.receivedInviteToken).then(() => {
       this.fire('open-dialog', {
-        heading: 'Friend Added', // TODO: translate
-        message: '',  // TODO:
+        heading: '',
+        message: ui.i18n_t("FRIEND_ADDED"),
         buttons: [{
           text: ui.i18n_t("OK")
         }]
@@ -18,13 +18,12 @@ Polymer({
       this.closeAcceptUserInvitePanel();
     }).catch(() => {
       this.fire('open-dialog', {
-        heading: '', // TODO: translate
-        message: 'There was an error adding your friend.',  // TODO:
+        heading: '',
+        message: ui.i18n_t("FRIEND_ADD_ERROR"),
         buttons: [{
           text: ui.i18n_t("OK")
         }]
       });
-      console.log('There was an error adding your friend.');
     });
   },
   openAcceptUserInvitePanel: function() {

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -23,7 +23,6 @@
       }
       a {
         cursor: pointer;
-        text-decoration: underline;
       }
       paper-dropdown-menu {
         padding: 0;

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -5,6 +5,7 @@
 <link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/polymer/polymer.html'>
 <link rel='import' href='button.html'>
+<link rel="import" href="i18n-filter.html">
 
 <polymer-element name='uproxy-invite-user'>
   <template>
@@ -13,26 +14,32 @@
         height: 100%;
         width: 100%;
         background-color: white;
-        text-align: center;
       }
       .section {
-        padding: 2em;
+        padding-left: 2em;
+        padding-right: 2em;
+        padding-top: 1em;
+        padding-bottom: 1em;
       }
       a {
         cursor: pointer;
+        text-decoration: underline;
+      }
+      paper-dropdown-menu {
+        padding: 0;
+        margin: 0;
       }
     </style>
-    <!-- TODO: localization -->
 
     <core-signals on-core-signal-open-invite-user-dialog='{{ openInviteUserPanel }}'></core-signals>
 
     <core-overlay id='inviteUserPanel'>
       <uproxy-app-bar on-go-back='{{ closeInviteUserPanel }}'>
-        Invite a friend
+        {{ 'INVITE_A_FRIEND' | $$ }}
       </uproxy-app-bar>
 
-      <div hidden?='{{ model.onlineNetworks.length <= 1}}'>
-        <p>How would you like to invite to your friends?</p>
+      <div hidden?='{{ model.onlineNetworks.length <= 1}}' class='section'>
+        <p>{{ 'HOW_TO_INVITE_FRIENDS' | $$ }}</p>
         <paper-dropdown-menu>
           <paper-dropdown class='dropdown'>
             <core-menu class='menu' selected='0' on-core-select='{{ onNetworkSelect }}' id='networkSelectMenu'>
@@ -46,27 +53,28 @@
 
       <div class='section'>
         <div hidden?='{{ selectedNetworkName != "Facebook-Firebase-V2"}}'>
-          <p>Click below to send a uProxy invite to your Facebook friends.  When they open this link with uProxy, they will appear in your uProxy contact list.</p>
+          <p>{{ 'FACEBOOK_INVITE_INSTRUCTIONS' | $$ }}</p>
           <uproxy-button affirmative on-tap='{{ sendToFacebookFriend }}'>
-            Send to Facebook Friend
+            {{ 'SEND_INVITATION' | $$ }}
           </uproxy-button>
         </div>
 
         <div hidden?='{{ selectedNetworkName != "GMail"}}'>
-          <p>Enter your friend's GMail address to send them a friend request by email.  When they accept the invitation, they will appear on your contact list.</p>
-          <paper-input-decorator label='GMail address' layout vertical>
+          <p>{{ 'GMAIL_INVITE_INSTRUCTIONS' | $$ }}</p>
+          <paper-input-decorator label='{{ "EMAIL_PLACEHOLDER" | $$ }}' layout vertical>
             <input is='core-input' value='{{ inviteUserEmail }}' />
           </paper-input-decorator>
 
           <uproxy-button affirmative on-tap='{{ sendToGMailFriend }}'>
-            Send to GMail Friend
+            {{ 'SEND_INVITATION' | $$ }}
           </uproxy-button>
         </div>
       </div>
 
       <div class='section'>
-        If your friend has sent you an invitation, you can use it
-        <a on-tap='{{ showAcceptUserInvite }}'>here</a>
+        <a on-tap='{{ showAcceptUserInvite }}'>
+          {{ 'ACCEPT_LINK_FROM_INVITE_PAGE' | $$ }}
+        </a>
       </div>
 
     </core-overlay>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -17,12 +17,12 @@ Polymer({
       core.sendEmail({
           networkInfo: selectedNetworkInfo,
           to: this.inviteUserEmail,
-          subject: 'Join me on uProxy',
-          body: 'Click here to join me on uProxy ' + inviteUrl
+          subject: ui.i18n_t('INVITE_EMAIL_SUBJECT'),
+          body: ui.i18n_t('INVITE_EMAIL_BODY', { url: inviteUrl })
       });
       this.fire('open-dialog', {
-        heading: 'Invitation Email sent', // TODO: translate
-        message: '',  // TODO:
+        heading: '',
+        message: ui.i18n_t("INVITE_EMAIL_SENT"),
         buttons: [{
           text: ui.i18n_t("OK")
         }]

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -546,7 +546,7 @@ export class UserInterface implements ui_constants.UiApi {
       return this.core.addUser(url);
     }).catch((e) => {
       // The user did not confirm adding their friend, not an error.
-      return Promise.resolve<void>();
+      return;
     })
   }
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -540,17 +540,21 @@ export class UserInterface implements ui_constants.UiApi {
     } catch(e) {
       return Promise.reject('Error parsing invite URL');
     }
-    return this.getConfirmation('', 'Would you like to add ' + userName + '?')
-        .then(() => {
+    var confirmationMessage =
+        this.i18n_t('ACCEPT_INVITE_CONFIRMATION', { name: userName });
+    return this.getConfirmation('', confirmationMessage).then(() => {
       return this.core.addUser(url);
-    });
+    }).catch((e) => {
+      // The user did not confirm adding their friend, not an error.
+      return Promise.resolve<void>();
+    })
   }
 
   public handleInviteUrlData = (url :string) => {
     var showUrlError = () => {
       this.fireSignal('open-dialog', {
         heading: '',
-        message: 'There was an error with your invite URL. Please try again.',
+        message: this.i18n_t("INVITE_URL_ERROR"),
         buttons: [{
           text: this.i18n_t("OK")
         }]
@@ -565,8 +569,11 @@ export class UserInterface implements ui_constants.UiApi {
       return;
     }
     if (!this.model.getNetwork(networkName)) {
-      this.getConfirmation('Login Required', 'You need to log into ' +
-            this.getNetworkDisplayName(networkName)).then(() => {
+      var confirmationTitle = this.i18n_t('LOGIN_REQUIRED_TITLE');
+      var confirmationMessage =
+          this.i18n_t('LOGIN_REQUIRED_MESSAGE',
+                      { network: this.getNetworkDisplayName(networkName) });
+      this.getConfirmation(confirmationTitle, confirmationMessage).then(() => {
         this.login(networkName).then(() => {
           this.view = ui_constants.View.ROSTER;
           this.bringUproxyToFront();


### PR DESCRIPTION
Translate invite UI, and update styles to be slightly closer to the ideal mocks https://folio.googleplex.com/izzie/uProxy/091015_InviteFlow#%2FInvite%20Flow_v3.png%3Fz=half (lots of styling work still remains).

The only part that hasn't yet been translated is invite-received.html, the page which appears in the browser tab when the user navigates to an invite URL.  This is similar to copypaste.html which also is not translated as it doesn't yet use Polymer.

Partly addresses https://github.com/uProxy/uproxy/issues/1908

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1911)
<!-- Reviewable:end -->