### PR TITLE
Enable monitoring for Quiver, and shorten the monitoring interval.

### DIFF
--- a/src/generic/network-options.ts
+++ b/src/generic/network-options.ts
@@ -32,7 +32,7 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
   'Quiver': {
     displayName: 'uProxy',
     isFirebase: false,
-    enableMonitoring: false,
+    enableMonitoring: true,
     areAllContactsUproxy: true,
     supportsReconnect: true,
     isExperimental: true,

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -690,7 +690,7 @@ export function notifyUI(networkName :string, userId :string) {
           this.getUser(userId).monitor();
         }
       };
-      this.monitorIntervalId_ = setInterval(monitorCallback, 60000);
+      this.monitorIntervalId_ = setInterval(monitorCallback, 15000);
     }
 
     private stopMonitor_ = () : void => {


### PR DESCRIPTION
This fixes an issue when a Quiver client auto-reconnects on all
servers at once (e.g. when waking from suspend).  Peers see a
new client come online, but they do not see a new instance
message, so they do not make the new client visible in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2300)
<!-- Reviewable:end -->
