### PR TITLE
Move metrics opt-in to the SPLASH view.

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -338,11 +338,6 @@
               hidden?='{{ !model.globalSettings.statsReportingEnabled }}' on-tap='{{ statsIconClicked }}'></core-icon>
           </core-tooltip>
 
-          <uproxy-bubble on-closed='{{ closeStatsBubble }}' active='{{ model.globalSettings.statsReportingEnabled && statsDialogOrBubbleOpen }}'>
-            <h3>{{ "STATS_ENABLED_TITLE" | $$ }}</h3>
-            <p>{{ "STATS_ENABLED_MESSAGE" | $$ }}</p>
-          </uproxy-bubble>
-
           <core-tooltip label='{{ "SHARING_ENABLED_TOOLTIP" | $$ }}' position='{{ dir == "rtl" ? "right" : "left" }}'>
             <core-icon id='sharingEnabledIcon' icon='uproxy-icons:share' class='status'
               hidden?='{{ !isSharingEnabledWithOthers }}'
@@ -379,7 +374,7 @@
           core-header-panel and it is positioned below the toolbar (see
           https://www.polymer-project.org/0.5/docs/elements/core-header-panel.html)
         -->
-        <uproxy-bubble class='core-header' on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome && !statsDialogOrBubbleOpen }}' noclear="true">
+        <uproxy-bubble class='core-header' on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome }}' noclear="true">
           <p>
             {{ "WELCOME_MESSAGE" | $$ }}
           </p>
@@ -461,22 +456,6 @@
         </uproxy-button>
       </template>
     </uproxy-action-dialog>
-
-    <core-overlay id='statsDialog' backdrop layered="false" heading='{{ "WELCOME" | $$ }}'>
-      <div>
-        <h1>{{ "WELCOME" | $$ }}</h1>
-        <p>
-          {{ "BETA_MESSAGE" | $$ }}<br><br>
-          {{ "CHANGE_STATS_CHOICE" | $$ }}
-        </p>
-        <p><b>{{ "ENABLE_METRICS" | $$ }}</b></p>
-        <uproxy-button id='enableStatsButton' on-tap='{{ enableStats }}'>{{ "IM_IN" | $$ }}</uproxy-button>
-        <uproxy-button id='disableStatsButton' on-tap='{{ disableStats }}'>{{ "NO_THANKS" | $$ }}</uproxy-button>
-      </div>
-      <uproxy-faq-link anchor='doesUproxyLogData'>
-        {{ "MORE_ABOUT_METRICS" | $$ }}
-      </uproxy-faq-link>
-    </core-overlay>
 
     <uproxy-action-dialog id='disconnectDialog' backdrop layered="false"
         opened="{{ !!core.disconnectedWhileProxying }}" autoCloseDisabled>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -36,10 +36,6 @@ Polymer({
     // this event.
     if (newView == ui_types.View.ROSTER && oldView == ui_types.View.SPLASH) {
       this.fire('core-signal', {name: "login-success"});
-      if (!model.globalSettings.hasSeenWelcome) {
-        this.statsDialogOrBubbleOpen = true;
-        this.$.statsDialog.toggle();
-      }
       this.closeSettings();
       this.$.modeTabs.updateBar();
     }
@@ -152,26 +148,7 @@ Polymer({
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
-    if (ui.view == ui_types.View.ROSTER &&
-        !model.globalSettings.hasSeenWelcome) {
-      this.statsDialogOrBubbleOpen = true;
-      this.$.statsDialog.open();
-    }
     this.updateDirectionality();
-  },
-  closeStatsBubble: function() {
-    this.statsDialogOrBubbleOpen = false;
-  },
-  enableStats: function() {
-    // TODO: clean up the logic which controls which welcome dialog or bubble
-    // is shown.
-    this.model.globalSettings.statsReportingEnabled = true;
-    this.$.statsDialog.close();
-  },
-  disableStats: function() {
-    this.model.globalSettings.statsReportingEnabled = false;
-    this.statsDialogOrBubbleOpen = false;
-    this.$.statsDialog.close();
   },
   tabSelected: function(e :Event) {
     if (this.ui.isSharingDisabled &&

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -189,7 +189,7 @@
         </uproxy-link>
 
         <div id='metricsCheckbox'>
-          <paper-checkbox checked='{{ model.globalSettings.statsReportingEnabled }}' label='{{ "STATS_ENABLED_TITLE" | $$ }}'></paper-checkbox>
+          <paper-checkbox label='{{ "STATS_ENABLED_TITLE" | $$ }}' checked='{{ model.globalSettings.statsReportingEnabled }}' on-change='{{updateStatsReportingEnabled}}'></paper-checkbox>
           <uproxy-faq-link class='faq-icon' anchor='doesUproxyLogData'>
             <core-icon icon='help'></core-icon>
           </uproxy-faq-link>

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -38,6 +38,9 @@ Polymer({
       this.connectedNetworks = ui.i18n_t("CONNECTED_WITH_NUMBER", {number: model.onlineNetworks.length});
     }
   },
+  updateStatsReportingEnabled: function() {
+    core.updateGlobalSettings(model.globalSettings);
+  },
   toggleAccountChooser: function() {
     this.accountChooserOpen = !this.accountChooserOpen;
   },

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -99,8 +99,17 @@
       margin-left: 8px;
       margin-right: 8px;
     }
-    #intro1, #networks {
+    #intro1, #networks, #metricsOptIn {
       height: 100%;
+    }
+    #metricsOptIn {
+      text-align: start;
+    }
+    #metricsButtons {
+      text-align: end;
+    }
+    #metricsButtons uproxy-button {
+      padding: 0px 10px;
     }
     #languageLink paper-dropdown-menu {
       border-bottom: 0px;
