### PR TITLE
Make login help text darker

### DIFF
--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -69,7 +69,7 @@
         margin-top: 0;
       }
       #loginToInviteFriendDialog p {
-        color: rgb(160, 160, 160);
+        color: #666;
         line-height: 18px;
         font-weight: lighter;
         font-size: 12px;


### PR DESCRIPTION
Make login help text darker, requested by @gwpenn 

Login text for GMail, GitHub, etc now look darker, matching what we had been using for Quiver:

GMail:
<img width="483" alt="screen shot 2016-02-09 at 11 49 41 am" src="https://cloud.githubusercontent.com/assets/6494307/12923391/8c4eee8e-cf23-11e5-972c-0388d31521ad.png">

GitHub:
<img width="483" alt="screen shot 2016-02-09 at 11 49 49 am" src="https://cloud.githubusercontent.com/assets/6494307/12923397/91d1a810-cf23-11e5-866e-6120afeb6663.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2233)
<!-- Reviewable:end -->
