### PR TITLE
Lengthen connection timeout from 30s to 90s

### DIFF
--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -78,7 +78,7 @@ import ui = ui_connector.connector;
     private isUIUpdatePending = false;
 
     // Number of milliseconds before timing out socksToRtc_.start
-    public SOCKS_TO_RTC_TIMEOUT :number = 30000;
+    public SOCKS_TO_RTC_TIMEOUT :number = 90000;
     // Ensure RtcToNet is only closed after SocksToRtc times out (i.e. finishes
     // trying to connect) by timing out rtcToNet_.start 15 seconds later than
     // socksToRtc_.start


### PR DESCRIPTION
This seems to be required for connections between my phone (nexus 4)
and test box (Atom-class server) over a fast connection.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2085)
<!-- Reviewable:end -->
