### PR TITLE
Fix invite parsing in cases where invite contains "==" (e.g. base64 cloud invites)

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -523,7 +523,8 @@ export class UserInterface implements ui_constants.UiApi {
   private parseInviteUrl_ = (invite :string) : social.InviteTokenData => {
     try {
       var params = uparams(invite);
-      if (Object.keys(params).length > 0) {
+      if (params && params['networkName']) {
+        // New style invite using URL params.
         return {
           v: parseInt(params['v'], 10),
           networkData: jsurl.parse(params['networkData']),


### PR DESCRIPTION
Fix invite parsing in cases where invite contains "==" (e.g. base64 cloud invites)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2222)
<!-- Reviewable:end -->
