### PR TITLE
Endpoint cleanup fun

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -128,6 +128,7 @@ taskManager.add 'test_ui', [
   'base'
   'browserify:genericUiUiSpec'
   'browserify:genericUiUserSpec'
+  'browserify:genericUiCopypasteStateSpec'
   'jasmine:generic_ui'
 ]
 
@@ -1027,6 +1028,7 @@ module.exports = (grunt) ->
 
       genericUiUiSpec: Rule.browserifySpec 'generic_ui/scripts/ui'
       genericUiUserSpec: Rule.browserifySpec 'generic_ui/scripts/user'
+      genericUiCopypasteStateSpec: Rule.browserifySpec 'generic_ui/scripts/copypaste-state'
       integrationSpec: Rule.browserifySpec 'integration/core'
       integrationFreedomModule: Rule.browserify 'integration/test_connection'
 

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -359,12 +359,13 @@ var generateProxyingSessionId_ = (): string => {
       this.sendUpdate_(uproxy_core_api.Update.STATE, this.getCurrentState());
     }
 
-    public getCurrentState = () => {
+    public getCurrentState = () :uproxy_core_api.ConnectionState => {
       return {
         bytesSent: this.bytesSent_,
         bytesReceived: this.bytesReceived_,
         localGettingFromRemote: this.localGettingFromRemote,
-        localSharingWithRemote: this.localSharingWithRemote
+        localSharingWithRemote: this.localSharingWithRemote,
+        activeEndpoint: this.activeEndpoint,
       };
     }
 

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -161,32 +161,36 @@ describe('remote_instance.RemoteInstance', () => {
     };
 
     it('can start proxying', (done) => {
-      expect(alice.localGettingFromRemote).toEqual(social.GettingState.NONE);
+      var aliceState = alice.currentStateForUi();
+      expect(aliceState.localGettingFromRemote).toEqual(social.GettingState.NONE);
       alice.user.consent.localRequestsAccessFromRemote = true;
       alice.wireConsentFromRemote.isOffering = true;
       // The module & constructor of SocksToRtc may change in the near future.
       spyOn(socks_to_rtc, 'SocksToRtc').and.returnValue(fakeSocksToRtc);
       alice.start().then(() => {
-        expect(alice.localGettingFromRemote)
+        aliceState = alice.currentStateForUi();
+        expect(aliceState.localGettingFromRemote)
             .toEqual(social.GettingState.GETTING_ACCESS);
         done();
       });
+      aliceState = alice.currentStateForUi();
       expect(socks_to_rtc.SocksToRtc).toHaveBeenCalled();
-      expect(alice.localGettingFromRemote)
+      expect(aliceState.localGettingFromRemote)
           .toEqual(social.GettingState.TRYING_TO_GET_ACCESS);
     });
 
     it('can stop proxying', () => {
       alice.stop();
-      expect(alice.localGettingFromRemote).toEqual(social.GettingState.NONE);
+      var aliceState = alice.currentStateForUi();
+      expect(aliceState.localGettingFromRemote).toEqual(social.GettingState.NONE);
     });
 
     it('refuses to start proxy without permission', () => {
       spyOn(socks_to_rtc, 'SocksToRtc').and.returnValue(fakeSocksToRtc);
       alice.wireConsentFromRemote.isOffering = false;
-      alice.localGettingFromRemote = social.GettingState.NONE;
       alice.start();
-      expect(alice.localGettingFromRemote).toEqual(social.GettingState.NONE);
+      var aliceState = alice.currentStateForUi();
+      expect(aliceState.localGettingFromRemote).toEqual(social.GettingState.NONE);
     });
 
     // This test no longer passes with the hack to use

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -435,6 +435,7 @@ import Persistent = require('../interfaces/persistent');
         localSharingWithRemote: connectionState.localSharingWithRemote,
         bytesSent:              connectionState.bytesSent,
         bytesReceived:          connectionState.bytesReceived,
+        activeEndpoint:         connectionState.activeEndpoint,
       };
     }
 

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -57,13 +57,8 @@ import Persistent = require('../interfaces/persistent');
     // Client version of the remote peer.
     public messageVersion :number;
 
