### PR TITLE
Add invite screen for WeChat

### DIFF
--- a/src/generic/network-options.ts
+++ b/src/generic/network-options.ts
@@ -37,7 +37,7 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     enableMonitoring: false,
     areAllContactsUproxy: false,
     supportsReconnect: false,
-    supportsInvites: false,
+    supportsInvites: true,
     isExperimental: true
   },
   'GitHub': {

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -69,6 +69,18 @@
           </uproxy-button>
         </div>
 
+        <div hidden?='{{ selectedNetworkName != "WeChat"}}'>
+          <!-- TODO: localization -->
+          <uproxy-button affirmative on-tap='{{ generateInviteUrl }}'>
+            Generate WeChat Invite Link
+          </uproxy-button>
+
+          <div hidden?='{{ inviteUrl == "" }}'>
+            <p>Send this link to your friend so they can find you on WeChat</p>
+            <input readonly is='core-input' on-tap='{{ select }}' value='{{ inviteUrl }}' />
+          </div>
+        </div>
+
         <div hidden?='{{ selectedNetworkName != "GMail"}}'>
           <p>{{ 'GMAIL_INVITE_INSTRUCTIONS' | $$ }}</p>
           <paper-input-decorator label='{{ "EMAIL_PLACEHOLDER" | $$ }}' layout vertical>


### PR DESCRIPTION
Add invite screen for WeChat, to generate invite URLs.  Note that freedom-social-wechat doesn't yet support invites yet, this is just to help us test.  Since WeChat is only available on the dev build it will not affect users

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2023)
<!-- Reviewable:end -->
