### PR TITLE
s/alpha/beta

### DIFF
--- a/src/chrome/app/_locales/en/messages.json
+++ b/src/chrome/app/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "The title that appears in the Chrome Extensions listing"
   },
   "appDescription": {
-    "message": "(Alpha version) uProxy, part 2 of 2.  You will also need part 1 of 2 to use uProxy.",
+    "message": "(Beta version) uProxy, part 2 of 2.  You will also need part 1 of 2 to use uProxy.",
     "description": "The description that appears in the Chrome Extensions listing"
   }
 }

--- a/src/chrome/extension/_locales/en/messages.json
+++ b/src/chrome/extension/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "The title that appears in the Chrome Extensions listing"
   },
   "extDescription": {
-    "message": "(Alpha version) uProxy, part 1 of 2.  You will also need part 2 of 2 to use uProxy.",
+    "message": "(Beta version) uProxy, part 1 of 2.  You will also need part 2 of 2 to use uProxy.",
     "description": "The description that appears in the Chrome Extensions listing"
   },
   "extTitle": {

--- a/src/generic_ui/faq.html
+++ b/src/generic_ui/faq.html
@@ -55,7 +55,7 @@
               <li><a href="#whatIsPortControl" class="i18n" data-i18n="WHAT_IS_PORT_CONTROL">What does "port control" mean?</a></li>
               <li><a href="#howDoesUproxyCompare" class="i18n" data-i18n="HOW_DOES_UPROXY_COMPARE">How does uProxy compare to VPNs?</a></li>
               <li><a href="#whoMadeUproxy" class="i18n" data-i18n="WHO_MADE_UPROXY">Who made uProxy?</a></li>
-              <li><a href="#whatIsAlpha" class="i18n" data-i18n="WHAT_IS_ALPHA">What is an alpha release?</a></li>
+              <li><a href="#whatIsBeta" class="i18n" data-i18n="WHAT_IS_BETA">What is a beta release?</a></li>
               <li><a href="#howDoISubmit" class="i18n" data-i18n="HOW_DO_I_SUBMIT">How do I submit feedback?</a></li>
             </ul>
           </section>
@@ -180,9 +180,9 @@
             <a class="top i18n" href="faq.html#" data-i18n="BACK_TO_TOP">Back to top</a>
           </section>
 
-          <section class="faq" id="whatIsAlpha">
-            <h2 class="i18n" data-i18n="WHAT_IS_ALPHA">What is an alpha release?</h2>
-            <p class="i18n" data-i18n="[html]WHAT_IS_ALPHA_ANSWER">This alpha version of uProxy is still under development and may be unstable at times; some features are not complete, and there's a <a href="https://github.com/uProxy/uproxy/issues">list of open issues</a> on GitHub. We'd love for you to try it and help us make improvements, by giving us feedback.</p>
+          <section class="faq" id="whatIsBeta">
+            <h2 class="i18n" data-i18n="WHAT_IS_BETA">What is a beta release?</h2>
+            <p class="i18n" data-i18n="[html]WHAT_IS_BETA_ANSWER">This beta version of uProxy is still under development and may be unstable at times; some features are not complete, and there's a <a href="https://github.com/uProxy/uproxy/issues">list of open issues</a> on GitHub. We'd love for you to try it and help us make improvements, by giving us feedback.</p>
 
             <a class="top i18n" href="faq.html#" data-i18n="BACK_TO_TOP">Back to top</a>
           </section>

--- a/src/generic_ui/locales/ar/messages.json
+++ b/src/generic_ui/locales/ar/messages.json
@@ -131,7 +131,7 @@
         "message": "غالباً لا",
         "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string."
     },
-    "ALPHA_MESSAGE": {
+    "BETA_MESSAGE": {
         "message": "هذا إصدار المرحلة ألفا لـ uProxy. يمكنك مساعدتنا على تحسين uProxy بمشاركة معايير مجهول مع فريق التطوير. يتم جعل مصدر البيانات التي يتم الإبلاغ عنها مجهولاً ونقلها بطريقة آمنة.",
         "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
     },

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -399,9 +399,9 @@
     "description": "Instructions that appears beside a big '+' button. Clicking the button opens a panel with options to add a uProxy friend.",
     "message": "Use this button to send an invitation to a friend or paste an invitation you've received."
   },
