### PR TITLE
migrate to travis containers for faster build start times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ install:
   - ./setup.sh install
 script:
   - grunt test
+sudo: false


### PR DESCRIPTION
As per:
https://github.com/uProxy/uproxy-lib/pull/264

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1953)
<!-- Reviewable:end -->
