### PR TITLE
Update freedomjs-anonymized-metrics, fix Gruntfile

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -585,8 +585,8 @@ gruntConfig = {
         pathsFromThirdPartyBuild: backendThirdPartyBuildPaths
         files: [
           {
-            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/',
-            src: ['anonmetrics.json', 'metric.js']
+            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/dist/',
+            src: ['**']
             dest: chromeAppDevPath + '/freedomjs-anonymized-metrics'
           },
           {
@@ -657,8 +657,8 @@ gruntConfig = {
         pathsFromThirdPartyBuild: backendThirdPartyBuildPaths
         files: [
           {
-            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/',
-            src: ['anonmetrics.json', 'metric.js']
+            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/dist/',
+            src: ['**']
             dest: firefoxDevPath + 'data/freedomjs-anonymized-metrics'
           },
           {
@@ -726,8 +726,8 @@ gruntConfig = {
         pathsFromThirdPartyBuild: backendThirdPartyBuildPaths
         files: [
           {
-            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/',
-            src: ['anonmetrics.json', 'metric.js']
+            expand: true, cwd: 'node_modules/freedomjs-anonymized-metrics/dist/',
+            src: ['**']
             dest: ccaDevPath + '/freedomjs-anonymized-metrics'
           },
           {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "freedom-social-github": "^0.1.3",
     "freedom-social-quiver": "^0.0.8",
     "freedom-social-wechat": "^0.1.5",
-    "freedomjs-anonymized-metrics": "~0.7.1",
+    "freedomjs-anonymized-metrics": "^0.7.2",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-browserify": "^3.3.1",


### PR DESCRIPTION
freedomjs-anonymized-metrics now uses a "normal" path structure!

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2237)
<!-- Reviewable:end -->
