### PR TITLE
Collapsed offline contacts by default

### DIFF
--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -116,11 +116,6 @@ Polymer({
     });
   },
   ready: function() {
-    // Collapse offline contacts by default
-    if (!this.contact.isOnline) {
-      this.contact.shareExpanded = false;
-      this.contact.getExpanded = false;
-    }
     this.ui = ui_context.ui;
     this.ui_constants = ui_constants;
     this.model = ui_context.model;

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -116,6 +116,11 @@ Polymer({
     });
   },
   ready: function() {
+    // Collapse offline contacts by default
+    if (!this.contact.isOnline) {
+      this.contact.shareExpanded = false;
+      this.contact.getExpanded = false;
+    }
     this.ui = ui_context.ui;
     this.ui_constants = ui_constants;
     this.model = ui_context.model;

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -194,5 +194,32 @@ describe('UI.User', () => {
     expect(sampleUser.offeringInstances[0]).toBe(second);
   });
 
+  it('expands contact if online', () => {
+    sampleUser.update(makeUpdateMessage({
+      offeringInstances: [
+        getInstance('instance1', '')
+      ],
+      consent: {
+        remoteRequestsAccessFromLocal: true
+      },
+      isOnline: true,
+    }));
+    expect(sampleUser.getExpanded).toBe(true);
+    expect(sampleUser.shareExpanded).toBe(true);
+  });
+
+  it('collapses contact if offline', () => {
+    sampleUser.update(makeUpdateMessage({
+      offeringInstances: [
+        getInstance('instance1', '')
+      ],
+      consent: {
+        remoteRequestsAccessFromLocal: true
+      },
+      isOnline: false,
+    }));
+    expect(sampleUser.getExpanded).toBe(false);
+    expect(sampleUser.shareExpanded).toBe(false);
+  });
   // TODO: more specs
 });  // UI.User

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -139,13 +139,13 @@ export class User implements social.BaseUser {
 
     // Update gettingConsentState, used to display correct getting buttons.
     if (this.offeringInstances.length > 0) {
-      // Expand the contact if there previously were no offers and we are not
-      // ignoring offers.
+      // Expand the contact if there previously were no offers, we are not
+      // ignoring offers, and the contact is online.
       if ((this.gettingConsentState ==
           GettingConsentState.NO_OFFER_OR_REQUEST ||
           this.gettingConsentState ==
           GettingConsentState.LOCAL_REQUESTED_REMOTE_NO_ACTION) &&
-          !this.consent_.ignoringRemoteUserOffer) {
+          !this.consent_.ignoringRemoteUserOffer && this.isOnline) {
         this.getExpanded = true;
       }
       if (this.consent_.localRequestsAccessFromRemote) {
@@ -169,13 +169,13 @@ export class User implements social.BaseUser {
 
     // Update sharingConsentState, used to display correct sharing buttons.
     if (this.consent_.remoteRequestsAccessFromLocal) {
-      // Expand the contact if there previously were no requests and we are not
-      // ignoring requests.
+      // Expand the contact if there previously were no requests, we are not
+      // ignoring requests, and the contact is online.
       if ((this.sharingConsentState ==
           SharingConsentState.NO_OFFER_OR_REQUEST ||
           this.sharingConsentState ==
           SharingConsentState.LOCAL_OFFERED_REMOTE_NO_ACTION) &&
-          !this.consent_.ignoringRemoteUserRequest) {
+          !this.consent_.ignoringRemoteUserRequest && this.isOnline) {
         this.shareExpanded = true;
       }
       if (this.consent_.localGrantsAccessToRemote) {


### PR DESCRIPTION
Fix for issue #2011 (offline contacts should be collapsed by default)
- Added logic to collapse offline users by default

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2198)
<!-- Reviewable:end -->
