### PR TITLE
migrate to uproxy-lib with cloud fix for firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "lodash": "^3.7.0",
     "regex2dfa": "^0.1.6",
     "tsd": "^0.6.3",
-    "uproxy-lib": "^35.0.1",
+    "uproxy-lib": "^35.0.2",
     "utransformers": "^0.2.1",
     "xregexp": "^2.0.0"
   },


### PR DESCRIPTION
Done, finally!

BTW, this does serve to specify the minimum required version of uproxy-lib, and help out anybody who was building against 35.0.1.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2091)
<!-- Reviewable:end -->
