### PR TITLE
For Cloud, display empty share rosters correctly.

### DIFF
--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -125,7 +125,6 @@
 
     <div tabindex='-1'
         class='nameRow frame {{ isOnline ? "online" : "offline" }} {{ contact.status==UserStatus.REMOTE_INVITED_BY_LOCAL ? "" : "expandable" }}'
-        hidden?="{{contact.network.name=='Cloud' && mode==ui_constants.Mode.SHARE}}"
         top horizontal layout>
       <uproxy-avatar src='{{ contact.imageData }}' network='{{ contact.network.name }}' showIcon='{{ model.onlineNetworks.length > 1 }}' on-tap='{{ toggle }}'></uproxy-avatar>
       <div flex>

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -22,6 +22,8 @@ Polymer({
     }
   },
   computed: {
-    'hasContacts': '(model.contacts.getAccessContacts.pending.length + model.contacts.getAccessContacts.trustedUproxy.length + model.contacts.getAccessContacts.untrustedUproxy.length + model.contacts.shareAccessContacts.pending.length + model.contacts.shareAccessContacts.trustedUproxy.length + model.contacts.shareAccessContacts.untrustedUproxy.length) > 0',
+    'hasGetContacts': '(model.contacts.getAccessContacts.pending.length + model.contacts.getAccessContacts.trustedUproxy.length + model.contacts.getAccessContacts.untrustedUproxy.length) > 0',
+    'hasShareContacts': '(model.contacts.shareAccessContacts.pending.length + model.contacts.shareAccessContacts.trustedUproxy.length + model.contacts.shareAccessContacts.untrustedUproxy.length) > 0',
+    'hasContacts': '(mode==ui_constants.Mode.GET && hasGetContacts) || (mode==ui_constants.Mode.SHARE && hasShareContacts)'
   },
 });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -86,8 +86,10 @@ export class Model {
       var userCategories = user.getCategories();
       categorizeUser(user, this.contacts.getAccessContacts,
                      userCategories.getTab, null);
-      categorizeUser(user, this.contacts.shareAccessContacts,
-                     userCategories.shareTab, null);
+      if (user.network.name !== "Cloud") {
+        categorizeUser(user, this.contacts.shareAccessContacts,
+                       userCategories.shareTab, null);
+      }
     }
 
     _.remove(this.onlineNetworks, { name: networkName });
@@ -963,8 +965,10 @@ export class UserInterface implements ui_constants.UiApi {
     // Update the user's category in both get and share tabs.
     categorizeUser(user, this.model.contacts.getAccessContacts,
         oldUserCategories.getTab, newUserCategories.getTab);
-    categorizeUser(user, this.model.contacts.shareAccessContacts,
-        oldUserCategories.shareTab, newUserCategories.shareTab);
+    if (user.network.name !== "Cloud") {
+      categorizeUser(user, this.model.contacts.shareAccessContacts,
+          oldUserCategories.shareTab, newUserCategories.shareTab);
+    }
     this.updateBadgeNotification_();
 
     console.log('Synchronized user.', user);


### PR DESCRIPTION
This removes logic for hiding contacts in contact.ts and instead just prevents Cloud contacts from being added to share rosters.

This is so that the "contacts.length" numbers everywhere are correct, and that the Share roster will look empty if we only have Cloud friends.

For example, before this fix, we would see:
![image](https://cloud.githubusercontent.com/assets/8723127/11344442/542b45b0-91df-11e5-8201-84cd045b6996.png)

Now we will see (as expected):
![image](https://cloud.githubusercontent.com/assets/8723127/11344452/66d39604-91df-11e5-9ad8-8dc78b2d9906.png)

while the get tab shows:
![image](https://cloud.githubusercontent.com/assets/8723127/11344830/84545572-91e1-11e5-976a-584702350217.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2079)
<!-- Reviewable:end -->
