### PR TITLE
Slight change to Quiver clientId parsing

### DIFF
--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -269,7 +269,8 @@ export function notifyUI(networkName :string, userId :string) {
     public getKeyFromClientId = (clientId :string) : string => {
       var beginPgpString = '-----BEGIN PGP PUBLIC KEY BLOCK-----';
       var endPgpString = '-----END PGP PUBLIC KEY BLOCK-----\r\n';
-      return clientId.match(beginPgpString + '(.|[\r\n])*' + endPgpString)[0];
+      var start = clientId.lastIndexOf(beginPgpString);
+      return clientId.slice(start).match(beginPgpString + '(.|[\r\n])*' + endPgpString)[0];
     }
 
   }  // class AbstractNetwork


### PR DESCRIPTION
Needed to allow freeform userId

This should be compatible with both current and future Quiver

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2155)
<!-- Reviewable:end -->
