### PR TITLE
Make the click (well, tap) targets for the uproxy-faq-links in splash bigger

### DIFF
--- a/src/generic_ui/polymer/faq-link.html
+++ b/src/generic_ui/polymer/faq-link.html
@@ -10,14 +10,6 @@ open the FAQ within the uProxy window.
 
 -->
 
-<polymer-element name='uproxy-faq-link' attributes='anchor'>
-
-  <template>
-    <uproxy-link role='link' on-tap='{{ openFaq }}'>
-      <content></content>
-    </uproxy-link>
-  </template>
-
+<polymer-element name='uproxy-faq-link' attributes='anchor' extends='uproxy-link' on-tap='{{ openFaq }}'>
   <script src='faq-link.js'></script>
-
 </polymer-element>

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -1,4 +1,5 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
+<link rel="import" href="../../bower/paper-button/paper-button.html">
 <link rel='import' href='../../bower/paper-item/paper-item.html'>
 <link rel="import" href="../../bower/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../../bower/paper-dropdown/paper-dropdown.html">
@@ -59,7 +60,7 @@
       opacity: 0;
       z-index: -1;
     }
-    uproxy-button {
+    #nextWrapper uproxy-button {
       width: 150px;
     }
     uproxy-network {
@@ -78,12 +79,12 @@
       margin-top: 1em;
       margin-bottom: 1em;
     }
-    uproxy-faq-link {
+    uproxy-faq-link paper-button {
       width: 100%;
-      padding-top: 1em;
-      padding-bottom: 1em;
+      padding-top: .3em;
+      padding-bottom: .3em;
       border-top: 1px solid rgb(221, 221, 221);
-      text-transform: uppercase;
+      margin: 0;
     }
     #logo {
       margin-bottom: 1em;
@@ -192,7 +193,9 @@
       </div>
 
       <uproxy-faq-link anchor='whatIsUproxy'>
-        {{ "LEARN_MORE_UPROXY" | $$ }}
+        <paper-button>
+          {{ "LEARN_MORE_UPROXY" | $$ }}
+        </paper-button>
       </uproxy-faq-link>
 
     </div>
@@ -255,7 +258,9 @@
         </div>
       </div>
       <uproxy-faq-link anchor='whyDoesUproxyConnect'>
-        {{ "LEARN_MORE_SOCIAL" | $$ }}
+        <paper-button>
+          {{ "LEARN_MORE_SOCIAL" | $$ }}
+        </paper-button>
       </uproxy-faq-link>
     </div>
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2030)
<!-- Reviewable:end -->
