### PR TITLE
Update GitHub confirmation text

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1127,6 +1127,6 @@
   },
   "GITHUB_LOGIN_CONFIRMATION": {
     "description": "Confirmation message the user sees prior to logging into GitHub",
-    "message": "Github is meant to allow software developers to share code, but uProxy can use Github to exchange the information necessary to setup direct connections with your friends.<br><br>Because uProxy creates Github gists, and it may be possible for others to tell which Github accounts are using uProxy, <strong>we recommend you create a new anonymous Github account</strong>, even if you already use Github."
+    "message": "uProxy can use Github, a developer tool, to help you connect with your friends.<br><br>Because it may be possible for others to tell which Github accounts are using uProxy, <strong>we recommend you create a new anonymous Github account</strong>, even if you already use Github.  <strong>You will need to verify your email with GitHub before you connect.</strong>"
   }
 }


### PR DESCRIPTION
Update GitHub confirmation text, the new text fits better and also mentions that users need to verify their email addresses:
<img width="483" alt="screen shot 2015-12-15 at 2 35 47 pm" src="https://cloud.githubusercontent.com/assets/6494307/11821831/76242ff4-a339-11e5-902c-419c9b53ec4c.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2138)
<!-- Reviewable:end -->
