### PR TITLE
Add newly deployed cloud friend to roster

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -656,6 +656,10 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       const MAX_INSTALLS = 5;
       return retry(install, MAX_INSTALLS);
     }).then((cloudNetworkData :any) => {
+      // TODO: make cloudNetworkData an Invite type.  This requires the cloud
+      // social provider to export the Invite interface, and also to cleanup
+      // reference paths so that uProxy doesn't need to include modules like
+      // ssh2.
       destroyModules();
 
       // Login to the Cloud network if the user isn't already so that

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -668,13 +668,12 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         // Synthesize an invite token based on cloudNetworkData.
         // CONSIDER: if we had a social.acceptInvitation that only took
         // networkData we wouldn't need to fake the other fields.
-        const inviteTokenData :social.InviteTokenData = {
+        return cloudNetwork.acceptInvitation({
           v: 2,
           networkName: 'Cloud',
           userName: cloudNetworkData['host'],
           networkData: JSON.stringify(cloudNetworkData)
-        }
-        return cloudNetwork.acceptInvitation(inviteTokenData);
+        });
       });
     }, (e: Error) => {
       destroyModules();
@@ -684,7 +683,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
 
   // Gets a social.Network, and logs the user in if they aren't yet logged in.
   private loginIfNeeded_ = (networkName :string) : Promise<social.Network> => {
-    var network = this.getNetworkByName_(networkName);
+    let network = this.getNetworkByName_(networkName);
     if (network) {
       return Promise.resolve(network);
     }
@@ -694,12 +693,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       network: networkName,
       loginType: uproxy_core_api.LoginType.INITIAL
     }).then(() => {
-      network = this.getNetworkByName_(networkName);
-      if (!network) {
-        // Sanity check - this should never happen.
-        return Promise.reject('Unable to find ' + networkName + ' network');
-      }
-      return Promise.resolve(network);
+      return this.getNetworkByName_(networkName);
     });
   }
 

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -1,6 +1,5 @@
 <link rel='import' href='../../bower/core-overlay/core-overlay.html'>
 <link rel='import' href='../../bower/core-signals/core-signals.html'>
-<link rel='import' href='../../bower/paper-input/paper-input-decorator.html'>
 <link rel='import' href='../../bower/paper-progress/paper-progress.html'>
 <link rel='import' href='../../bower/paper-radio-button/paper-radio-button.html'>
 <link rel='import' href='../../bower/paper-radio-group/paper-radio-group.html'>
@@ -100,14 +99,7 @@
 
     <uproxy-dialog layered='false' backdrop='true' id='successDialog'>
       <h1>Create a cloud server</h1>
-      <p>Your cloud server is ready!</p>
-      <p>Below is the URL to administer your new server. Copy and paste it into a file and save it somewhere you'll be able to get to it in the future. Think of it as a password: keep it safe and don't share it with anyone you don't trust.</p>
-      <p>Once you've saved the URL, open it in your browser to add your new server to your contacts list.</p>
-      <div>
-        <paper-input-decorator layout vertical>
-          <input readonly is='core-input' on-tap='{{ select }}' value='{{ inviteUrl }}' />
-        </paper-input-decorator>
-      </div>
+      <p>Your cloud server is ready, and will now appear in your uProxy friends list.</p>
       <uproxy-button on-tap='{{ closeDialogs }}'>{{ 'OK' | $$ }}</uproxy-button>
     </uproxy-dialog>
 

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -99,7 +99,7 @@
 
     <uproxy-dialog layered='false' backdrop='true' id='successDialog'>
       <h1>Create a cloud server</h1>
