### PR TITLE
Add help and FAQ text for Quiver

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1156,5 +1156,15 @@
   "INVITATION_PLACEHOLDER_TEXT": {
     "description": "Invitation placeholder text, instructing users to enter an invite in this field",
     "message": "Have an invitation code?  Enter it here"
+  },
+  "QUIVER_LOGIN_TEXT": {
+    "description": "Text shown to the user when they are about to login to the uProxy Network (aka Quiver)",
+    "message": "The uProxy network is a simple way to reliably find and connect to your friends. <uproxy-faq-link anchor='whatIsUproxyNetwork'>Learn more.</uproxy-faq-link>"
+  },
+  "WHAT_IS_UPROXY_NETWORK": {
+    "message": "What is the uProxy Network?"
+  },
+  "WHAT_IS_UPROXY_NETWORK_ANSWER": {
+    "message": "<p>The uProxy network is designed to be one of the simplest ways to reliably connect with your friends, while still being hard to block. To use the uProxy network, you only need to enter a name (which does not have to be unique) and then you're logged in and ready to share invitations with friends. Currently, identity is tied to a single machine; if you want to set up uProxy on a new computer, you will need to reinvite your friends, in order to connect with them from that machine.</p><p>The uProxy team operates the uProxy network, though in the future it will be possible for third-parties to augment the network by running additional server. All information that is sent over the uProxy network is encrypted end-to-end, between peers, so no one can interfere with it. However, network operators can still tell which IP addresses are connecting to each other.</p>"
   }
 }

--- a/src/generic_ui/polymer/faq.html
+++ b/src/generic_ui/polymer/faq.html
@@ -134,6 +134,11 @@
               <p class="i18n" data-i18n="HOW_DO_I_FIND_ANSWER"></p>
             </section>
 
+            <section class="faq" id="whatIsUproxyNetwork">
+              <h2 class="i18n" data-i18n="WHAT_IS_UPROXY_NETWORK"></h2>
+              <p class="i18n" data-i18n="WHAT_IS_UPROXY_NETWORK_ANSWER"></p>
+            </section>
+
             <section class="faq" id="whatIsGitHub">
               <h2 class="i18n" data-i18n="WHAT_IS_GITHUB"></h2>
               <p class="i18n" data-i18n="WHAT_IS_GITHUB_ANSWER"></p>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -105,7 +105,6 @@ var inviteUser = {
       this.initInviteForNetwork(networkName);
     } else {
       if (networkName === 'Quiver') {
-        // TODO: set a message explaining Quiver
         return ui.loginToQuiver().then(() => {
           this.initInviteForNetwork('Quiver');
         });

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -183,12 +183,15 @@
         color: #009688;
         font-weight: normal;
       }
-      #dialog p {
+      #dialogMessage {
         line-height: 20px;
         color: #666;
         font-weight: 300;
         letter-spacing: 0.4px;
         margin: 0;
+      }
+      #dialog uproxy-faq-link {
+        font-weight: bold;
       }
       #disconnectDialog {
         text-align: center;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -614,6 +614,11 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   public loginToQuiver = (message ?:string) : Promise<void> => {
+    if (message) {
+      message += '<p>' + this.i18n_t('QUIVER_LOGIN_TEXT') + '</p>';
+    } else {
+      message = this.i18n_t('QUIVER_LOGIN_TEXT');
+    }
     return this.getUserInput(
         this.i18n_t('UPROXY_NETWORK_LOGIN_TITLE'),
         message || '',


### PR DESCRIPTION
Add help and FAQ text for Quiver.

This is the new Quiver login screen:
<img width="483" alt="screen shot 2016-02-08 at 12 19 08 pm" src="https://cloud.githubusercontent.com/assets/6494307/12894725/911de4e6-ce66-11e5-99ad-cccaeb4ea3b3.png">

This is the screen users see if they click on a Quiver invite without yet being signed into Quiver:
<img width="483" alt="screen shot 2016-02-08 at 12 19 33 pm" src="https://cloud.githubusercontent.com/assets/6494307/12894739/9e6a44b4-ce66-11e5-8186-be0b1441635f.png">

This is the FAQ entry they see if they click "Learn more":
<img width="483" alt="screen shot 2016-02-08 at 12 25 40 pm" src="https://cloud.githubusercontent.com/assets/6494307/12894745/a9e59690-ce66-11e5-9cd1-f5a5fc4e4cfb.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2224)
<!-- Reviewable:end -->
