### PR TITLE
Fix Quiver disconnect and automatic reconnect

### DIFF
--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -482,8 +482,8 @@ export function notifyUI(networkName :string, userId :string) {
         return Promise.resolve(true);
       }
 
-      if (this.myInstance.userId == client.userId &&
-          this.myInstance.clientId == client.clientId) {
+      if (this.myInstance.userId === client.userId &&
+          this.myInstance.clientId === client.clientId) {
         // Received client for local instance.
         return Promise.resolve(true);
       }

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -482,6 +482,12 @@ export function notifyUI(networkName :string, userId :string) {
         return Promise.resolve(true);
       }
 
+      if (this.myInstance.userId == client.userId &&
+          this.myInstance.clientId == client.clientId) {
+        // Received client for local instance.
+        return Promise.resolve(true);
+      }
+
       // Hack around ClientState type, as inviteResponse is only available
       // for Quiver and not checked into mainline freedom yet.
       var inviteResponse = (<any>client)['inviteResponse'];


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/1982

Prior to this change, Quiver had been correctly emitting an onClientState event for the logged in user with status='OFFLINE' when the user was disconnected, however uProxy didn't treat it as coming from a valid client and so ignored the message.  With this change, Quiver is recognized as logged out and automatic reconnect is attempted.

Tested with Quiver in Chrome by logging in, then disabling my internet connection for ~1 minute.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2180)
<!-- Reviewable:end -->