-  "ALPHA_MESSAGE": {
+  "BETA_MESSAGE": {
     "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development.",
-    "message": "This is an alpha release of uProxy, and it may occasionally be unreliable."
+    "message": "This is a beta release of uProxy, and it may occasionally be unreliable."
   },
   "MORE_ABOUT_METRICS": {
     "description": "",

--- a/src/generic_ui/locales/fa/messages.json
+++ b/src/generic_ui/locales/fa/messages.json
@@ -131,7 +131,7 @@
         "message": "نه اصلا",
         "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established."
     },
-    "ALPHA_MESSAGE": {
+    "BETA_MESSAGE": {
         "message": "این نسخه آلفا یوپراکسی است. شما با به اشتراک گذاری اطلاعات آماری خود با تیم توسعه دهندگان به صورت ناشناس می توانید به توسعه نرم افزار کمک کنید. داده های گزارش در سیستم کلاینت ناشناس شده و سپس به صورت کاملا امن منتقل می شوند.",
         "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
     },

--- a/src/generic_ui/locales/tr/messages.json
+++ b/src/generic_ui/locales/tr/messages.json
@@ -131,8 +131,8 @@
         "message": "muhtemelen değil",
         "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string."
     },
-    "ALPHA_MESSAGE": {
-        "message": "Bu, uProxy'nin bir alpha sürümü. Anonim metrikleri geliştirme ekibiyle paylaşarak, uProxy'i geliştirmemize yardım edebilirsin. Raporlanan veri müşteri tarafından anonim hale getirilir ve güvenli bir şekilde iletilir.",
+    "BETA_MESSAGE": {
+        "message": "Bu, uProxy'nin bir beta sürümü. Anonim metrikleri geliştirme ekibiyle paylaşarak, uProxy'i geliştirmemize yardım edebilirsin. Raporlanan veri müşteri tarafından anonim hale getirilir ve güvenli bir şekilde iletilir.",
         "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
     },
     "MORE_INFORMATION": {

--- a/src/generic_ui/locales/vi/messages.json
+++ b/src/generic_ui/locales/vi/messages.json
@@ -131,8 +131,8 @@
         "message": "có lẽ là không",
         "description": "Meaning very low probability. Used in context of the probability that network settings are preventing a uProxy connection from being established. Used in analysisResults string."
     },
-    "ALPHA_MESSAGE": {
-        "message": "Đây là phiên bản alpha của uProxy. Bạn có thể giúp chúng tôi cải thiện uProxy bằng cách chia sẻ các số liệu ẩn danh với nhóm phát triển. Dữ liệu báo cáo sẽ được máy khách ẩn danh và được truyền đi một cách bảo mật.",
+    "BETA_MESSAGE": {
+        "message": "Đây là phiên bản beta của uProxy. Bạn có thể giúp chúng tôi cải thiện uProxy bằng cách chia sẻ các số liệu ẩn danh với nhóm phát triển. Dữ liệu báo cáo sẽ được máy khách ẩn danh và được truyền đi một cách bảo mật.",
         "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development."
     },
     "MORE_INFORMATION": {

--- a/src/generic_ui/polymer/faq.html
+++ b/src/generic_ui/polymer/faq.html
@@ -102,7 +102,7 @@
                 <li><a data-anchor="whatIsPortControl" on-tap="{{scroll}}" class="i18n" data-i18n="WHAT_IS_PORT_CONTROL">What does "port control" mean?</a></li>
                 <li><a data-anchor="howDoesUproxyCompare" on-tap="{{scroll}}" class="i18n" data-i18n="HOW_DOES_UPROXY_COMPARE">How does uProxy compare to VPNs?</a></li>
                 <li><a data-anchor="whoMadeUproxy" on-tap="{{scroll}}" class="i18n" data-i18n="WHO_MADE_UPROXY">Who made uProxy?</a></li>
-                <li><a data-anchor="whatIsAlpha" on-tap="{{scroll}}" class="i18n" data-i18n="WHAT_IS_ALPHA">What is an alpha release?</a></li>
+                <li><a data-anchor="whatIsBeta" on-tap="{{scroll}}" class="i18n" data-i18n="WHAT_IS_BETA">What is a beta release?</a></li>
                 <li><a data-anchor="howDoISubmit" on-tap="{{scroll}}" class="i18n" data-i18n="HOW_DO_I_SUBMIT">How do I submit feedback?</a></li>
               </ul>
             </section>
@@ -210,9 +210,9 @@
 
             </section>
 
-            <section class="faq" id="whatIsAlpha">
-              <h2 class="i18n" data-i18n="WHAT_IS_ALPHA">What is an alpha release?</h2>
-              <p class="i18n" data-i18n="[html]WHAT_IS_ALPHA_ANSWER">This alpha version of uProxy is still under development and may be unstable at times; some features are not complete, and there's a <a href="https://github.com/uProxy/uproxy/issues">list of open issues</a> on GitHub. We'd love for you to try it and help us make improvements, by giving us feedback.</p>
+            <section class="faq" id="whatIsBeta">
+              <h2 class="i18n" data-i18n="WHAT_IS_BETA">What is a beta release?</h2>
+              <p class="i18n" data-i18n="[html]WHAT_IS_BETA_ANSWER">This beta version of uProxy is still under development and may be unstable at times; some features are not complete, and there's a <a href="https://github.com/uProxy/uproxy/issues">list of open issues</a> on GitHub. We'd love for you to try it and help us make improvements, by giving us feedback.</p>
 
             </section>
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -446,7 +446,7 @@
       <div>
         <h1>{{ "WELCOME" | $$ }}</h1>
         <p>
-          {{ "ALPHA_MESSAGE" | $$ }}<br><br>
+          {{ "BETA_MESSAGE" | $$ }}<br><br>
           {{ "CHANGE_STATS_CHOICE" | $$ }}
         </p>
         <p><b>{{ "ENABLE_METRICS" | $$ }}</b></p>


### PR DESCRIPTION
uProxy graduated from alpha to beta last month but it still calls itself "alpha" in e.g. chrome://extensions and the FAQ:

![screen shot 2015-11-17 at 17 28 34](https://cloud.githubusercontent.com/assets/64992/11227235/d347d6c4-8d52-11e5-8837-e78c7976e3fb.png)

This PR changes "alpha" to "beta" everywhere in this source tree, but is mostly to understand the contribution process for changes to copy (particularly when they require translators to review).

