### PR TITLE
Fix accepting invites

### DIFF
--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -92,11 +92,6 @@ ui_connector.onPromiseCommand(
     uproxy_core_api.Command.SEND_INVITATION,
     core.inviteUser);
 
-// Required for version 0.8.23
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.ADD_USER,
-    core.addUser);
-
 ui_connector.onPromiseCommand(
     uproxy_core_api.Command.GET_INVITE_URL,
     core.getInviteUrl);

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -568,13 +568,13 @@ export function notifyUI(networkName :string, userId :string) {
       });
     }
 
-    public acceptInvitation = (url ?:string, userId ?:string) : Promise<void> => {
+    public acceptInvitation = (token ?:string, userId ?:string) : Promise<void> => {
       var networkData :string = null;
-      if (url) {
-        // url may be a URL with a token, or just the token.  Remove the
+      if (token) {
+        // token may be a URL with a token, or just the token.  Remove the
         // prefixed URL if it is set.
-        var token = url.lastIndexOf('/') >= 0 ?
-            url.substr(url.lastIndexOf('/') + 1) : url;
+        token = token.lastIndexOf('/') >= 0 ?
+            token.substr(token.lastIndexOf('/') + 1) : token;
         networkData = JSON.parse(atob(token)).networkData;
       } else if (userId) {
         networkData = userId;

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -244,11 +244,6 @@ export function notifyUI(networkName :string, userId :string) {
       throw new Error('Operation not implemented');
     }
 
-    // Required for version 0.8.23
-    public addUserRequest = (networkData :string): Promise<void> => {
-      throw new Error('Operation not implemented');
-    }
-
     public getInviteUrl = () : Promise<string> => {
       throw new Error('Operation not implemented');
     }
@@ -267,7 +262,7 @@ export function notifyUI(networkName :string, userId :string) {
       return options ? options.areAllContactsUproxy === true : false;
     }
 
-    public acceptInvitation = (data :string) : Promise<void> => {
+    public acceptInvitation = (url ?:string, userId ?:string) : Promise<void> => {
       throw new Error('Operation not implemented');
     }
 
@@ -573,14 +568,17 @@ export function notifyUI(networkName :string, userId :string) {
       });
     }
 
-    // Required for version 0.8.23
-    public addUserRequest = (networkData :string): Promise<void> => {
-      return this.freedomApi_.acceptUserInvitation(networkData).catch((e) => {
-        log.error('Error calling acceptUserInvitation: ' + networkData, e.message);
-      });
-    }
-
-    public acceptInvitation = (networkData :string): Promise<void> => {
+    public acceptInvitation = (url ?:string, userId ?:string) : Promise<void> => {
+      var networkData :string = null;
+      if (url) {
+        // url may be a URL with a token, or just the token.  Remove the
+        // prefixed URL if it is set.
+        var token = url.lastIndexOf('/') >= 0 ?
+            url.substr(url.lastIndexOf('/') + 1) : url;
+        networkData = JSON.parse(atob(token)).networkData;
+      } else if (userId) {
+        networkData = userId;
+      }
       return this.freedomApi_.acceptUserInvitation(networkData).catch((e) => {
         log.error('Error calling acceptUserInvitation: ' + networkData, e.message);
       });

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -262,7 +262,7 @@ export function notifyUI(networkName :string, userId :string) {
       return options ? options.areAllContactsUproxy === true : false;
     }
 
-    public acceptInvitation = (url ?:string, userId ?:string) : Promise<void> => {
+    public acceptInvitation = (token ?:string, userId ?:string) : Promise<void> => {
       throw new Error('Operation not implemented');
     }
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -575,7 +575,11 @@ export function notifyUI(networkName :string, userId :string) {
         // prefixed URL if it is set.
         token = token.lastIndexOf('/') >= 0 ?
             token.substr(token.lastIndexOf('/') + 1) : token;
-        networkData = JSON.parse(atob(token)).networkData;
+        try {
+          networkData = JSON.parse(atob(token)).networkData;
+        } catch (e) {
+          return Promise.reject('Invalid invite token ' + token);
+        }
       } else if (userId) {
         networkData = userId;
       }

--- a/src/generic_ui/polymer/accept-user-invite.ts
+++ b/src/generic_ui/polymer/accept-user-invite.ts
@@ -11,13 +11,12 @@ Polymer({
     this.receivedInviteToken.substr(this.receivedInviteToken.lastIndexOf('/') + 1) : this.receivedInviteToken;
     var tokenObj = JSON.parse(atob(token));
     var networkName = tokenObj.networkName;
-    var networkData = tokenObj.networkData;
     var socialNetworkInfo = {
       name: networkName,
       userId: "" /* The current user's ID will be determined by the core. */
     };
 
-    core.acceptInvitation({network: socialNetworkInfo, data: networkData})
+    core.acceptInvitation({network: socialNetworkInfo, token: this.receivedInviteToken})
         .then(() => {
       this.fire('open-dialog', {
         heading: '',

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -52,7 +52,7 @@ Polymer({
       userId: this.contact.network.userId
     };
     ui_context.core.acceptInvitation({
-      network: socialNetworkInfo, data: this.contact.userId
+      network: socialNetworkInfo, userId: this.contact.userId
     });
   },
   // |action| is the string end for a uproxy_core_api.ConsentUserAction

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -209,11 +209,6 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.SEND_INVITATION, data);
   }
 
-  // Required for version 0.8.23
-  addUser = (inviteUrl: string): Promise<void> => {
-    return this.promiseCommand(uproxy_core_api.Command.ADD_USER, inviteUrl);
-  }
-
   // TODO: this should probably take the network path, including userId
   getInviteUrl = (networkInfo :social.SocialNetworkInfo): Promise<string> => {
     return this.promiseCommand(uproxy_core_api.Command.GET_INVITE_URL,
@@ -250,8 +245,8 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.GET_VERSION);
   }
 
-  acceptInvitation = (obj: { network: social.SocialNetworkInfo; data: string }) : Promise<void>=> {
-    return this.promiseCommand(uproxy_core_api.Command.ACCEPT_INVITATION, obj);
+  acceptInvitation = (data :uproxy_core_api.AcceptInvitationData) : Promise<void>=> {
+    return this.promiseCommand(uproxy_core_api.Command.ACCEPT_INVITATION, data);
   }
 }  // class CoreConnector
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -530,26 +530,30 @@ export class UserInterface implements ui_constants.UiApi {
     };
   }
 
-  private addUserWithConfirmation_ = (url: string) : Promise<void> => {
+  private addUser_ = (url: string, showConfirmation :boolean) : Promise<void> => {
     try {
       var token = url.substr(url.lastIndexOf('/') + 1);
       var tokenObj = JSON.parse(atob(token));
       var userName = tokenObj.userName;
       var networkName = tokenObj.networkName;
       var networkData = tokenObj.networkData;
-      var userId = JSON.parse(networkData)['userId'];
     } catch(e) {
       return Promise.reject('Error parsing invite URL');
     }
 
-    var confirmationMessage =
-        this.i18n_t('ACCEPT_INVITE_CONFIRMATION', { name: userName });
-    return this.getConfirmation('', confirmationMessage).then(() => {
+    var getConfirmation = Promise.resolve();
+    if (showConfirmation) {
+      var confirmationMessage =
+          this.i18n_t('ACCEPT_INVITE_CONFIRMATION', { name: userName });
+      getConfirmation = this.getConfirmation('', confirmationMessage);
+    }
+    return getConfirmation.then(() => {
       var socialNetworkInfo :social.SocialNetworkInfo = {
         name: networkName,
         userId: "" /* The current user's ID will be determined by the core. */
       };
-      return this.core.acceptInvitation({network: socialNetworkInfo, data: userId});
+      return this.core.acceptInvitation(
+          {network: socialNetworkInfo, token: url});
     }).catch((e) => {
       // The user did not confirm adding their friend, not an error.
       return;
@@ -584,11 +588,12 @@ export class UserInterface implements ui_constants.UiApi {
         this.login(networkName).then(() => {
           this.view = ui_constants.View.ROSTER;
           this.bringUproxyToFront();
-          this.core.addUser(url).catch(showUrlError);
+          // Add user without showing a 2nd confirmation.
+          this.addUser_(url, false).catch(showUrlError);
         });
       });
     } else {
-      this.addUserWithConfirmation_(url).catch(showUrlError);;
+      this.addUser_(url, true).catch(showUrlError);;
     }
   }
 

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -294,15 +294,9 @@ export interface Network {
   getUser :(userId :string) => RemoteUser;
 
   /**
-   * Ask the social network to add the user.
-   * Required for version 0.8.23
-   */
-  addUserRequest: (networkData :string) => Promise<void>;
-
-  /**
    * Accept an invite to use uProxy with a friend
    */
-  acceptInvitation: (data: string) => Promise<void>;
+  acceptInvitation: (url ?:string, userId ?:string) => Promise<void>;
 
   /**
    * Send an invite to a friend to use uProxy

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -296,7 +296,7 @@ export interface Network {
   /**
    * Accept an invite to use uProxy with a friend
    */
-  acceptInvitation: (url ?:string, userId ?:string) => Promise<void>;
+  acceptInvitation: (token ?:string, userId ?:string) => Promise<void>;
 
   /**
    * Send an invite to a friend to use uProxy

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -98,7 +98,6 @@ export enum Command {
   HANDLE_CORE_UPDATE = 1021,
   REFRESH_PORT_CONTROL = 1022,
   CREDENTIALS_ERROR = 1023,
-  ADD_USER = 1024, /* Deprecated as of 0.8.23 */
   GET_INVITE_URL = 1025,
   SEND_EMAIL = 1026,
   ACCEPT_INVITATION = 1027,
@@ -193,6 +192,12 @@ export interface EmailData {
   to :string;
   subject :string;
   body :string;
+};
+
+export interface AcceptInvitationData {
+  network :social.SocialNetworkInfo;
+  token ?:string;
+  userId ?:string;
 };
 
 export enum PortControlSupport {PENDING, TRUE, FALSE};


### PR DESCRIPTION
Fix accepting invites:
* remove old addUser method, that was deprecated
* acceptInvitation now takes optional token (url, for Firebase providers) and userId (GitHub)

Tested with GMail (working) and GitHub providers (sending invites are broken - but this was broken before this change anyways)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/1997)
<!-- Reviewable:end -->