### PR TITLE
replace cloud confirmation dialog with a toast

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -785,7 +785,7 @@
   },
   "CLOUD_INVITE_CONFIRM" : {
     "description": "Confirmation message asking the user if they would like to add a cloud instance to their buddy list, which will connect them to a virtual machine.",
-    "message": "You've entered an experimental Cloud invitation. Accepting this invitation will connect you to a virtual machine. Would you like to accept?"
+    "message": "You're now being connected to a uProxy cloud server. Thanks for being one of our first testers of this experimental feature!"
   },
   "FRIEND_ADDED": {
     "description": "Confirmation message after adding a friend to the roster.",

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -539,8 +539,12 @@ export class UserInterface implements ui_constants.UiApi {
     if (networkName == 'Cloud') {
       // Cloud confirmation is the same regardless of whether the user is
       // logged into cloud yet.
-      return this.getConfirmation('', this.i18n_t('CLOUD_INVITE_CONFIRM'))
-      .then(() => {
+      this.toastMessage = this.i18n_t('CLOUD_INVITE_CONFIRM');
+      // no need to make the user confirm this, auto-accept the invite instead.
+      // the user pasting the invite link means they know what they're doing
+      // and just want to connect.
+      var getConfirmation = Promise.resolve<void>();
+      getConfirmation.then(() => {
         // Log into cloud if needed.
         var loginPromise = Promise.resolve<void>();
         if (!this.model.getNetwork('Cloud')) {
@@ -553,6 +557,7 @@ export class UserInterface implements ui_constants.UiApi {
           return this.addUser_(token, false).catch(showTokenError);
         });
       });
+      return getConfirmation;
     }
 
     if (this.model.getNetwork(networkName)) {


### PR DESCRIPTION
No need to make the user confirm before connecting to the cloud instance. The user getting this far means they know what they're doing already and just want to connect.

@trevj Still have to test this and probably needs work but wanted to get the PR started and maybe we can land it together.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2179)
<!-- Reviewable:end -->
