### PR TITLE
Update the way we configure freedom-module

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1000,10 +1000,17 @@ testDirectory = (dir) ->
       # include the browserification in this step
       testNames.push('browserify:' + testName)
 
-  # add the jasmine task so we can run it
-  gruntConfig['jasmine'][dir] = Rule.jasmineSpec(dir)
-  # include running the tests in this task
-  testNames.push('jasmine:' + dir)
+      gruntConfig['jasmine'][testName] =
+        src: [
+          require.resolve('arraybuffer-slice'),
+          require.resolve('es6-promise')
+          path.join(thirdPartyBuildPath, 'promise-polyfill.js'),
+        ]
+        options:
+          specs: [path.join(devBuildPath, dir, match[1] + '.spec.static.js')]
+          outfile: path.join(devBuildPath, dir, match[1] + 'Runner.html')
+          keepRunner: true
+      testNames.push('jasmine:' + testName)
 
   return testNames
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-jasmine": "^0.8.0",
+    "grunt-contrib-jasmine": "^0.9.0",
     "grunt-exec": "^0.4.6",
     "grunt-gitinfo": "^0.1.7",
     "grunt-jasmine-chromeapp": "git://github.com/uproxy/grunt-jasmine-chromeapp",

--- a/src/generic_core/firewall.spec.ts
+++ b/src/generic_core/firewall.spec.ts
@@ -6,13 +6,13 @@ import mockFreedomRtcPeerConnection = require('../../../third_party/uproxy-lib/f
 
 import freedom_mocks = require('../mocks/freedom-mocks');
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
-    'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
-    'loggingcontroller': () => { return new freedom_mocks.MockLoggingController(); },
-    'metrics': () => { return new freedom_mocks.MockMetrics(); },
-    'core.tcpsocket': () => { return new freedom_mocks.MockTcpSocket(); },
-    'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); },
-    'pgp': () => { return new freedom_mocks.PgpProvider() },
-    'portControl': () => { return new Object }
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'loggingcontroller': () => { return new freedom_mocks.MockLoggingController(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'core.tcpsocket': () => { return new freedom_mocks.MockTcpSocket(); },
+  'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
 });
 
 

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -102,10 +102,6 @@ ui_connector.onCommand(uproxy_core_api.Command.STOP_PROXYING,
     core.stop);
 
 ui_connector.onCommand(
-    uproxy_core_api.Command.HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE,
-    core.handleManualNetworkInboundMessage);
-
-ui_connector.onCommand(
     uproxy_core_api.Command.UPDATE_GLOBAL_SETTINGS,
     core.updateGlobalSettings);
 

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -52,80 +52,31 @@ var exported = {
 };
 export = exported;
 
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.LOGIN,
-    core.login);
+var commands :{[command :number] :((data?:any) => (Promise<any>|void))} = {};
+commands[uproxy_core_api.Command.LOGIN] = core.login;
+commands[uproxy_core_api.Command.LOGOUT] = core.logout;
+commands[uproxy_core_api.Command.MODIFY_CONSENT] = core.modifyConsent;
+commands[uproxy_core_api.Command.START_PROXYING_COPYPASTE_GET] = core.startCopyPasteGet;
+commands[uproxy_core_api.Command.START_PROXYING_COPYPASTE_SHARE] = core.startCopyPasteShare;
+commands[uproxy_core_api.Command.COPYPASTE_SIGNALLING_MESSAGE] = core.sendCopyPasteSignal;
+commands[uproxy_core_api.Command.START_PROXYING] = core.start;
+commands[uproxy_core_api.Command.SEND_INVITATION] = core.inviteUser;
+commands[uproxy_core_api.Command.GET_INVITE_URL] = core.getInviteUrl;
+commands[uproxy_core_api.Command.SEND_EMAIL] = core.sendEmail;
+commands[uproxy_core_api.Command.STOP_PROXYING] = core.stop;
+commands[uproxy_core_api.Command.UPDATE_GLOBAL_SETTINGS] = core.updateGlobalSettings;
+commands[uproxy_core_api.Command.GET_LOGS] = core.getLogsAndNetworkInfo;
+commands[uproxy_core_api.Command.GET_NAT_TYPE] = core.getNatType;
+commands[uproxy_core_api.Command.REFRESH_PORT_CONTROL] = core.refreshPortControlSupport;
+commands[uproxy_core_api.Command.GET_FULL_STATE] = core.getFullState;
+commands[uproxy_core_api.Command.HANDLE_CORE_UPDATE] = core.handleUpdate;
+commands[uproxy_core_api.Command.GET_VERSION] = core.getVersion;
+commands[uproxy_core_api.Command.PING_UNTIL_ONLINE] = core.pingUntilOnline;
+commands[uproxy_core_api.Command.ACCEPT_INVITATION] = core.acceptInvitation;
 
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.LOGOUT,
-    core.logout);
-
-ui_connector.onCommand(uproxy_core_api.Command.MODIFY_CONSENT,
-    core.modifyConsent);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.START_PROXYING_COPYPASTE_GET,
-    core.startCopyPasteGet);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.STOP_PROXYING_COPYPASTE_GET,
-    core.stopCopyPasteGet);
-
-ui_connector.onCommand(
-    uproxy_core_api.Command.START_PROXYING_COPYPASTE_SHARE,
-    core.startCopyPasteShare);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.STOP_PROXYING_COPYPASTE_SHARE,
-    core.stopCopyPasteShare);
-
-ui_connector.onCommand(
-    uproxy_core_api.Command.COPYPASTE_SIGNALLING_MESSAGE,
-    core.sendCopyPasteSignal);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.START_PROXYING,
-    core.start);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.SEND_INVITATION,
-    core.inviteUser);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.GET_INVITE_URL,
-    core.getInviteUrl);
-
-ui_connector.onCommand(uproxy_core_api.Command.SEND_EMAIL,
-    core.sendEmail);
-
-ui_connector.onCommand(uproxy_core_api.Command.STOP_PROXYING,
-    core.stop);
-
-ui_connector.onCommand(
-    uproxy_core_api.Command.UPDATE_GLOBAL_SETTINGS,
-    core.updateGlobalSettings);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.GET_LOGS,
-    core.getLogsAndNetworkInfo);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.GET_NAT_TYPE,
-    core.getNatType);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.REFRESH_PORT_CONTROL,
-    core.refreshPortControlSupport);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.GET_FULL_STATE,
-    core.getFullState);
-
-ui_connector.onCommand(uproxy_core_api.Command.HANDLE_CORE_UPDATE,
-    core.handleUpdate);
-
-ui_connector.onPromiseCommand(uproxy_core_api.Command.GET_VERSION,
-    core.getVersion);
+for (var command in commands) {
+  ui_connector.onCommand(command, commands[command]);
+}
 
 var dailyMetricsReporter = new metrics_module.DailyMetricsReporter(
     globals.metrics, globals.storage, core.getNetworkInfoObj,
@@ -136,12 +87,3 @@ var dailyMetricsReporter = new metrics_module.DailyMetricsReporter(
             {payload: payload, cloudfrontPath: 'submit-rappor-stats'});
       }
     });
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.PING_UNTIL_ONLINE,
-    core.pingUntilOnline);
-
-ui_connector.onPromiseCommand(
-    uproxy_core_api.Command.ACCEPT_INVITATION,
-    core.acceptInvitation);
-

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -1,4 +1,5 @@
 /// <reference path='../../../third_party/typings/freedom/freedom-module-env.d.ts' />
