### PR TITLE
Add "Analyze NAT" button to Advanced Settings page #1176

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -303,6 +303,10 @@
     "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team.",
     "message": "Analyze network and include logs"
   },
+  "ANALYZE_NAT": {
+    "description": "Analyze network settings uProxy logs",
+    "message": "Analyze NAT"
+  },
   "P_I_I_MESSAGE": {
     "description": "Message helping make sure the user understands that personally identifiable information may be included in their feedback to uProxy.",
     "message": "Your feedback and email address will be sent to uProxy.org. Your logs, network information and email may include personally identifiable information."

--- a/src/generic_ui/polymer/advanced-settings.html
+++ b/src/generic_ui/polymer/advanced-settings.html
@@ -37,6 +37,27 @@
       color: grey;
       margin-top: 1em;
     }
+    #analyzeNAT{
+      width: 100%;
+      border-bottom: 1px solid rgb(221, 221, 221);
+      padding: 20px 30px;
+      text-align: start;
+      overflow: auto;
+      color: #009688;
+    }
+    #analyzeNAT core-icon {
+      height: 15px !important;
+      color: grey;
+      opacity: 0.6;
+      margin-bottom: 2px;
+      margin-right: 0px;
+      -webkit-transition: all 0.23s !important;
+      -moz-transition: all 0.23s !important;
+      transition: all 0.23s !important;
+    }
+    #analyzeNAT core-icon:hover {
+      opacity: 1;
+    }
     #setAdvancedSettings {
       width: 100%;
       padding-top: 1.5em;
@@ -117,7 +138,16 @@
         <uproxy-app-bar on-go-back='{{ close }}'>
           {{ "ADVANCED_SETTINGS_SENTENCE_CASE" | $$ }}
         </uproxy-app-bar>
+        <div id='analyzeNAT'>
+          <p class='inputLabel'> <uproxy-link on-tap='{{ viewLogs }}'>
+            {{ "ANALYZE_NAT" | $$ }} </uproxy-link>
+            <uproxy-faq-link anchor='doesUproxyLogData'>
+              <core-icon icon="help"></core-icon>
+            </uproxy-faq-link>
+          </p>
+        </div>
         <div id='portControlBox'>
+
           <p class='inputLabel'>
             {{ 'PORT_CONTROL_TITLE' | $$ }}
             <uproxy-faq-link anchor='whatIsPortControl'>

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -8,6 +8,7 @@
 
 var ui = ui_context.ui;
 var core = ui_context.core;
+var model = ui_context.model;
 
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 
@@ -66,9 +67,13 @@ Polymer({
       this.status = StatusState.PARSE_ERROR;
     }
   },
+  viewLogs: function() {
+    this.ui.openTab('generic_ui/view-logs.html?lang=' + this.model.globalSettings.language);
+  },
   ready: function() {
     this.ui = ui;
     this.uproxy_core_api = uproxy_core_api;
+    this.model = model;
   },
   refreshPortControl: function() {
     core.refreshPortControlSupport();


### PR DESCRIPTION
Per: https://github.com/uProxy/uproxy/issues/1176

Added "Analyze NAT" button to Advanced Settings page, modified three files: 
advanced_settings.html, advanced_settings.ts, messages.json (english)


Result:
![screen shot 2015-10-14 at 2 34 30 pm](https://cloud.githubusercontent.com/assets/1848042/10495324/d3f67e32-7280-11e5-873f-bfef3b505d9c.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1966)
<!-- Reviewable:end -->
