### PR TITLE
Fix v1 invites (briefly broke due to Quiver changes)

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -537,11 +537,15 @@ export class UserInterface implements ui_constants.UiApi {
         // Removes any non base64 characters that may appear, e.g. "%E2%80%8E"
         token = token.match("[A-Za-z0-9+/=_]+")[0];
         var parsedObj = JSON.parse(atob(token));
+        var networkData = parsedObj.networkData;
+        if (typeof networkData === 'object' && networkData.networkData) {
+          // Firebase invites have a nested networkData string within a
+          // networkData object.  TODO: move Firebase to use v2 invites.
+          networkData = networkData.networkData;
+        }
         return {
           v: 1,
-          // For v1 invites networkData contains a single string, also
-          // called networkData.
-          networkData: parsedObj.networkData.networkData,
+          networkData: networkData,
           networkName: parsedObj.networkName,
           userName: parsedObj.userName
         };

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -536,7 +536,15 @@ export class UserInterface implements ui_constants.UiApi {
         var token = invite.substr(invite.lastIndexOf('/') + 1);
         // Removes any non base64 characters that may appear, e.g. "%E2%80%8E"
         token = token.match("[A-Za-z0-9+/=_]+")[0];
-        return JSON.parse(atob(token));
+        var parsedObj = JSON.parse(atob(token));
+        return {
+          v: 1,
+          // For v1 invites networkData contains a single string, also
+          // called networkData.
+          networkData: parsedObj.networkData.networkData,
+          networkName: parsedObj.networkName,
+          userName: parsedObj.userName
+        };
       }
     } catch(e) {
       return null;


### PR DESCRIPTION
Fix v1 invites (briefly broke due to Quiver changes)

v1 of invites are confusing because the invite contains an object called "networkData", which itself contains a string called "networkData".  Older social providers (e.g. Firebase) expected only the inner networkData string, however due to Quiver changes we had been passing the outer networkData object.  Good news is this mess is cleaned up with v2 invites which we can start moving social providers to use.

here is an example of a decoded v1 invite where you can see the networkData mess:
```
"{"v":1,"networkName":"GMail","userName":"XXX","networkData":{"networkData":"{\"v\":1,\"userId\":\"XXX\",\"permissionToken\":XXX}"}}"
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2236)
<!-- Reviewable:end -->