+/// <reference path='../../../third_party/typings/lodash/lodash.d.ts' />
 
 import _ = require('lodash');
 import local_storage = require('./storage');

--- a/src/generic_core/metrics.spec.ts
+++ b/src/generic_core/metrics.spec.ts
@@ -1,5 +1,12 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+});
+
 import metrics_module = require('./metrics');
 import mock_storage = require('../mocks/mock-storage');
 var MockStorage = mock_storage.MockStorage;

--- a/src/generic_core/remote-connection.spec.ts
+++ b/src/generic_core/remote-connection.spec.ts
@@ -6,6 +6,18 @@
  * after that connection is established
  */
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'core.tcpsocket': () => { return new freedom_mocks.MockTcpSocket(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
+
 import globals = require('./globals');
 import remote_connection = require('./remote-connection');
 import social = require('../interfaces/social');

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -8,6 +8,17 @@
  */
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'core.tcpsocket': () => { return new freedom_mocks.MockTcpSocket(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
+
 import remote_user = require('./remote-user');
 import consent = require('./consent');
 import remote_instance = require('./remote-instance');

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -1,5 +1,15 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
+
 import social = require('../interfaces/social');
 import remote_user = require('./remote-user');
 import remote_instance = require('./remote-instance');

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -1,6 +1,15 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 /// <reference path='../../../third_party/typings/freedom/freedom-module-env.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
 
 import social = require('../interfaces/social');
 

--- a/src/generic_core/storage.spec.ts
+++ b/src/generic_core/storage.spec.ts
@@ -1,5 +1,14 @@
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
 
 import local_storage = require('./storage');
 import globals = require('./globals');

--- a/src/generic_core/ui_connector.spec.ts
+++ b/src/generic_core/ui_connector.spec.ts
@@ -1,0 +1,113 @@
+/// <reference path='../../../third_party/typings/freedom/freedom.d.ts' />
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+import mockFreedomRtcPeerConnection = require('../../../third_party/uproxy-lib/freedom/mocks/mock-rtcpeerconnection');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+});
+
+var updates :{[name :string] :Function} = {};
+var fakeFreedom = freedom();
+
+var nextCommand = 12345;
+var nextPromise = 12345;
+
+import ui_connector = require('./ui_connector');
+import UIConnector = ui_connector.UIConnector;
+import uproxy_core_api = require('../interfaces/uproxy_core_api');
+
+describe('UIConnector', () => {
+  var connector :UIConnector;
+
+  beforeEach(() => {
+    connector = new UIConnector();
+
+    spyOn(fakeFreedom, 'on').and.callFake((name :string, callback :Function) => {
+      updates[name] = callback;
+    });
+    spyOn(fakeFreedom, 'emit');
+  });
+
+  it('non-promise function', (done) => {
+    var fn = () => { /* MT */ }
+    var command = nextCommand++;
+
+    connector.onCommand(command, fn);
+    updates[command.toString()]({data: {}}).then(() => {
+      expect(fakeFreedom.emit).not.toHaveBeenCalled();
+      done();
+    });
+  });
+
+  it('function returning nothing', (done) => {
+    var fn = () => { /* MT */ }
+    var command = nextCommand++;
+    var promiseId = nextPromise++;
+
+    connector.onCommand(command, fn);
+    updates[command.toString()]({data: {}, promiseId: promiseId}).then(() => {
+      expect(fakeFreedom.emit).toHaveBeenCalledWith(
+          uproxy_core_api.Update.COMMAND_FULFILLED.toString(),
+          jasmine.objectContaining({
+            promiseId: promiseId
+          })
+      );
+      done();
+    });
+  });
+
+  it('function returinng unexpected value', (done) => {
+    var fn = () => { return <any>true; }
+    var command = nextCommand++;
+    var promiseId = nextPromise++;
+
+    connector.onCommand(command, fn);
+    updates[command.toString()]({data: {}, promiseId: promiseId}).then(() => {
+      expect(fakeFreedom.emit).toHaveBeenCalledWith(
+          uproxy_core_api.Update.COMMAND_FULFILLED.toString(),
+          jasmine.objectContaining({
+            promiseId: promiseId,
+            argsForCallback: true,
+          })
+      );
+      done();
+    });
+  });
+
+  it('function behaving correctly', (done) => {
+    var fn = () => { return Promise.resolve(true); }
+    var command = nextCommand++;
+    var promiseId = nextPromise++;
+
+    connector.onCommand(command, fn);
+    updates[command.toString()]({data: {}, promiseId: promiseId}).then(() => {
+      expect(fakeFreedom.emit).toHaveBeenCalledWith(
+          uproxy_core_api.Update.COMMAND_FULFILLED.toString(),
+          jasmine.objectContaining({
+            promiseId: promiseId,
+            argsForCallback: true,
+          })
+      );
+      done();
+    });
+  });
+
+  it('function throws exception', (done) => {
+    var fn = () => { throw new Error(); };
+    var command = nextCommand++;
+    var promiseId = nextPromise++;
+
+    connector.onCommand(command, fn);
+    updates[command.toString()]({data: {}, promiseId: promiseId}).then(() => {
+      expect(fakeFreedom.emit).toHaveBeenCalledWith(
+          uproxy_core_api.Update.COMMAND_REJECTED.toString(),
+          jasmine.objectContaining({
+            promiseId: promiseId,
+          })
+      );
+      done();
+    });
+  });
+});

--- a/src/generic_core/ui_connector.ts
+++ b/src/generic_core/ui_connector.ts
@@ -18,51 +18,64 @@ var bgAppPageChannel = freedom();
 export class UIConnector {
   constructor() {}
 
-  /**
-   * Install a handler for commands received from the UI.
-   */
-  public onCommand = (cmd :uproxy_core_api.Command, handler:any) => {
-    bgAppPageChannel.on('' + cmd,
-      (args :browser_connector.PromiseCommand) => {
-        // Call handler with args.data and ignore other fields in args
-        // like promiseId.
-        handler(args.data);
-      });
+  private fulfillPromise_(promiseId :number,
+                          command :uproxy_core_api.Command,
+                          args?:any) {
+    this.update(uproxy_core_api.Update.COMMAND_FULFILLED, {
+      command: command,
+      promiseId: promiseId,
+      argsForCallback: args,
+    });
   }
 
-  /**
-   * Install a handler for promise commands received from the UI.
-   * Promise commands return an ack or error to the UI.
-   */
-  public onPromiseCommand = (cmd :uproxy_core_api.Command,
-                             handler :(data ?:any) => Promise<any>) => {
-    var promiseCommandHandler = (args :browser_connector.PromiseCommand) => {
-      // Ensure promiseId is set for all requests
-      if (!args.promiseId) {
-        var err = 'onPromiseCommand called for cmd ' + cmd +
-                  'with promiseId undefined';
-        log.error(err);
-        return Promise.reject(new Error(err));
+  private rejectPromise_(promiseId :number, reason :Error) {
+    this.update(uproxy_core_api.Update.COMMAND_REJECTED, {
+      promiseId: promiseId,
+      errorForCallback: reason.toString(),
+    });
+  }
+
+  public onCommand(cmd :uproxy_core_api.Command,
+                   handler :(data ?:any) => (Promise<any>|void)) {
+    // this function returns a promise solely for use in tests, it will normally
+    // not affect anything
+    var commandHandler = (args :browser_connector.PromiseCommand) => {
+      try {
+        var result = handler(args.data);
+      } catch (e) {
+        result = Promise.reject(e);
       }
 
-      // Call handler function, then return success or failure to UI.
-      handler(args.data).then(
-        (argsForCallback ?:any) => {
-          this.update(uproxy_core_api.Update.COMMAND_FULFILLED,
-              { command: cmd,
-                promiseId: args.promiseId,
-                argsForCallback: argsForCallback });
-        },
-        (errorForCallback :Error) => {
-          var rejectionData = {
-            promiseId: args.promiseId,
-            errorForCallback: errorForCallback.toString()
-          };
-          this.update(uproxy_core_api.Update.COMMAND_REJECTED, rejectionData);
+      if (!args.promiseId) {
+        if (result) {
+          console.warn('Unexpected return value from command ' + cmd + ' with ' +
+                       'no way to send result');
         }
-      );
-    };
-    bgAppPageChannel.on('' + cmd, promiseCommandHandler);
+        return Promise.resolve<void>();
+      }
+
+      if (!result) {
+        this.fulfillPromise_(args.promiseId, cmd, null);
+        log.warn('Handler for command ' + cmd + ' did not return the expected ' +
+                 'value');
+        return Promise.resolve<void>();
+      }
+
+      if (!(<Promise<any>>result).then) {
+        log.warn('Handler for command ' + cmd + ' returned a value instead of ' +
+                 'a promise');
+        this.fulfillPromise_(args.promiseId, cmd, result);
+        return Promise.resolve<void>();
+      }
+
+      return (<Promise<any>>result).then((result?:any) => {
+        this.fulfillPromise_(args.promiseId, cmd, result);
+      }, (error :Error) => {
+        this.rejectPromise_(args.promiseId, error);
+      });
+    }
+
+    bgAppPageChannel.on('' + cmd, commandHandler);
   }
 
   /**

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -63,32 +63,6 @@ describe('Core', () => {
     expect(user.modifyConsent).toHaveBeenCalledWith(uproxy_core_api.ConsentUserAction.REQUEST);
   });
 
-  it('relays incoming manual network messages to the manual network', () => {
-    var manualNetwork :social_network.ManualNetwork =
-        new social_network.ManualNetwork(social_network.MANUAL_NETWORK_ID);
-
-    spyOn(social_network, 'getNetwork').and.returnValue(manualNetwork);
-    spyOn(manualNetwork, 'receive');
-
-    var senderClientId = 'dummy_sender';
-    var message :social.VersionedPeerMessage = {
-      type: social.PeerMessageType.SIGNAL_FROM_SERVER_PEER,
-      data: {
-        elephants: 'have trunks',
-        birds: 'do not'
-      },
-      version: globals.MESSAGE_VERSION
-    };
-    var command :social.HandleManualNetworkInboundMessageCommand = {
-      senderClientId: senderClientId,
-      message: message
-    };
-    core.handleManualNetworkInboundMessage(command);
-
-    expect(social_network.getNetwork).toHaveBeenCalledWith(social_network.MANUAL_NETWORK_ID, '');
-    expect(manualNetwork.receive).toHaveBeenCalledWith(senderClientId, message);
-  });
-
   it('login fails for invalid network', (done) => {
     core.login({network: 'nothing', reconnect: false}).catch(() => {
       done();

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -8,6 +8,17 @@
  */
 /// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
 
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+
+import freedom_mocks = require('../mocks/freedom-mocks');
+freedom = freedomMocker.makeMockFreedomInModuleEnv({
+  'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
+  'loggingcontroller': () => { return new freedom_mocks.MockLoggingController(); },
+  'metrics': () => { return new freedom_mocks.MockMetrics(); },
+  'pgp': () => { return new freedom_mocks.PgpProvider() },
+  'portControl': () => { return new Object },
+});
+
 import globals = require('./globals');
 import social = require('../interfaces/social');
 import social_network = require('./social');

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -375,20 +375,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     // TODO: Handle revoked permissions notifications.
   }
 
-  public handleManualNetworkInboundMessage =
-      (command :social.HandleManualNetworkInboundMessageCommand) => {
-    var manualNetwork :social_network.ManualNetwork =
-        <social_network.ManualNetwork> social_network.getNetwork(
-            social_network.MANUAL_NETWORK_ID, '');
-    if (!manualNetwork) {
-      log.error('Manual network does not exist, discarding inbound message',
-                command);
-      return;
-    }
-
-    manualNetwork.receive(command.senderClientId, command.message);
-  }
-
   /**
    * Obtain the RemoteInstance corresponding to an instance path.
    */

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -259,13 +259,6 @@ export class UserInterface implements ui_constants.UiApi {
 
     core.onUpdate(uproxy_core_api.Update.USER_FRIEND, this.syncUser);
 
-    core.onUpdate(uproxy_core_api.Update.MANUAL_NETWORK_OUTBOUND_MESSAGE,
-                  (message :social.PeerMessage) => {
-      console.log('Manual network outbound message: ' +
-                  JSON.stringify(message));
-      // TODO: Display the message in the 'manual network' UI.
-    });
-
     core.onUpdate(uproxy_core_api.Update.ONETIME_MESSAGE, (message:string) => {
       this.copyPasteState.message = message;
     });

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -158,15 +158,6 @@ export interface VersionedPeerMessage extends PeerMessage {
   version: number;
 }
 
-// The payload of a HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE command. There is a
-// client ID for the sender but no user ID because in the manual network
-// there is no concept of a single user having multiple clients; in the
-// manual network the client ID uniquely identifies the user.
-export interface HandleManualNetworkInboundMessageCommand {
-  message         :VersionedPeerMessage;
-  senderClientId  :string;
-}
-
 // The different states that uProxy consent can be in w.r.t. a peer. These
 // are the values that get sent or received on the wire.
 export interface ConsentWireState {

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -87,8 +87,6 @@ export enum Command {
   STOP_PROXYING_COPYPASTE_SHARE = 1011,
   COPYPASTE_SIGNALLING_MESSAGE = 1012,
 
-  // Payload should be a HandleManualNetworkInboundMessageCommand.
-  HANDLE_MANUAL_NETWORK_INBOUND_MESSAGE = 1013,
   SEND_CREDENTIALS = 1014,
   UPDATE_GLOBAL_SETTINGS = 1015,
   GET_LOGS = 1016,
@@ -118,8 +116,6 @@ export enum Update {
   STOP_GETTING_FROM_FRIEND = 2008,
   START_GIVING_TO_FRIEND = 2009,
   STOP_GIVING_TO_FRIEND = 2010,
-  // Payload should be a Message.
-  MANUAL_NETWORK_OUTBOUND_MESSAGE = 2011,
   // TODO: "Get credentials" is a command, not an "update". Consider
   // renaming the "Update" enum.
   GET_CREDENTIALS = 2012,


### PR DESCRIPTION
    Make it easier to register commands
    
    This makes it easier to register commands by adding an array we loop
    through.
    
    In order to support that, we needed a single function we could call in
    order to register a function that may or may not return a promise, this
    is done as a new onCommand function.
    
    In order to have a single function, we now have the onCommand do error
    checking to determine whether a promise was passed/expected and then
    have it send the promise.  Anyways, that's going to take error handling.
    Yay!
    
    Because that is confusing, this also adds tests.
    
    Review for this should include answering the question: Does this
    actually improve anything?

Also changed:

    Switch our unit tests to have single-file scope
    Remove the manual social network from the codebase

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2072)
<!-- Reviewable:end -->
