### PR TITLE
Fix Firefox URL matching

### DIFF
--- a/src/firefox/lib/url-handler.js
+++ b/src/firefox/lib/url-handler.js
@@ -10,9 +10,9 @@ exports.setup = function(panel, button) {
       subject.QueryInterface(Ci.nsIHttpChannel);
       var url = subject.URI.spec
 
-      if (/https:\/\/www.uproxy.org\/(request|offer)\/(.*)/.test(url)) {
+      if (/^https:\/\/www.uproxy.org\/(request|offer)\/(.*)/.test(url)) {
         panel.port.emit('copyPasteUrlData', url);
-      } else if (/https:\/\/www.uproxy.org\/invite\/(.*)/.test(url)) {
+      } else if (/^https:\/\/www.uproxy.org\/invite\/(.*)/.test(url)) {
         panel.port.emit('inviteUrlData', url);
       } else {
         return;


### PR DESCRIPTION
Fix Firefox URL matching.

Previously URLs used in the Facebook send dialog were triggering the URL handler, resulting in errors.

e.g. this URL should not trigger the event handlers anymore:
```https://www.facebook.com/dialog/send?app_id=%20161927677344933&link=https://www.uproxy.org/invite/eyJ2IjoxLCJuZXR3b3JrTmFtZSI6IkZhY2Vib29rLUZpcmViYXNlLVYyIiwidXNlck5hbWUiOiJEYW5pZWwgQm9ya2FuIiwibmV0d29ya0RhdGEiOiJ7XCJ2XCI6MSxcInVzZXJJZFwiOlwiNjcwNjg0OFwiLFwicGVybWlzc2lvblRva2VuXCI6MTk0NTcxMTYwNzF9In0=&redirect_uri=https://www.uproxy.org/```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1933)
<!-- Reviewable:end -->