-    public bytesSent   :number = 0;
-    public bytesReceived    :number = 0;
     // Current proxy access activity of the remote instance with respect to the
     // local instance of uProxy.
-    public localGettingFromRemote = social.GettingState.NONE;
-    public localSharingWithRemote = social.SharingState.NONE;
-
     public wireConsentFromRemote :social.ConsentWireState = {
       isRequesting: false,
       isOffering: false
@@ -162,10 +157,6 @@ import Persistent = require('../interfaces/persistent');
           });
           break;
         case uproxy_core_api.Update.STATE:
-          this.bytesSent = data.bytesSent;
-          this.bytesReceived = data.bytesReceived;
-          this.localGettingFromRemote = data.localGettingFromRemote;
-          this.localSharingWithRemote = data.localSharingWithRemote;
           this.user.notifyUI();
           break;
         default:
@@ -185,7 +176,7 @@ import Persistent = require('../interfaces/persistent');
     }
 
     public isSharing = () => {
-      return this.localSharingWithRemote === social.SharingState.SHARING_ACCESS;
+      return this.connection_.localSharingWithRemote === social.SharingState.SHARING_ACCESS;
     }
 
     /**
@@ -268,7 +259,7 @@ import Persistent = require('../interfaces/persistent');
       */
     private startShare_ = () : void => {
       var sharingStopped :Promise<void>;
-      if (this.localSharingWithRemote === social.SharingState.NONE) {
+      if (this.connection_.localSharingWithRemote === social.SharingState.NONE) {
         // Stop any existing sharing attempts with this instance.
         sharingStopped = Promise.resolve<void>();
       } else {
@@ -305,12 +296,12 @@ import Persistent = require('../interfaces/persistent');
     }
 
     public stopShare = () :Promise<void> => {
-      if (this.localSharingWithRemote === social.SharingState.NONE) {
+      if (this.connection_.localSharingWithRemote === social.SharingState.NONE) {
         log.warn('Cannot stop sharing while currently not sharing.');
         return Promise.resolve<void>();
       }
 
-      if (this.localSharingWithRemote === social.SharingState.TRYING_TO_SHARE_ACCESS) {
+      if (this.connection_.localSharingWithRemote === social.SharingState.TRYING_TO_SHARE_ACCESS) {
         clearTimeout(this.startRtcToNetTimeout_);
       }
       return this.connection_.stopShare();
@@ -434,14 +425,16 @@ import Persistent = require('../interfaces/persistent');
     // TODO: bad smell: remote-instance should not need to know the structure of
     // UI message data. Maybe rename to |getInstanceData|?
     public currentStateForUi = () :social.InstanceData => {
+      var connectionState = this.connection_.getCurrentState();
+
       return {
         instanceId:             this.instanceId,
         description:            this.description,
-        localGettingFromRemote: this.localGettingFromRemote,
-        localSharingWithRemote: this.localSharingWithRemote,
         isOnline:               this.user.isInstanceOnline(this.instanceId),
-        bytesSent:              this.bytesSent,
-        bytesReceived:          this.bytesReceived
+        localGettingFromRemote: connectionState.localGettingFromRemote,
+        localSharingWithRemote: connectionState.localSharingWithRemote,
+        bytesSent:              connectionState.bytesSent,
+        bytesReceived:          connectionState.bytesReceived,
       };
     }
 

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -573,8 +573,8 @@ var log :logging.Log = new logging.Log('remote-user');
         // stop the proxy session.
         if (uproxy_core_api.ConsentUserAction.CANCEL_OFFER === action) {
           for (var instanceId in this.instances_) {
-            if (this.instances_[instanceId].localSharingWithRemote ==
-                social.SharingState.SHARING_ACCESS) {
+            var instanceData = this.instances_[instanceId].currentStateForUi();
+            if (instanceData.localSharingWithRemote == social.SharingState.SHARING_ACCESS) {
               this.instances_[instanceId].stopShare();
             }
           }

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -230,14 +230,17 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   public getFullState = () :Promise<uproxy_core_api.InitialState> => {
     return globals.loadSettings.then(() => {
+      var copyPasteConnectionState = copyPasteConnection.getCurrentState();
+
       return {
         networkNames: Object.keys(social_network.networks),
         globalSettings: globals.settings,
         onlineNetworks: social_network.getOnlineNetworks(),
         availableVersion: this.availableVersion_,
+        copyPasteConnection: copyPasteConnectionState,
         copyPasteState: {
-          connectionState: copyPasteConnection.getCurrentState(),
-          endpoint: copyPasteConnection.activeEndpoint
+          connectionState: copyPasteConnectionState,
+          endpoint: copyPasteConnectionState.activeEndpoint,
         },
         portControlSupport: this.portControlSupport_,
       };

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -69,7 +69,7 @@
         </span>
       </uproxy-app-bar>
 
-      <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.BAD_URL }}' on-closed='{{ dismissError }}' class='error'>
+      <uproxy-bubble active='{{ ui.copyPasteState.error === ui_constants.CopyPasteError.BAD_URL }}' on-closed='{{ dismissError }}' class='error'>
         {{ 'ERROR_PARSING_LINK' | $$ }}
       </uproxy-bubble>
 
@@ -91,7 +91,7 @@
                 </uproxy-button>
               </div>
 
-              <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.FAILED }}' on-closed='{{ dismissError }}' class='error'>
+              <uproxy-bubble active='{{ ui.copyPasteState.error === ui_constants.CopyPasteError.FAILED }}' on-closed='{{ dismissError }}' class='error'>
                 {{ 'ERROR_STARTING_CONNECTION' | $$ }}
               </uproxy-bubble>
 
@@ -107,7 +107,7 @@
                   </p>
 
                   <paper-input-decorator label="{{ 'LOADING' | $$ }}" layout vertical>
-                    <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/request/{{ ui.copyPasteMessage | encodeMessage }}' />
+                    <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/request/{{ ui.copyPasteState.message | encodeMessage }}' />
                   </paper-input-decorator>
                 </div>
 
@@ -132,27 +132,27 @@
                 <p>{{ 'ONE_TIME_GETTING_SUCCESS' | $$ }}</p>
 
                 <p>
-                  <span hidden?='{{ ui.copyPastePendingEndpoint === null}}'>
+                  <span hidden?='{{ ui.copyPasteState.pendingEndpoint === null}}'>
                     {{ 'START_ONE_TIME_INSTRUCTION' | $$ }}
                   </span>
-                  <span hidden?='{{ ui.copyPastePendingEndpoint !== null}}'>
+                  <span hidden?='{{ ui.copyPasteState.pendingEndpoint !== null}}'>
                     {{ 'STOP_ONE_TIME_INSTRUCTION' | $$ }}
                   </span>
                 </p>
 
                 <div class='centered'>
                   <uproxy-button raised on-tap='{{ startProxying }}'
-                      hidden?='{{ ui.copyPastePendingEndpoint === null }}'>
+                      hidden?='{{ ui.copyPasteState.pendingEndpoint === null }}'>
                     {{ 'START_GETTING' | $$ }}
                   </uproxy-button>
 
                   <uproxy-button raised class='grey' on-tap='{{ stopGetting }}'
-                      hidden?='{{ ui.copyPastePendingEndpoint !== null }}'>
+                      hidden?='{{ ui.copyPasteState.pendingEndpoint !== null }}'>
                     {{ 'STOP_GETTING' | $$ }}
                   </uproxy-button>
                 </div>
 
-                <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}'>
+                <uproxy-bubble active='{{ ui.copyPasteState.error === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}'>
                   <p>{{ 'ONE_TIME_GETTING' | $$ }}</p>
                   <p>
                     {{ 'STOP_ONE_TIME_GETTING_BEFORE_NEW' | $$ }}
@@ -171,13 +171,13 @@
 
 
                 <paper-input-decorator label="{{ 'LOADING' | $$ }}" layout vertical>
-                  <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/offer/{{ ui.copyPasteMessage | encodeMessage }}' />
+                  <input readonly is='core-input' on-tap='{{ select }}' value='https://www.uproxy.org/offer/{{ ui.copyPasteState.message | encodeMessage }}' />
                 </paper-input-decorator>
 
                 <div>
                   <a href='#' on-tap='{{ switchToGetting }}'>{{ 'GET_ONE_TIME_INSTEAD' | $$ }}</a>
 
-                  <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}'>
+                  <uproxy-bubble active='{{ ui.copyPasteState.error === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}'>
                     <p>
                       {{ 'TRYING_TO_SHARE_ONE_TIME' | $$ }}
                     </p>
@@ -197,7 +197,7 @@
 
                 <uproxy-button raised class='grey' on-tap='{{ stopSharing }}'>{{ 'STOP_ONE_TIME_SHARING' | $$ }}</uproxy-button>
 
-                <uproxy-bubble active='{{ ui.copyPasteError === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}' class='error'>
+                <uproxy-bubble active='{{ ui.copyPasteState.error === ui_constants.CopyPasteError.UNEXPECTED }}' on-closed='{{ dismissError }}' class='error'>
                   <p>{{ 'ONE_TIME_SHARING' | $$ }}</p>
 
                   <p>
@@ -209,7 +209,7 @@
           </div> <!-- #wrapper -->
 
           <div id='status'>
-            <div class='statusRow' hidden?='{{ ui.copyPasteState.localGettingFromRemote !== GettingState.GETTING_ACCESS || ui.copyPastePendingEndpoint !== null }}'>
+            <div class='statusRow' hidden?='{{ ui.copyPasteState.localGettingFromRemote !== GettingState.GETTING_ACCESS || ui.copyPasteState.pendingEndpoint !== null }}'>
               <div class='statusText'>
                 <core-icon icon='uproxy-icons:receive'></core-icon>
                 {{ 'GETTING_ACCESS_FROM_FRIEND' | $$ }}

--- a/src/generic_ui/polymer/copypaste.html
+++ b/src/generic_ui/polymer/copypaste.html
@@ -132,22 +132,22 @@
                 <p>{{ 'ONE_TIME_GETTING_SUCCESS' | $$ }}</p>
 
                 <p>
-                  <span hidden?='{{ ui.copyPasteState.pendingEndpoint === null}}'>
+                  <span hidden?='{{ ui.copyPasteState.active === true }}'>
                     {{ 'START_ONE_TIME_INSTRUCTION' | $$ }}
                   </span>
-                  <span hidden?='{{ ui.copyPasteState.pendingEndpoint !== null}}'>
+                  <span hidden?='{{ ui.copyPasteState.active !== true }}'>
                     {{ 'STOP_ONE_TIME_INSTRUCTION' | $$ }}
                   </span>
                 </p>
 
                 <div class='centered'>
                   <uproxy-button raised on-tap='{{ startProxying }}'
-                      hidden?='{{ ui.copyPasteState.pendingEndpoint === null }}'>
+                      hidden?='{{ ui.copyPasteState.active === true }}'>
                     {{ 'START_GETTING' | $$ }}
                   </uproxy-button>
 
                   <uproxy-button raised class='grey' on-tap='{{ stopGetting }}'
-                      hidden?='{{ ui.copyPasteState.pendingEndpoint !== null }}'>
+                      hidden?='{{ ui.copyPasteState.active !== true }}'>
                     {{ 'STOP_GETTING' | $$ }}
                   </uproxy-button>
                 </div>
@@ -209,7 +209,7 @@
           </div> <!-- #wrapper -->
 
           <div id='status'>
-            <div class='statusRow' hidden?='{{ ui.copyPasteState.localGettingFromRemote !== GettingState.GETTING_ACCESS || ui.copyPasteState.pendingEndpoint !== null }}'>
+            <div class='statusRow' hidden?='{{ ui.copyPasteState.localGettingFromRemote !== GettingState.GETTING_ACCESS || ui.copyPasteState.active !== true }}'>
               <div class='statusText'>
                 <core-icon icon='uproxy-icons:receive'></core-icon>
                 {{ 'GETTING_ACCESS_FROM_FRIEND' | $$ }}

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -42,13 +42,13 @@ Polymer({
     }
 
     doneStopping.then(() => {
-      ui.copyPasteMessage = '';
-      ui.copyPasteError = ui_constants.CopyPasteError.NONE;
-      ui.copyPastePendingEndpoint = null;
+      ui.copyPasteState.message = '';
+      ui.copyPasteState.error = ui_constants.CopyPasteError.NONE;
+      ui.copyPasteState.pendingEndpoint = null;
 
       return core.startCopyPasteGet();
     }).then((endpoint) => {
-      ui.copyPastePendingEndpoint = endpoint;
+      ui.copyPasteState.pendingEndpoint = endpoint;
     }).catch((e) => {
       // TODO we will see this any time the connection is aborted by the user or
       // when something actually goes wrong with the connection.  We should
@@ -57,7 +57,7 @@ Polymer({
       // an error, so we are just going to warn about it.
 
       console.warn('error when starting copy+paste get', e);
-      ui.copyPasteError = ui_constants.CopyPasteError.FAILED;
+      ui.copyPasteState.error = ui_constants.CopyPasteError.FAILED;
     });
   },
   handleBackClick: function() {
@@ -83,11 +83,11 @@ Polymer({
     ui.stopUsingProxy();
     return core.stopCopyPasteGet().then(() => {
       // clean up the pending endpoint in case we got here from going back
-      ui.copyPastePendingEndpoint = null;
+      ui.copyPasteState.pendingEndpoint = null;
     });
   },
   startProxying: function() {
-    if (!ui.copyPastePendingEndpoint) {
+    if (!ui.copyPasteState.pendingEndpoint) {
       console.error('Attempting to start copy+paste proxying without a pending endpoint');
       return;
     }
@@ -97,8 +97,8 @@ Polymer({
       return;
     }
 
-    ui.startGettingInUiAndConfig(null, ui.copyPastePendingEndpoint);
-    ui.copyPastePendingEndpoint = null;
+    ui.startGettingInUiAndConfig(null, ui.copyPasteState.pendingEndpoint);
+    ui.copyPasteState.pendingEndpoint = null;
   },
   switchToGetting: function() {
     this.stopSharing().then(() => {
@@ -114,7 +114,7 @@ Polymer({
     sender.select();
   },
   dismissError: function() {
-    ui.copyPasteError = ui_constants.CopyPasteError.NONE;
+    ui.copyPasteState.error = ui_constants.CopyPasteError.NONE;
   },
   exitMode: function() {
     // if we are currently in the middle of setting up a connection, end it

--- a/src/generic_ui/polymer/copypaste.ts
+++ b/src/generic_ui/polymer/copypaste.ts
@@ -44,11 +44,10 @@ Polymer({
     doneStopping.then(() => {
       ui.copyPasteState.message = '';
       ui.copyPasteState.error = ui_constants.CopyPasteError.NONE;
-      ui.copyPasteState.pendingEndpoint = null;
 
       return core.startCopyPasteGet();
     }).then((endpoint) => {
-      ui.copyPasteState.pendingEndpoint = endpoint;
+      ui.copyPasteState.activeEndpoint = endpoint;
     }).catch((e) => {
       // TODO we will see this any time the connection is aborted by the user or
       // when something actually goes wrong with the connection.  We should
@@ -81,13 +80,10 @@ Polymer({
   },
   stopGetting: function() {
     ui.stopUsingProxy();
-    return core.stopCopyPasteGet().then(() => {
-      // clean up the pending endpoint in case we got here from going back
-      ui.copyPasteState.pendingEndpoint = null;
-    });
+    return core.stopCopyPasteGet();
   },
   startProxying: function() {
-    if (!ui.copyPasteState.pendingEndpoint) {
+    if (!ui.copyPasteState.activeEndpoint) {
       console.error('Attempting to start copy+paste proxying without a pending endpoint');
       return;
     }
@@ -97,8 +93,8 @@ Polymer({
       return;
     }
 
-    ui.startGettingInUiAndConfig(null, ui.copyPasteState.pendingEndpoint);
-    ui.copyPasteState.pendingEndpoint = null;
+    ui.copyPasteState.active = true;
+    ui.startGettingInUiAndConfig(null, ui.copyPasteState.activeEndpoint);
   },
   switchToGetting: function() {
     this.stopSharing().then(() => {

--- a/src/generic_ui/scripts/copypaste-state.spec.ts
+++ b/src/generic_ui/scripts/copypaste-state.spec.ts
@@ -13,6 +13,7 @@ describe('CopyPasteState', () => {
       localSharingWithRemote: social.SharingState.SHARING_ACCESS,
       bytesSent: 1,
       bytesReceived: 2,
+      activeEndpoint: null,
     };
 
     state.updateFromConnectionState(update);

--- a/src/generic_ui/scripts/copypaste-state.spec.ts
+++ b/src/generic_ui/scripts/copypaste-state.spec.ts
@@ -1,0 +1,23 @@
+/// <reference path='../../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import CopyPasteState = require('./copypaste-state');
+import social = require('../../interfaces/social');
+import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+
+describe('CopyPasteState', () => {
+  it('correctly handles update', () => {
+    var state = new CopyPasteState();
+
+    var update :uproxy_core_api.ConnectionState = {
+      localGettingFromRemote: social.GettingState.TRYING_TO_GET_ACCESS,
+      localSharingWithRemote: social.SharingState.SHARING_ACCESS,
+      bytesSent: 1,
+      bytesReceived: 2,
+    };
+
+    state.updateFromConnectionState(update);
+
+    expect(state.localGettingFromRemote).toEqual(update.localGettingFromRemote);
+    expect(state.localSharingWithRemote).toEqual(update.localSharingWithRemote);
+  });
+});

--- a/src/generic_ui/scripts/copypaste-state.ts
+++ b/src/generic_ui/scripts/copypaste-state.ts
@@ -17,6 +17,7 @@ class CopyPasteState {
   public updateFromConnectionState = (state :uproxy_core_api.ConnectionState) :void => {
     this.localGettingFromRemote = state.localGettingFromRemote;
     this.localSharingWithRemote = state.localSharingWithRemote;
+    this.activeEndpoint = state.activeEndpoint;
   }
 }
 

--- a/src/generic_ui/scripts/copypaste-state.ts
+++ b/src/generic_ui/scripts/copypaste-state.ts
@@ -10,8 +10,9 @@ class CopyPasteState {
   public localGettingFromRemote :social.GettingState = social.GettingState.NONE;
   public localSharingWithRemote :social.SharingState = social.SharingState.NONE;
   public error :ui_constants.CopyPasteError = ui_constants.CopyPasteError.NONE;
-  public pendingEndpoint :net.Endpoint = null;
   public message :string = null;
+  public activeEndpoint :net.Endpoint = null;
+  public active :boolean = false;
 
   public updateFromConnectionState = (state :uproxy_core_api.ConnectionState) :void => {
     this.localGettingFromRemote = state.localGettingFromRemote;

--- a/src/generic_ui/scripts/copypaste-state.ts
+++ b/src/generic_ui/scripts/copypaste-state.ts
@@ -1,0 +1,22 @@
+import net = require('../../../../third_party/uproxy-lib/net/net.types');
+import social = require('../../interfaces/social');
+import ui_constants = require('../../interfaces/ui');
+import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+
+/**
+ * Simple utility struct to keep track of state for the copy+paste connection
+ */
+class CopyPasteState {
+  public localGettingFromRemote :social.GettingState = social.GettingState.NONE;
+  public localSharingWithRemote :social.SharingState = social.SharingState.NONE;
+  public error :ui_constants.CopyPasteError = ui_constants.CopyPasteError.NONE;
+  public pendingEndpoint :net.Endpoint = null;
+  public message :string = null;
+
+  public updateFromConnectionState = (state :uproxy_core_api.ConnectionState) :void => {
+    this.localGettingFromRemote = state.localGettingFromRemote;
+    this.localSharingWithRemote = state.localSharingWithRemote;
+  }
+}
+
+export = CopyPasteState;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -259,6 +259,8 @@ export class UserInterface implements ui_constants.UiApi {
 
     // indicates the current getting connection has ended
     core.onUpdate(uproxy_core_api.Update.STOP_GETTING, (error :boolean) => {
+      this.copyPasteState.activeEndpoint = null;
+      this.copyPasteState.active = false;
       this.stoppedGetting({instanceId: null, error: error});
     });
 
@@ -1075,7 +1077,7 @@ export class UserInterface implements ui_constants.UiApi {
 
     // Maybe refactor this to be copyPasteState.
     this.copyPasteState.updateFromConnectionState(state.copyPasteState.connectionState);
-    this.copyPasteState.pendingEndpoint = state.copyPasteState.endpoint;
+    this.copyPasteState.activeEndpoint = state.copyPasteState.endpoint;
 
     while (this.model.onlineNetworks.length > 0) {
       var toRemove = this.model.onlineNetworks[0];

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1076,8 +1076,7 @@ export class UserInterface implements ui_constants.UiApi {
     this.model.updateGlobalSettings(state.globalSettings);
 
     // Maybe refactor this to be copyPasteState.
-    this.copyPasteState.updateFromConnectionState(state.copyPasteState.connectionState);
-    this.copyPasteState.activeEndpoint = state.copyPasteState.endpoint;
+    this.copyPasteState.updateFromConnectionState(state.copyPasteConnection);
 
     while (this.model.onlineNetworks.length > 0) {
       var toRemove = this.model.onlineNetworks[0];

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -916,12 +916,10 @@ export class UserInterface implements ui_constants.UiApi {
       var gettingState = payload.offeringInstances[i].localGettingFromRemote;
       var instanceId = payload.offeringInstances[i].instanceId;
       if (gettingState === social.GettingState.GETTING_ACCESS) {
-        this.instanceGettingAccessFrom_ = instanceId;
-        user.isSharingWithMe = true;
-        this.updateGettingStatusBar_();
+        this.startGettingInUiAndConfig(instanceId, payload.offeringInstances[i].activeEndpoint);
         break;
       } else if (gettingState === social.GettingState.TRYING_TO_GET_ACCESS) {
-        this. instanceTryingToGetAccessFrom = instanceId;
+        this.instanceTryingToGetAccessFrom = instanceId;
         this.updateGettingStatusBar_();
         break;
       }

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -29,7 +29,8 @@ describe('UI.User', () => {
       localGettingFromRemote: social.GettingState.NONE,
       isOnline: true,
       bytesSent: 0,
-      bytesReceived: 0
+      bytesReceived: 0,
+      activeEndpoint: null,
     };
   }
 

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -69,6 +69,7 @@ export interface InstanceData {
   isOnline               :boolean;
   localGettingFromRemote :GettingState;
   localSharingWithRemote :SharingState;
+  activeEndpoint         :net.Endpoint;
 }
 
 export interface UserData {

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -41,7 +41,8 @@ export interface InitialState {
   globalSettings :GlobalSettings;
   onlineNetworks :social.NetworkState[];
   availableVersion :string;
-  copyPasteState :CopyPasteState;
+  copyPasteState :CopyPasteState; //TODO(jpevarnek): remove this property
+  copyPasteConnection :ConnectionState;
   portControlSupport :PortControlSupport;
 }
 
@@ -50,8 +51,10 @@ export interface ConnectionState {
   localSharingWithRemote :social.SharingState;
   bytesSent :number;
   bytesReceived :number;
+  activeEndpoint :net.Endpoint;
 }
 
+//TODO(jpevarnek) remove this interface
 export interface CopyPasteState {
   connectionState :ConnectionState;
   endpoint :net.Endpoint;


### PR DESCRIPTION
Do a better job of keeping track of the endpoints for active connections, send that information to the UI, and use it to re-enable a proxying connection on extension restart.

Tested manually and by running `grunt test`.

See commit messages for a more detailed view of what was done.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1921)
<!-- Reviewable:end -->
