### PR TITLE
enable compression of one-time messages

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -262,7 +262,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   }
 
   // Resets the copy/paste signal batcher.
-  // TODO: enable compression
   private resetBatcher_ = () : void => {
     this.batcher_ = new onetime.SignalBatcher<social.PeerMessage>((signal:string) => {
       ui.update(uproxy_core_api.Update.ONETIME_MESSAGE, signal);
@@ -273,7 +272,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       // returns true.
       return signal.data && (<any>signal.data).signals &&
         bridge.isTerminatingSignal(<bridge.SignallingMessage>signal.data);
-    }, false);
+    }, true);
   }
 
   public startCopyPasteGet = () : Promise<net.Endpoint> => {


### PR DESCRIPTION
@jpevarnek I'll defer to you on when's a good time to enable this but I figure since support for reading compressed messages has been out for 1-2 releases now, it's about time to enable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1915)
<!-- Reviewable:end -->