@@ -198,6 +207,26 @@
         </paper-button>
       </uproxy-faq-link>
 
+    </div>
+
+    <div vertical layout id="metricsOptIn" hidden?='{{SPLASH_STATES.METRICS_OPT_IN!==model.globalSettings.splashState}}'>
+      <div class="view" flex>
+        <h1>{{ "WELCOME" | $$ }}</h1>
+        <p>
+          {{ "BETA_MESSAGE" | $$ }}<br><br>
+          {{ "CHANGE_STATS_CHOICE" | $$ }}
+        </p>
+        <p><b>{{ "ENABLE_METRICS" | $$ }}</b></p>
+        <div id="metricsButtons">
+          <uproxy-button id='enableStatsButton' on-tap='{{ enableStats }}'>{{ "IM_IN" | $$ }}</uproxy-button>
+          <uproxy-button id='disableStatsButton' on-tap='{{ disableStats }}'>{{ "NO_THANKS" | $$ }}</uproxy-button>
+        </div>
+      </div>
+      <uproxy-faq-link anchor='doesUproxyLogData'>
+        <paper-button>
+          {{ "MORE_ABOUT_METRICS" | $$ }}
+        </paper-button>
+      </uproxy-faq-link>
     </div>
 
     <div vertical layout id='networks' hidden?='{{SPLASH_STATES.NETWORKS!==model.globalSettings.splashState}}'>

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -108,11 +108,13 @@ Polymer({
     this.supportsQuiver = supportsQuiver;
   },
   enableStats: function() {
-    this.model.globalSettings.statsReportingEnabled = true;
+    model.globalSettings.statsReportingEnabled = true;
+    core.updateGlobalSettings(model.globalSettings);
     this.next();
   },
   disableStats: function() {
-    this.model.globalSettings.statsReportingEnabled = false;
+    model.globalSettings.statsReportingEnabled = false;
+    core.updateGlobalSettings(model.globalSettings);
     this.next();
   },
   observe: {

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -23,7 +23,8 @@ var model = ui_context.model;
 Polymer({
   SPLASH_STATES: {
     INTRO: 0,
-    NETWORKS: 1
+    METRICS_OPT_IN: 1,
+    NETWORKS: 2
   },
   setState: function(state :Number) {
     if (state < 0 || state > Object.keys(this.SPLASH_STATES).length) {
@@ -33,15 +34,28 @@ Polymer({
     model.globalSettings.splashState = state;
     core.updateGlobalSettings(model.globalSettings);
   },
+  // TODO: Remove the if and else if blocks for next() and prev() when we
+  // remove the NETWORKS splash state.
   next: function() {
-    if (this.supportsQuiver) {
+    if (this.supportsQuiver && model.globalSettings.splashState
+        == this.SPLASH_STATES.METRICS_OPT_IN) {
       ui.view = ui_constants.View.ROSTER;
+    } else if (model.globalSettings.hasSeenWelcome &&
+        model.globalSettings.splashState == this.SPLASH_STATES.INTRO) {
+        // Skip metrics opt-in if we've seen it before.
+        this.setState(this.SPLASH_STATES.NETWORKS);
     } else {
       this.setState(model.globalSettings.splashState + 1);
     }
   },
   prev: function() {
-    this.setState(model.globalSettings.splashState - 1);
+    if (model.globalSettings.hasSeenWelcome &&
+        model.globalSettings.splashState == this.SPLASH_STATES.NETWORKS) {
+        // Skip metrics opt-in if we've seen it before.
+        this.setState(this.SPLASH_STATES.INTRO);
+    } else {
+      this.setState(model.globalSettings.splashState - 1);
+    }
   },
   copypaste: function() {
     this.fire('core-signal', { name: 'copypaste-init' });
@@ -92,6 +106,14 @@ Polymer({
     // Only set .supportsQuiver after iterating through all networks, to prevent
     // any flicker in case we switch from true to false to true again.
     this.supportsQuiver = supportsQuiver;
+  },
+  enableStats: function() {
+    this.model.globalSettings.statsReportingEnabled = true;
+    this.next();
+  },
+  disableStats: function() {
+    this.model.globalSettings.statsReportingEnabled = false;
+    this.next();
   },
   observe: {
     'model.networkNames': 'updateNetworkButtonNames'


### PR DESCRIPTION
Tested in Chrome/FF in dist and dev. 
For FF this also fixes the extra wide buttons we were seeing on the metrics opt in page.

@dborkan I'm removing the "Anonymous metrics enabled" bubble in this PR too (it made things simpler) so I can wait until you have your changes in before having this reviewed!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2116)
<!-- Reviewable:end -->
