### PR TITLE
Improve Quiver UI, update permission storage

### DIFF
--- a/src/generic_core/local-instance.ts
+++ b/src/generic_core/local-instance.ts
@@ -25,7 +25,7 @@ import storage = globals.storage;
     public clientId :string;
     public userName :string;
     public imageData :string;
-    public invitePermissionTokens :string[] = [];
+    public invitePermissionTokens :{ [token :string] :social.PermissionTokenInfo } = {};
 
     /**
      * Generate an instance for oneself, either from scratch or based on some
@@ -116,13 +116,18 @@ import storage = globals.storage;
       });
     }
 
-    public addInvitePermissionToken = (permissionToken :string) => {
-      this.invitePermissionTokens.push(permissionToken);
+    public generateInvitePermissionToken = () : string => {
+      var permissionToken = String(Math.random());
+      this.invitePermissionTokens[permissionToken] = {
+        access: social.PermissionTokenAccess.FRIEND_REQUEST,
+        createdAt: Date.now()
+      };
       this.saveToStorage();
+      return permissionToken;
     }
 
     public isValidInvite = (permissionToken :string) : boolean => {
-      return this.invitePermissionTokens.indexOf(permissionToken) >= 0;
+      return permissionToken in this.invitePermissionTokens;
     }
 
   }  // class local_instance.LocalInstance

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -445,7 +445,7 @@ describe('Quiver social networks', () => {
     var user = network.addUser(userId);
     spyOn(user, 'handleMessage').and.returnValue(Promise.resolve());
 
-    network.myInstance.addInvitePermissionToken('validToken');
+    var permissionToken = network.myInstance.generateInvitePermissionToken();
     var validClientState :freedom.Social.ClientState = {
       userId: userId,
       clientId: clientId,
@@ -455,7 +455,7 @@ describe('Quiver social networks', () => {
       inviteUserData: JSON.stringify({
         publicKey: publicKey,
         userId: userId,
-        permissionToken: 'validToken'
+        permissionToken: permissionToken
       })
     };
     network.handleMessage({from: validClientState, message: message})

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -757,8 +757,7 @@ export function notifyUI(networkName :string, userId :string) {
       return this.freedomApi_.inviteUser('').then((data: { networkData :string }) => {
         var tokenObj :Object;
         if (this.name === 'Quiver') {
-          var permissionToken = String(Math.random());
-          this.myInstance.addInvitePermissionToken(permissionToken);
+          var permissionToken = this.myInstance.generateInvitePermissionToken();
           tokenObj = {
             v: 2,
             networkName: this.name,

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -819,9 +819,9 @@
     "description": "Question above network select dropdown on invite screen",
     "message": "How would you like to invite to your friends?"
   },
-  "SIGN_IN_WITH_A_NETWORK": {
+  "FIND_YOUR_FRIENDS_ON_A_SOCIAL_NETWORK": {
     "description": "Title above social network icons on the page to find and/or invite friends.",
-    "message": "Sign in with a social network."
+    "message": "Find your friends on a social network."
   },
   "FACEBOOK_INVITE_INSTRUCTIONS": {
     "description": "Invite instructions for Facebook",

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -68,13 +68,14 @@
         top: 15px;
         right: 15px;
         color: rgb(180,180,180);
+        cursor: pointer;
       }
       #QuiverLoginButton {
         width: 200px;
         margin-top: 1em;
         margin-bottom: 1em;
       }
-      #QuiverTitle {
+      .QuiverTitle {
         font-size: 1.4em;
         color: #009688;
         font-weight: normal;
@@ -153,7 +154,7 @@
         <div id="allInviteMethods" hidden?='{{!ui.showRosterBeforeLogin}}'>
           <div hidden?="{{!supportsQuiver}}">
             <div hidden?='{{isQuiverLoggedIn}}' class='section'>
-              <h1 id='QuiverTitle'>Sign in to the uProxy network</h1>
+              <h1 class='QuiverTitle'>Sign in to the uProxy network</h1>
               <paper-input-decorator label='Choose a user name' layout vertical>
                 <input is='core-input' value='{{ userName }}' />
               </paper-input-decorator>
@@ -161,19 +162,17 @@
             </div>
             <div hidden?='{{!isQuiverLoggedIn}}' class='section'>
               <!-- TODO: localization -->
-              <uproxy-button affirmative on-tap='{{ generateQuiverInviteUrl }}'>
-                Generate Quiver Invite Link
-              </uproxy-button>
-
-              <div hidden?='{{ inviteUrl == "" }}'>
-                <p>Send this link to your friend so they can find you on Quiver</p>
-                <input readonly is='core-input' on-tap='{{ select }}' value='{{ inviteUrl }}' />
+              <h1 class='QuiverTitle'>Send this link to your friends so they can find you on uProxy</h1>
+              <div hidden?='{{ quiverInviteUrl == "" }}'>
+                <paper-input-decorator layout vertical>
+                  <input readonly is='core-input' on-tap='{{ select }}' value='{{ quiverInviteUrl }}' />
+                </paper-input-decorator>
               </div>
             </div>
             <div class='orText'>- - - OR - - -</div>
           </div>
           <div class='section'>
-          <p>{{ "SIGN_IN_WITH_A_NETWORK" | $$ }}</p>
+          <p>{{ "FIND_YOUR_FRIENDS_ON_A_SOCIAL_NETWORK" | $$ }}</p>
             <template repeat='{{ n in networkButtonNames }}' vertical layout>
               <div on-tap='{{ networkTapped }}' class='networkLoginButton' data-network='{{n}}'>
                 <core-icon icon='uproxy-icons:{{n}}'></core-icon>
@@ -183,14 +182,15 @@
                 </div>
               </div>
             </template>
+
+            <div class='networkLoginButton copypaste' on-tap='{{ copypaste }}' class='section'>
+              <core-icon icon='uproxy-icons:CopyAndPaste'></core-icon>
+              <div class='networkName'>{{ "SET_UP_ONE_TIME" | $$ }}</div>
+            </div>
+
             <div class="section">
               {{ "WE_WONT_POST" | $$ }}
             </div>
-          </div>
-          <div class='orText'>- - - OR - - -</div>
-          <div class='networkLoginButton copypaste' on-tap='{{ copypaste }}' class='section'>
-            <core-icon icon='uproxy-icons:CopyAndPaste'></core-icon>
-            <div class='networkName'>{{ "SET_UP_ONE_TIME" | $$ }}</div>
           </div>
 
           <div class="section">
@@ -254,30 +254,6 @@
                 {{ 'DONE' | $$ }}
               </uproxy-button>
             </div>
-
-            <div hidden?='{{ selectedNetworkName != "WeChat"}}'>
-              <!-- TODO: localization -->
-              <uproxy-button affirmative on-tap='{{ generateInviteUrl }}'>
-                Generate WeChat Invite Link
-              </uproxy-button>
-
-              <div hidden?='{{ inviteUrl == "" }}'>
-                <p>Send this link to your friend so they can find you on WeChat</p>
-                <input readonly is='core-input' on-tap='{{ select }}' value='{{ inviteUrl }}' />
-              </div>
-            </div>
-
-            <div hidden?='{{ selectedNetworkName != "Quiver"}}'>
-              <!-- TODO: localization -->
-              <uproxy-button affirmative on-tap='{{ generateInviteUrl }}'>
-                Generate uProxy Invite Link
-              </uproxy-button>
-
-              <div hidden?='{{ inviteUrl == "" }}'>
-                <p>Send this link to your friend so they can find you on the uProxy network</p>
-                <input readonly is='core-input' on-tap='{{ select }}' value='{{ inviteUrl }}' />
-              </div>
-            </div>
           </div>
           <div class='section'>
             <a on-tap='{{ showAcceptUserInvite }}'>
@@ -290,7 +266,7 @@
 
     <uproxy-dialog layered="false" backdrop="true" id='loginToInviteFriendDialog' on-core-overlay-open-completed="{{loginToInviteFriendDialogOpened}}">
       <h1>{{ "SIGN_IN_TO_NETWORK" | $$({network: getNetworkDisplayName(selectedNetworkName)})}}</h1>
-      <core-icon icon="clear" on-tap='{{ close }}'></core-icon>
+      <core-icon icon="clear" on-tap='{{ closeLoginDialog }}'></core-icon>
       <p hidden?="{{!supportsInvites(selectedNetworkName)}}">
         {{ "SIGN_IN_TO_INVITE_FRIENDS" | $$({network: getNetworkDisplayName(selectedNetworkName)})}}
       </p>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -127,25 +127,23 @@ Polymer({
   },
   /* Functions required for roster-before-login flow. */
   onlineNetworksChanged: function() {
-    var oldQuiverValue = this.isQuiverLoggedIn;
-    var newQuiverValue = false;
     for (var i = 0; i < model.onlineNetworks.length; ++i) {
-      var name = model.onlineNetworks[i].name;
-      if (name == "Quiver") {
-        newQuiverValue = true;
-        break;
+      if (model.onlineNetworks[i].name === 'Quiver') {
+        // User is logged into Quiver.
+        if (!this.isQuiverLoggedIn) {
+          // User just logged on, generate an invite URL.
+          this.generateInviteUrl('Quiver').then((inviteUrl :string) => {
+            this.quiverInviteUrl = inviteUrl;
+          });
+        }
+        this.isQuiverLoggedIn = true;
+        return;
       }
     }
-    if (!oldQuiverValue && newQuiverValue) {
-      // User is now logged into Quiver, generate an inviteUrl to display.
-      this.generateInviteUrl('Quiver').then((inviteUrl :string) => {
-        this.quiverInviteUrl = inviteUrl;
-      });
-    } else if (!newQuiverValue) {
-      // User is not signed into Quiver, clear the invite URL.
-      this.quiverInviteUrl = '';
-    }
-    this.isQuiverLoggedIn = newQuiverValue;
+
+    // User is not logged into Quiver
+    this.quiverInviteUrl = '';
+    this.isQuiverLoggedIn = false;
   },
   loginToQuiver: function() {
     model.globalSettings.quiverUserName = this.userName;

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -9,29 +9,19 @@ var core = ui_context.core;
 
 Polymer({
   generateInviteUrl: function(name :string) {
-    var selectedNetwork = model.getNetwork(name);
-    var info = {
-      name: selectedNetwork.name,
-      userId: selectedNetwork.userId
-    };
-    return core.getInviteUrl(info).then((inviteUrl :string) => {
-      this.inviteUrl = inviteUrl;
-      return selectedNetwork;
-    });
+    var network = model.getNetwork(name);
+    var networkInfo = { name: network.name, userId: network.userId };
+    return core.getInviteUrl(networkInfo);
   },
   sendToGMailFriend: function() {
-    this.generateInviteUrl('GMail')
-        .then((selectedNetwork :user_interface.Network) => {
-      var selectedNetworkInfo = {
-        name: selectedNetwork.name,
-        userId: selectedNetwork.userId
-      };
-      var name = selectedNetwork.userName || selectedNetwork.userId;
+    var network = model.getNetwork('GMail');
+    this.generateInviteUrl('GMail').then((inviteUrl :string) => {
+      var userName = network.userName || network.userId;
       var emailBody = core.sendEmail({
-          networkInfo: selectedNetworkInfo,
+          networkInfo: {name: network.name, userId: network.userId},
           to: this.inviteUserEmail,
-          subject: ui.i18n_t('INVITE_EMAIL_SUBJECT', { name: name }),
-          body: ui.i18n_t('INVITE_EMAIL_BODY', { url: this.inviteUrl, name: name })
+          subject: ui.i18n_t('INVITE_EMAIL_SUBJECT', { name: userName }),
+          body: ui.i18n_t('INVITE_EMAIL_BODY', { url: inviteUrl, name: userName })
       });
       this.closeInviteUserPanel();
       this.fire('open-dialog', {
@@ -43,14 +33,11 @@ Polymer({
       });
     });
   },
-  generateQuiverInviteUrl: function() {
-    return this.generateInviteUrl('Quiver');
-  },
   sendToFacebookFriend: function() {
-    this.generateInviteUrl('Facebook-Firebase-V2').then(() => {
+    this.generateInviteUrl('Facebook-Firebase-V2').then((inviteUrl :string) => {
       var facebookUrl =
           'https://www.facebook.com/dialog/send?app_id=%20161927677344933&link='
-          + this.inviteUrl + '&redirect_uri=https://www.uproxy.org/';
+          + inviteUrl + '&redirect_uri=https://www.uproxy.org/';
       ui.openTab(facebookUrl);
       this.closeInviteUserPanel();
       this.fire('open-dialog', {
@@ -63,10 +50,8 @@ Polymer({
     });
   },
   inviteGithubFriend: function() {
-    var selectedNetwork =
-      model.onlineNetworks[this.$.networkSelectMenu.selectedIndex];
     core.inviteUser({
-      networkId: selectedNetwork.name,
+      networkId: 'GitHub',
       userName: this.githubUserIdInput
     }).then(() => {
       this.closeInviteUserPanel();
@@ -91,10 +76,11 @@ Polymer({
     });
   },
   addCloudInstance: function() {
-    var selectedNetwork =
-      model.onlineNetworks[this.$.networkSelectMenu.selectedIndex];
+    // TODO: this should be using acceptUserInvitation, not inviteUser,
+    // as the user is entering an invite URL they've received and is not
+    // sending any invite to their friends at this point.
     core.inviteUser({
-      networkId: selectedNetwork.name,
+      networkId: 'Cloud',
       userName: this.cloudInstanceInput
     }).then(() => {
       console.log('invited!');
@@ -122,7 +108,6 @@ Polymer({
     this.$.inviteUserPanel.open();
   },
   closeInviteUserPanel: function() {
-    this.inviteUrl = '';
     this.$.inviteUserPanel.close();
   },
   showAcceptUserInvite: function() {
@@ -142,14 +127,25 @@ Polymer({
   },
   /* Functions required for roster-before-login flow. */
   onlineNetworksChanged: function() {
-    this.isQuiverLoggedIn = false;
+    var oldQuiverValue = this.isQuiverLoggedIn;
+    var newQuiverValue = false;
     for (var i = 0; i < model.onlineNetworks.length; ++i) {
       var name = model.onlineNetworks[i].name;
       if (name == "Quiver") {
-        this.isQuiverLoggedIn = true;
+        newQuiverValue = true;
         break;
       }
     }
+    if (!oldQuiverValue && newQuiverValue) {
+      // User is now logged into Quiver, generate an inviteUrl to display.
+      this.generateInviteUrl('Quiver').then((inviteUrl :string) => {
+        this.quiverInviteUrl = inviteUrl;
+      });
+    } else if (!newQuiverValue) {
+      // User is not signed into Quiver, clear the invite URL.
+      this.quiverInviteUrl = '';
+    }
+    this.isQuiverLoggedIn = newQuiverValue;
   },
   loginToQuiver: function() {
     model.globalSettings.quiverUserName = this.userName;
@@ -239,6 +235,13 @@ Polymer({
   supportsInvites: function(networkName :string) {
     return ui.supportsInvites(networkName);
   },
+  closeLoginDialog: function() {
+    this.$.loginToInviteFriendDialog.close();
+  },
+  select: function(e :Event, d :Object, input :HTMLInputElement) {
+    input.focus();
+    input.select();
+  },
   observe: {
     'model.networkNames': 'networkNamesChanged',
     'model.onlineNetworks': 'onlineNetworksChanged'
@@ -250,7 +253,7 @@ Polymer({
     this.githubUserIdInput = ''; // for GitHub
     this.inviteUserEmail = ''; // for GMail
     this.selectedNetworkName = '';
-    this.inviteUrl = '';
+    this.quiverInviteUrl = '';
     this.model = model;
     this.cloudInstanceInput = '';
     this.ui = ui;

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -205,17 +205,16 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.LOGOUT, networkInfo);
   }
 
+  // TODO: this should take a SocialNetworkInfo instead of networkId
   inviteUser = (data: { networkId: string; userName: string }): Promise<void> => {
     return this.promiseCommand(uproxy_core_api.Command.SEND_INVITATION, data);
   }
 
-  // TODO: this should probably take the network path, including userId
   getInviteUrl = (networkInfo :social.SocialNetworkInfo): Promise<string> => {
     return this.promiseCommand(uproxy_core_api.Command.GET_INVITE_URL,
         networkInfo);
   }
 
-  // TODO: this should probably take the network path, including userId
   sendEmail = (emailData :uproxy_core_api.EmailData): void => {
     this.sendCommand(uproxy_core_api.Command.SEND_EMAIL, emailData);
   }

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -31,12 +31,24 @@ export interface StopProxyInfo {
   error      :boolean;
 }
 
+export enum PermissionTokenAccess {
+  FRIEND_REQUEST = 0,   // only requesting that the user is a friend
+  REQUEST_ACCESS,
+  OFFER_ACCESS,
+  REQUEST_AND_OFFER_ACCESS
+}
+
+export interface PermissionTokenInfo {
+  access :PermissionTokenAccess;
+  createdAt :number;
+}
+
 export interface LocalInstanceState {
   instanceId       :string;
   userId           :string;
   userName         :string;
   imageData        :string;
-  invitePermissionTokens :string[];
+  invitePermissionTokens :{ [token :string] :PermissionTokenInfo };
 }
 
 export interface NetworkMessage {


### PR DESCRIPTION
Update permission storage: now in addition to storing permission tokens, we store what access it gives the receiver.  Currently only FRIEND_REQUEST is supported, but this will allow us to more easily add support for granting+requesting access as part of invites.  Also we are now storing the timestamp that a token was generated at in case we decide to expire old tokens in the future

Improve Quiver UI:
* Automatically show invite URLs after logging into Quiver.  These URLs are also automatically selected when clicked on
* X button now closes GMail, Facebook, etc login popups
* Change text to now say "Find your friends on a social network" - which makes sense both before and after the user has logged into the network
* Some code cleanup

This is how it looks before logging into Quiver:
<img width="242" alt="screen shot 2015-11-18 at 3 15 28 pm" src="https://cloud.githubusercontent.com/assets/6494307/11253072/74eb3228-8e07-11e5-9309-4190c22eb4d6.png">

and after logging into Quiver:
<img width="242" alt="screen shot 2015-11-18 at 3 15 33 pm" src="https://cloud.githubusercontent.com/assets/6494307/11253079/7cf39712-8e07-11e5-8d59-ee92ebf1e0b6.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2070)
<!-- Reviewable:end -->