-      <p>Your cloud server is ready, and will now appear in your uProxy friends list.</p>
+      <p>Your cloud server is ready and has been added to your friends list.</p>
       <uproxy-button on-tap='{{ closeDialogs }}'>{{ 'OK' | $$ }}</uproxy-button>
     </uproxy-dialog>
 

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -21,20 +21,15 @@ Polymer({
   },
   loginTapped: function() {
     this.closeDialogs();
-    // TODO: show the dialog when this value changes, not this nasty hack
     ui.cloudInstallStatus = '';
     this.$.installingDialog.open();
 
     ui.cloudInstall({
       providerName: DEFAULT_PROVIDER,
       region: this.$.regionMenu.selected
-    }).then((result: uproxy_core_api.CloudInstallResult) => {
-      this.inviteUrl = result.invite;
+    }).then(() => {
       this.closeDialogs();
       this.$.successDialog.open();
-
-      // TODO: In addition to displaying the URL so the user can store it somewhere
-      //       we should add the new server to the user's contact list.
     }).catch((e: Error) => {
       // TODO: Figure out which fields in e are set, because message isn't.
       this.closeDialogs();
@@ -47,6 +42,5 @@ Polymer({
   },
   ready: function() {
     this.ui = ui;
-    this.inviteUrl = '';
   }
 });

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -247,8 +247,8 @@ class CoreConnector implements uproxy_core_api.CoreApi {
     return this.promiseCommand(uproxy_core_api.Command.ACCEPT_INVITATION, data);
   }
 
-  cloudInstall = (args:uproxy_core_api.CloudInstallArgs): Promise<uproxy_core_api.CloudInstallResult> => {
-    return this.promiseCommand(uproxy_core_api.Command.CLOUD_INSTALL, args); 
+  cloudInstall = (args:uproxy_core_api.CloudInstallArgs): Promise<void> => {
+    return this.promiseCommand(uproxy_core_api.Command.CLOUD_INSTALL, args);
   }
 }  // class CoreConnector
 

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -87,8 +87,10 @@ export class Model {
       var userCategories = user.getCategories();
       categorizeUser(user, this.contacts.getAccessContacts,
                      userCategories.getTab, null);
-      categorizeUser(user, this.contacts.shareAccessContacts,
-                     userCategories.shareTab, null);
+      if (user.network.name !== "Cloud") {
+        categorizeUser(user, this.contacts.shareAccessContacts,
+                       userCategories.shareTab, null);
+      }
     }
 
     _.remove(this.onlineNetworks, { name: networkName });

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -87,10 +87,8 @@ export class Model {
       var userCategories = user.getCategories();
       categorizeUser(user, this.contacts.getAccessContacts,
                      userCategories.getTab, null);
-      if (user.network.name !== "Cloud") {
-        categorizeUser(user, this.contacts.shareAccessContacts,
-                       userCategories.shareTab, null);
-      }
+      categorizeUser(user, this.contacts.shareAccessContacts,
+                     userCategories.shareTab, null);
     }
 
     _.remove(this.onlineNetworks, { name: networkName });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1350,7 +1350,7 @@ export class UserInterface implements ui_constants.UiApi {
     return i18nMessage.replace(/<((?!(\/?(strong|a|p|br|uproxy-faq-link)))[^>]+)>/g, '');
   }
 
-  public cloudInstall = (args:uproxy_core_api.CloudInstallArgs): Promise<uproxy_core_api.CloudInstallResult> => {
+  public cloudInstall = (args:uproxy_core_api.CloudInstallArgs): Promise<void> => {
     return this.core.cloudInstall(args);
   }
 } // class UserInterface

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1030,11 +1030,8 @@ export class UserInterface implements ui_constants.UiApi {
     // Update the user's category in both get and share tabs.
     model.categorizeUser(user, this.model.contacts.getAccessContacts,
         oldUserCategories.getTab, newUserCategories.getTab);
-
-    if (user.status != social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL) {
-      model.categorizeUser(user, this.model.contacts.shareAccessContacts,
-          oldUserCategories.shareTab, newUserCategories.shareTab);
-    }
+    model.categorizeUser(user, this.model.contacts.shareAccessContacts,
+        oldUserCategories.shareTab, newUserCategories.shareTab);
     this.updateBadgeNotification_();
 
     console.log('Synchronized user.', user);

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1030,8 +1030,10 @@ export class UserInterface implements ui_constants.UiApi {
     // Update the user's category in both get and share tabs.
     model.categorizeUser(user, this.model.contacts.getAccessContacts,
         oldUserCategories.getTab, newUserCategories.getTab);
-    model.categorizeUser(user, this.model.contacts.shareAccessContacts,
-        oldUserCategories.shareTab, newUserCategories.shareTab);
+    if (user.status != social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL) {
+      model.categorizeUser(user, this.model.contacts.shareAccessContacts,
+          oldUserCategories.shareTab, newUserCategories.shareTab);
+    }
     this.updateBadgeNotification_();
 
     console.log('Synchronized user.', user);

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -138,7 +138,6 @@ export enum Update {
   PORT_CONTROL_STATUS = 2025,
   // Payload is a string, obtained from the SignalBatcher in uproxy-lib.
   ONETIME_MESSAGE = 2026,
-  // Payload is a CloudInstallResult.
   CLOUD_INSTALL_STATUS = 2027
 }
 
@@ -223,13 +222,6 @@ export interface CloudInstallArgs {
   region: string;
 };
 
-// Output of #cloudInstall.
-export interface CloudInstallResult {
-  // Invitation URL, iff the the server was successfully created
-  // and provisioned.
-  invite: string;
-};
-
 /**
  * The primary interface to the uProxy Core.
  *
@@ -296,6 +288,6 @@ export interface CoreApi {
   // callers should expose CLOUD_INSTALL_STATUS updates to the user.
   // This may also invoke an OAuth flow, in order to perform operations
   // with the cloud computing provider on the user's behalf.
-  cloudInstall(args:CloudInstallArgs): Promise<CloudInstallResult>;
+  cloudInstall(args:CloudInstallArgs): Promise<void>;
 }
 


### PR DESCRIPTION
after cloudInstall we now:
* sign into the Cloud social network if we aren't yet logged in
* add ```isAdmin=true``` to the object returned by the installer
* pass this networkData to ```acceptUserInivtation```

```cloudInstall``` also now just returns a ```Promise<void>```, since the UI doesn't need to know the invite anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2305)
<!-- Reviewable:end -->
