### PR TITLE
migrate to latest uproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^32.0.0",
+    "uproxy-lib": "^33.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },


### PR DESCRIPTION
No change in behaviour, the major version bump was just for a bunch of files that moved around during a big refactor.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1926)
<!-- Reviewable:end -->
