### PR TITLE
Make accept-user-invite screen use same code+logic as invite URLs

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -915,9 +915,9 @@
     "description": "Message for confirmation that the user must login to a network to accept an invitation",
     "message": "To accept this invitation to connect with __name__, you will need to login to uProxy with __network__.  Click yes to continue."
   },
-  "INVITE_URL_ERROR": {
-    "description": "Error message shown for invalid invite URLs",
-    "message": "There was an error with your invite URL."
+  "INVITE_ERROR": {
+    "description": "Error message shown for invalid invite URLs or tokens",
+    "message": "There was an error with your invite."
   },
   "INVITE_EMAIL_SUBJECT": {
     "description": "Default email subject for sending an uProxy invite",

--- a/src/generic_ui/polymer/accept-user-invite.ts
+++ b/src/generic_ui/polymer/accept-user-invite.ts
@@ -9,45 +9,11 @@ var core = ui_context.core;
 
 Polymer({
   acceptInvitation: function() {
-    var token = this.receivedInviteToken.lastIndexOf('/') >= 0 ?
-    this.receivedInviteToken.substr(this.receivedInviteToken.lastIndexOf('/') + 1) : this.receivedInviteToken;
-    var tokenObj = JSON.parse(atob(token));
-    var networkName = tokenObj.networkName;
-
-    var confirmLogin = Promise.resolve<void>();
-    if (networkName === "Cloud") {
-      // Inform the user that their invite code will connect them to our Cloud
-      // social provider.
-      // TODO: Remove this when we fully launch Cloud.
-      var confirmationMessage = ui.i18n_t("CLOUD_INVITE_CONFIRM");
-      confirmLogin = ui.getConfirmation('', confirmationMessage).then(() => {
-        // Set mode to GET, as Cloud friends only appear in the GET tab.
-        ui.setMode(ui_constants.Mode.GET);
-        if (model.getNetwork("Cloud")) {
-          return Promise.resolve<void>();
-        }
-        return ui.login("Cloud").catch((e :Error) => {
-          console.warn('Error logging into Cloud', e);
-        });
-      }).catch(() => {
-        console.log("Cloud login declined");
-        return;
-      });
-    }
-
-    var socialNetworkInfo = {
-      name: networkName,
-      userId: "" /* The current user's ID will be determined by the core. */
-    };
-
-    confirmLogin.then(() => {
-      core.acceptInvitation({network: socialNetworkInfo, token: this.receivedInviteToken})
-          .then(() => {
-        ui.showDialog('', ui.i18n_t('FRIEND_ADDED'));
-        this.closeAcceptUserInvitePanel();
-      }).catch(() => {
-        ui.showDialog('', ui.i18n_t('FRIEND_ADD_ERROR'));
-      });
+    ui.handleInvite(this.receivedInviteToken).then(() => {
+      ui.showDialog('', ui.i18n_t('FRIEND_ADDED'));
+      this.closeAcceptUserInvitePanel();
+    }).catch(() => {
+      ui.showDialog('', ui.i18n_t('FRIEND_ADD_ERROR'));
     });
   },
   openAcceptUserInvitePanel: function() {


### PR DESCRIPTION
Make accept-user-invite screen use same code+logic as invite URLs.  Fixes #2075 (accepting an invite from the accept-user-invite.html screen was failing if you weren't already logged into the network).

Also makes a small change to the cloud invite confirmation text.  Now, regardless of whether the user is logged into Cloud or not, they still see the same confirmation, ```You've entered an experimental Cloud invitation. Accepting this invitation will connect you to a virtual machine. Would you like to accept?```

Tested the following:
* navigating to URLs for GMail, Quiver, Cloud when already logged into those networks
* navigating to URLs for GMail, Quiver, Cloud when not yet logged into those networks
* entering an invite into accept-user-invite.html when already logged into the network
* entering an invite into accept-user-invite.html when not yet logged into the network
* entering invites in accept-user-invite.html both with and without the leading URL

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2100)
<!-- Reviewable:end -->
