### PR TITLE
migrate to latest uproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^33.0.0",
+    "uproxy-lib": "^34.0.0",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },


### PR DESCRIPTION
Major version bump has no effect on uProxy.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2006)
<!-- Reviewable:end -->
