### PR TITLE
Updated gruntfile and index.html to build uProxy on ios

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -208,18 +208,22 @@ gruntConfig = {
       command: 'rm -rf <%= androidDevPath %>; rm -rf <%= androidDistPath %>'
     }
     ccaCreateIosDev: {
-      command: '<%= ccaJsPath %> create <%= iosDevPath %> --link-to=<%= ccaDevPath %>'
+      command: '<%= ccaJsPath %> create <%= iosDevPath %> org.uproxy.uProxy "uProxy" --link-to=<%= ccaDevPath %>'
     }
     ccaCreateIosDist: {
-      command: '<%= ccaJsPath %> create <%= iosDistPath %> --link-to=<%= ccaDistPath %>'
+      command: '<%= ccaJsPath %> create <%= iosDistPath %> org.uproxy.uProxy "uProxy" --link-to=<%= ccaDevPath %>'
     }
-    ccaBuildIosDev: {
+    ccaPrepareIosDev: {
       cwd: '<%= iosDevPath %>'
-      command: '<%= ccaJsPath %> build ios'
+      command: '<%= ccaJsPath %> prepare'
     }
-    ccaBuildIosDist: {
+    ccaPrepareIosDist: {
       cwd: '<%= iosDistPath %>'
-      command: '<%= ccaJsPath %> build ios'
+      command: '<%= ccaJsPath %> prepare'
+    }
+    ccaEmulateIos: {
+      cwd: '<%= iosDevPath %>'
+      command: '<%= ccaJsPath %> run ios --emulator'
     }
     rmIosBuild: {
       command: 'rm -rf <%= iosDevPath %>; rm -rf <%= iosDistPath %>'
@@ -1092,7 +1096,7 @@ taskManager.add 'release_android', [
   'exec:ccaReleaseAndroid'
 ]
 
-# Emulate the mobile client
+# Emulate the mobile client for android
 taskManager.add 'emulate_android', [
  'build_android'
  'exec:ccaEmulateAndroid'
@@ -1101,8 +1105,14 @@ taskManager.add 'emulate_android', [
 taskManager.add 'build_ios', [
   'exec:rmIosBuild'
   'build_cca'
-  'exec:ccaCreateIos'
-  'exec:ccaBuildIos'
+  'exec:ccaCreateIosDev'
+  'exec:ccaPrepareIosDev'
+]
+
+# Emulate the mobile client for ios
+taskManager.add 'emulate_ios', [
+ 'build_ios'
+ 'exec:ccaEmulateIos'
 ]
 
 # --- Testing tasks ---

--- a/src/cca/app/index.html
+++ b/src/cca/app/index.html
@@ -6,8 +6,9 @@
   <title>uProxy</title>
   <meta name='viewport' content='width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes'>
   <!-- This version of index.html is only loaded in Chrome (Crosswalk), so the shim is not needed -->
-  <!-- TODO: Will we need to reintroduce the shim to support iOS? -->
-  <!-- <script src='../bower/webcomponentsjs/webcomponents.min.js'></script> -->
+  <!-- Needed to reintroduce the shim to support iOS -->
+  <!-- TODO: Can the shim be removed when crosswalk for ios is implemented? -->
+  <script src='../bower/webcomponentsjs/webcomponents.min.js'></script>
 
   <script src='scripts/context.static.js'></script>
 


### PR DESCRIPTION
- Updated cca/app/index.html by uncommenting <script src='../bower/webcomponentsjs/webcomponents.min.js'></script>
- Updated Gruntfile by adding correct commands to build ios; now you can use 'grunt build_ios' or 'grunt emulate_ios' to run uproxy on ios

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2165)
<!-- Reviewable:end -->
