### PR TITLE
improve cloud invite confirm message

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -785,7 +785,7 @@
   },
   "CLOUD_INVITE_CONFIRM" : {
     "description": "Confirmation message asking the user if they would like to add a cloud instance to their buddy list, which will connect them to a virtual machine.",
-    "message": "You've entered an experimental Cloud invitation. Accepting this invitation will connect you to a virtual machine. Would you like to accept?"
+    "message": "You're about to connect to a uProxy cloud server! Thanks for being one of our first testers of this experimental feature. Would you like to continue?"
   },
   "FRIEND_ADDED": {
     "description": "Confirmation message after adding a friend to the roster.",


### PR DESCRIPTION
Goal of this PR is to get the user excited about what's about to happen (after potentially following a bunch of difficult steps), reframe the fact that cloud is experimental as another thing to be excited / feel special about, and remove "virtual machine" (unnecessary technical jargon).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2182)
<!-- Reviewable:end -->
