### PR TITLE
Replace chrome-install with install for website paths

### DIFF
--- a/src/chrome/app/polymer/ext-missing.ts
+++ b/src/chrome/app/polymer/ext-missing.ts
@@ -2,6 +2,6 @@
 
 Polymer({
   downloadExt: function() {
-    window.open('http://www.uproxy.org/chrome-install');
+    window.open('http://www.uproxy.org/install');
   }
 });

--- a/src/chrome/extension/polymer/app-missing.ts
+++ b/src/chrome/extension/polymer/app-missing.ts
@@ -3,20 +3,20 @@
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
 // Launch the Chrome webstore page for the uProxy app,
-// or activate the user's tab open to uproxy.org/chrome-install
+// or activate the user's tab open to uproxy.org/install
 function openDownloadAppPage() : void {
   chrome.tabs.query({}, function (tabs) {
     for (var i = 0; i < tabs.length; i++) {
       var url = tabs[i].url;
-      if (url.indexOf('uproxysite.appspot.com/chrome-install') > 1 ||
-          url.indexOf('uproxy.org/chrome-install') > 1) {
+      if (url.indexOf('uproxysite.appspot.com/install') > 1 ||
+          url.indexOf('uproxy.org/install') > 1) {
         chrome.tabs.update(tabs[i].id, { active: true });
         chrome.windows.update(tabs[i].windowId, { focused: true });
         return;
       }
     }
 
-    // Only reached if the user didn't have uproxy.org/chrome-install open,
+    // Only reached if the user didn't have uproxy.org/install open,
     // allowing us to assume the user is completeing the webstore install flow.
     // For consistency, we direct them to the app download page in the webstore
     // instead of uproxy.org.

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -115,8 +115,8 @@ chrome.runtime.onInstalled.addListener((details :chrome.runtime.InstalledDetails
   chrome.tabs.query({currentWindow: true, active: true}, function(tabs){
       // Do not open the extension when it's installed if the user is
       // going through the inline install flow.
-      if ((tabs[0].url.indexOf("uproxysite.appspot.com/chrome-install") == -1) &&
-          (tabs[0].url.indexOf("uproxy.org/chrome-install") == -1)) {
+      if ((tabs[0].url.indexOf("uproxysite.appspot.com/install") == -1) &&
+          (tabs[0].url.indexOf("uproxy.org/install") == -1)) {
         browserApi.bringUproxyToFront();
       }
   });


### PR DESCRIPTION
We made the switch to /install a while back, apparently I forgot to
update it in the actual uproxy extension.  Oops.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2261)
<!-- Reviewable:end -->
