### PR TITLE
Quiver fixes + cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "freedom-social-xmpp": "^0.4.0",
     "freedom-social-github": "^0.1.3",
     "freedom-social-wechat": "^0.1.5",
-    "freedom-social-quiver": "=0.0.0",
+    "freedom-social-quiver": "^0.0.2",
     "freedomjs-anonymized-metrics": "~0.1.0",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",

--- a/src/generic/network-options.ts
+++ b/src/generic/network-options.ts
@@ -52,7 +52,7 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     isFirebase: false,
     enableMonitoring: false,
     areAllContactsUproxy: true,
-    supportsReconnect: false,
+    supportsReconnect: true,
     supportsInvites: true,
     isExperimental: true
   }

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -44,7 +44,8 @@ export var settings :uproxy_core_api.GlobalSettings = {
   force_message_version: 0, // zero means "don't override"
   // TODO: remove this in November 2015, to allow 1 month for existing users to
   // see the notification that Google+Facebook social providers have changed.
-  hasSeenGoogleAndFacebookChangedNotification: false
+  hasSeenGoogleAndFacebookChangedNotification: false,
+  quiverUserName: ''
 };
 
 export var natType :string = '';

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -499,13 +499,17 @@ export function notifyUI(networkName :string, userId :string) {
           rememberLogin: !reconnect
         };
       } else if (this.name === 'Quiver') {
-        // TODO: remove this crazy hack of passing userName in the version
+        if (!userName) {
+          // userName may not be passed in for reconnect.
+          userName = globals.settings.quiverUserName;
+        }
         request = {
           agent: 'uproxy',
-          version: JSON.stringify({userId: userName}),
+          version: '0.1',
           url: 'https://github.com/uProxy/uProxy',
           interactive: !reconnect,
-          rememberLogin: !reconnect
+          rememberLogin: !reconnect,
+          userName: userName
         };
       } else {
         request = {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -66,7 +66,9 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
     this.refreshPortControlSupport();
 
-    this.connectedNetworks_.get().then((networks :string[]) => {
+    globals.loadSettings.then(() => {
+      return this.connectedNetworks_.get();
+    }).then((networks :string[]) => {
       var logins :Promise<void>[] = [];
 
       for (var i in networks) {
@@ -234,6 +236,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     globals.settings.force_message_version = newSettings.force_message_version;
     globals.settings.hasSeenGoogleAndFacebookChangedNotification =
         newSettings.hasSeenGoogleAndFacebookChangedNotification;
+    globals.settings.quiverUserName = newSettings.quiverUserName;
   }
 
   public getFullState = () :Promise<uproxy_core_api.InitialState> => {

--- a/src/generic_ui/polymer/network-in-settings.ts
+++ b/src/generic_ui/polymer/network-in-settings.ts
@@ -14,6 +14,10 @@ Polymer({
     this.networkInfo = network ? network : null;
   },
   connect: function() {
+    if (this.name == 'Quiver') {
+      this.fire('core-signal', { name: 'open-quiver-login-dialog' });
+      return;
+    }
     ui.login(this.name).catch((e :Error) => {
       console.warn('Did not log in', e);
     });

--- a/src/generic_ui/polymer/network.ts
+++ b/src/generic_ui/polymer/network.ts
@@ -9,9 +9,8 @@ var model = ui_context.model;
 
 Polymer({
   connect: function() {
-    // TODO: clean this up, make generic!
     if (this.networkName == 'Quiver') {
-      this.fire('core-signal', {name: 'show-quiver-login'});
+      this.fire('core-signal', {name: 'open-quiver-login-dialog'});
       return;
     }
 

--- a/src/generic_ui/polymer/quiver-login.html
+++ b/src/generic_ui/polymer/quiver-login.html
@@ -1,0 +1,55 @@
+<link rel='import' href='../../bower/core-icons/core-icons.html'>
+<link rel='import' href='../../bower/core-overlay/core-overlay.html'>
+<link rel="import" href="../../bower/core-signals/core-signals.html">
+<link rel='import' href='../../bower/paper-dropdown-menu/paper-dropdown-menu.html'>
+<link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
+<link rel='import' href='../../bower/polymer/polymer.html'>
+<link rel='import' href='button.html'>
+<link rel="import" href="i18n-filter.html">
+
+<polymer-element name='uproxy-quiver-login'>
+  <template>
+    <style>
+      #quiverLoginPanel {
+        height: 100%;
+        width: 100%;
+        background-color: white;
+      }
+      h1 {
+        font-size: 1.4em;
+        color: #009688;  /* dark green */
+      }
+      #contents {
+        margin: 2em;
+        line-height: 20px;
+      }
+      uproxy-button {
+        margin: 0;
+        padding-left: 1em;
+        padding-right: 1em;
+      }
+      paper-input-decorator {
+        font-size: 16px;
+      }
+    </style>
+
+    <core-signals on-core-signal-open-quiver-login-dialog='{{ openQuiverLoginPanel }}'></core-signals>
+
+    <core-overlay id='quiverLoginPanel'>
+      <!-- TODO: translate everything before launching on webstore -->
+
+      <uproxy-app-bar on-go-back='{{ closeQuiverLoginPanel }}'>
+        Login to Quiver
+      </uproxy-app-bar>
+
+      <div id='contents'>
+        <h1>Please enter your name</h1>
+        <paper-input-decorator label="name" layout vertical>
+          <input is='core-input' value='{{ userName }}' />
+        </paper-input-decorator>
+        <uproxy-button raised on-tap='{{ loginToQuiver }}'>Connect</uproxy-button>
+      </div>
+
+  </template>
+  <script src='quiver-login.js'></script>
+</polymer-element>

--- a/src/generic_ui/polymer/quiver-login.ts
+++ b/src/generic_ui/polymer/quiver-login.ts
@@ -1,0 +1,36 @@
+/// <reference path='./context.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+
+var ui = ui_context.ui;
+var model = ui_context.model;
+var core = ui_context.core;
+
+declare var require: (path: string) => Object;
+import ui_constants = require('../../interfaces/ui');
+
+Polymer({
+  loginToQuiver: function() {
+    console.log('loginToQuiver called, ' + this.userName);  // TODO: remove
+    model.globalSettings.quiverUserName = this.userName;
+    core.updateGlobalSettings(model.globalSettings);
+    ui.login('Quiver', this.userName).then(() => {
+      // Fire an update-view event, which root.ts listens for.
+      // TODO: is this a duplicate?
+      this.fire('update-view', { view: ui_constants.View.ROSTER });
+      this.closeQuiverLoginPanel();
+    }).catch((e: Error) => {
+      // TODO: display error on screen?
+      console.warn('Did not log in ', e);
+    });
+  },
+  openQuiverLoginPanel: function() {
+    this.userName = model.globalSettings.quiverUserName;
+    this.$.quiverLoginPanel.open();
+  },
+  closeQuiverLoginPanel: function() {
+    this.$.quiverLoginPanel.close();
+  },
+  ready: function() {
+    this.userName = '';
+  }
+});

--- a/src/generic_ui/polymer/quiver-login.ts
+++ b/src/generic_ui/polymer/quiver-login.ts
@@ -15,11 +15,9 @@ Polymer({
     core.updateGlobalSettings(model.globalSettings);
     ui.login('Quiver', this.userName).then(() => {
       // Fire an update-view event, which root.ts listens for.
-      // TODO: is this a duplicate?
       this.fire('update-view', { view: ui_constants.View.ROSTER });
       this.closeQuiverLoginPanel();
     }).catch((e: Error) => {
-      // TODO: display error on screen?
       console.warn('Did not log in ', e);
     });
   },

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -27,6 +27,7 @@
 <link rel='import' href='icons.html'>
 <link rel='import' href='proxy-error.html'>
 <link rel='import' href='button.html'>
+<link rel='import' href='quiver-login.html'>
 
 <polymer-element name='uproxy-root' attributes='model' on-open-dialog='{{ openDialog }}'>
 
@@ -280,9 +281,10 @@
 
     <uproxy-advanced-settings id='advancedSettings'></uproxy-advanced-settings>
 
+    <!-- core-overlays, launched using core-signals -->
     <uproxy-invite-user></uproxy-invite-user>
-
     <uproxy-accept-user-invite></uproxy-accept-user-invite>
+    <uproxy-quiver-login></uproxy-quiver-login>
 
     <uproxy-splash id='splash' hidden?='{{ui_constants.View.SPLASH!=ui.view}}'>
     </uproxy-splash>

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -97,7 +97,7 @@
       margin-left: 8px;
       margin-right: 8px;
     }
-    #intro1, #networks, #quiverLogin {
+    #intro1, #networks {
       height: 100%;
     }
     #languageLink paper-dropdown-menu {
@@ -173,26 +173,6 @@
       </div>
       <uproxy-faq-link anchor='whyDoesUproxyConnect'>
         {{ "LEARN_MORE_SOCIAL" | $$ }}
-      </uproxy-faq-link>
-    </div>
-
-    <!-- TODO: should this be in root to work with settings login? -->
-    <core-signals on-core-signal-show-quiver-login="{{ showQuiverLogin }}"></core-signals>
-    <div vertical layout id='quiverLogin' hidden?='{{ SPLASH_STATES.QUIVER_LOGIN !== model.globalSettings.splashState }}'>
-       <!-- TODO: translate all text here -->
-      <div class='view' flex>
-
-        <h1>Set your display name</h1>
-
-        <paper-input-decorator label="name" layout vertical>
-          <input is='core-input' value='{{ userName }}' />
-        </paper-input-decorator>
-
-        <uproxy-button raised on-tap='{{ loginToQuiver }}'>Start</uproxy-button>
-
-      </div>
-      <uproxy-faq-link anchor='quiverLogin'>
-        Learn more
       </uproxy-faq-link>
     </div>
 

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -23,8 +23,7 @@ var model = ui_context.model;
 Polymer({
   SPLASH_STATES: {
     INTRO: 0,
-    NETWORKS: 1,
-    QUIVER_LOGIN: 2
+    NETWORKS: 1
   },
   setState: function(state :Number) {
     if (state < 0 || state > Object.keys(this.SPLASH_STATES).length) {
@@ -53,20 +52,6 @@ Polymer({
       window.location.reload();
     }
   },
-  showQuiverLogin: function() {
-    model.globalSettings.splashState = this.SPLASH_STATES.QUIVER_LOGIN;
-  },
-  loginToQuiver: function() {
-    console.log('loginToQuiver called, ' + this.userName);
-    ui.login('Quiver', this.userName).then(() => {
-      // Fire an update-view event, which root.ts listens for.
-      this.fire('update-view', { view: ui_constants.View.ROSTER });
-    }).catch((e :Error) => {
-      // TODO: why does this result in an error popup?
-      console.warn('Did not log in ', e);
-    });
-  },
-  userName: '',
   ready: function() {
     this.model = model;
     this.languages = languages;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -63,7 +63,8 @@ export class Model {
     consoleFilter: 2, // loggingTypes.Level.warn
     language: 'en',
     force_message_version: 0,
-    hasSeenGoogleAndFacebookChangedNotification: false
+    hasSeenGoogleAndFacebookChangedNotification: false,
+    quiverUserName: ''
   };
 
   public reconnecting = false;
@@ -854,7 +855,7 @@ export class UserInterface implements ui_constants.UiApi {
             this.supportsReconnect_(networkMsg.name) &&
             !this.core.disconnectedWhileProxying && !this.instanceGettingAccessFrom_) {
           console.warn('Unexpected logout, reconnecting to ' + networkMsg.name);
-          this.reconnect(networkMsg.name);
+          this.reconnect_(networkMsg.name);
         } else {
           if (this.instanceGettingAccessFrom_) {
             this.stopGettingFromInstance(this.instanceGettingAccessFrom_);
@@ -986,8 +987,9 @@ export class UserInterface implements ui_constants.UiApi {
     return this.core.logout(networkInfo);
   }
 
-  public reconnect = (network :string) => {
+  private reconnect_ = (network :string) => {
     this.model.reconnecting = true;
+    // TODO: add wechat, quiver, github URLs
     var pingUrl = network == 'Facebook'
         ? 'https://graph.facebook.com' : 'https://www.googleapis.com';
     this.core.pingUntilOnline(pingUrl).then(() => {
@@ -995,7 +997,6 @@ export class UserInterface implements ui_constants.UiApi {
       // haven't clicked to stop reconnecting while we were waiting for the
       // ping response).
       // TODO: this doesn't work quite right if the user is signed into multiple social networks
-      // FIXME: Preserve display name for Quiver
       if (this.model.reconnecting) {
         this.core.login({network: network, reconnect: true}).then(() => {
           // TODO: we don't necessarily want to hide the reconnect screen, as we might only be reconnecting to 1 of multiple disconnected networks

--- a/src/interfaces/social2.ts
+++ b/src/interfaces/social2.ts
@@ -40,18 +40,20 @@ export interface LoginRequest {
   // the same agent field will be listed as having status |ONLINE|, where
   // those with different agents will be listed as
   // |ONLINE_WITH_OTHER_CLIENT|
-  agent          :string;
+  agent :string;
   // Version of application
-  version        :string;
+  version :string;
   // URL of application
-  url            :string;
+  url :string;
   // When |interactive === true| social will always prompt user for login.
   // Promise fails if the user did not login or provided invalid
   // credentials. When |interactive === false|, promise fails unless the
   // social provider has  cached tokens/credentials.
-  interactive    :boolean;
+  interactive :boolean;
   // When true, social provider will remember the token/credentials.
-  rememberLogin  :boolean;
+  rememberLogin :boolean;
+  // UserName for logged in user.
+  userName ?:string;
 }
 
 // Interfaces for Freedom social API

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -36,6 +36,7 @@ export interface GlobalSettings {
   language         :string;
   force_message_version :number;
   hasSeenGoogleAndFacebookChangedNotification :boolean;
+  quiverUserName :string;
 }
 export interface InitialState {
   networkNames :string[];


### PR DESCRIPTION
* Store quiverUserName in global settings
* Support reconnect in Quiver (using stored name) from both UI (unexpected disconnect) and uProxy restart (https://github.com/uProxy/uproxy/issues/1954)
* Refactor Quiver login screen to be a core-overlay, instead of page within splash.html, to allow it to be re-used when logging in via the settings drawer (https://github.com/uProxy/uproxy/issues/1960)
* Add userName to social2 API to remove version hack (https://github.com/uProxy/uproxy/issues/1955)

Tested in Chrome using latest version of Quiver

Here's a screenshot of the latest Quiver login screen.  It will be translated prior to webstore launch, probably after we restyle everything to move the login screens behind the invite button:
<img width="483" alt="screen shot 2015-10-16 at 12 41 53 pm" src="https://cloud.githubusercontent.com/assets/6494307/10547572/4cbffe28-7403-11e5-8fb0-39f244893e15.png">


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1973)
<!-- Reviewable:end -->
