### PR TITLE
Update freedom-for-chrome to 0.4.22, which has a socket fix for Cordova

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "crypto": "^0.0.3",
     "es6-promise": "^2.0.0",
     "freedom": "^0.6.27",
-    "freedom-for-chrome": "^0.4.20",
+    "freedom-for-chrome": "^0.4.22",
     "freedom-for-firefox": "^0.6.15",
     "freedom-pgp-e2e": "^0.5.0",
     "freedom-port-control": "^0.9.0",


### PR DESCRIPTION
This fixes #2084.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2114)
<!-- Reviewable:end -->
