### PR TITLE
Firefox metrics fix: Upped package.json to freedomjs-anonymized-metrics 0.7.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "freedom-social-github": "^0.1.3",
     "freedom-social-quiver": "^0.0.8",
     "freedom-social-wechat": "^0.1.5",
-    "freedomjs-anonymized-metrics": "^0.7.2",
+    "freedomjs-anonymized-metrics": "^0.7.4",
     "fs-extra": "^0.12.0",
     "grunt": "^0.4.2",
     "grunt-browserify": "^3.3.1",


### PR DESCRIPTION
This should do it for firefix, afaict.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2257)
<!-- Reviewable:end -->
