### PR TITLE
Cloud UI cleanup

### DIFF
--- a/src/generic_ui/locales/ar/messages.json
+++ b/src/generic_ui/locales/ar/messages.json
@@ -327,10 +327,6 @@
         "message": "تحليل الشبكة والسجلات",
         "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
     },
-    "WELCOME_MESSAGE": {
-        "message": "للبدء، اختر \"الحصول على وصول\" أو \"مشاركة الوصول\" ثم النقر على صديق لتحقيق الإيصال.",
-        "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
-    },
     "NO_THANKS": {
         "message": "لا شكراً",
         "description": "Do not agree to submitting anonymous metrics to uProxy."

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -387,10 +387,6 @@
     "description": "",
     "message": "Welcome to uProxy"
   },
-  "WELCOME_MESSAGE": {
-    "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately.",
-    "message": "uProxy allows you to get access from your friends, share access with them or do both at once! To get started, choose \"Get access\" or \"Share access.\""
-  },
   "BETA_MESSAGE": {
     "description": "Text in a popup that appears wen the user first uses uProxy. Explains that the current version of uProxy is an early, unfinished release, and anonymous statistics (from the user, if they choose) can help with uProxy's development.",
     "message": "This is a beta release of uProxy, and it may occasionally be unreliable."
@@ -557,7 +553,7 @@
   },
   "SET_UP_ONE_TIME": {
     "description": "Clickable link on the login page. As an alternative to logging in to a social network, user's can attempt a connection with a one-time link.",
-    "message": "Set up a one-time connection"
+    "message": "Set up a 1-time connection"
   },
   "WE_WONT_POST": {
     "description": "Inform the user that uProxy does not share data or post to their social network accounts without agreement from the user.",

--- a/src/generic_ui/locales/fa/messages.json
+++ b/src/generic_ui/locales/fa/messages.json
@@ -331,10 +331,6 @@
         "message": " تحلیل شبکه و لاگ ها ",
         "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
     },
-    "WELCOME_MESSAGE": {
-        "message": "برای شروع کار، \"دریافت دسترسی\" یا \"به اشتراک گذاری دسترسی\" را فعال کرده و سپس بر روی دوستی که تمایل دارید به او متصل شوید کلیک کنید. ",
-        "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
-    },
     "NO_THANKS": {
         "message": "نه ممنونم",
         "description": "Do not agree to submitting anonymous metrics to uProxy."

--- a/src/generic_ui/locales/tr/messages.json
+++ b/src/generic_ui/locales/tr/messages.json
@@ -327,10 +327,6 @@
         "message": "Ağı analiz et ve girişleri dahil et",
         "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
     },
-    "WELCOME_MESSAGE": {
-        "message": "Başlamak için, \"Erişim edin\" ya da \"Erişim paylaş\" ı seç ve sonra bağlanmak için bir arkadaşa tıkla.",
-        "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
-    },
     "NO_THANKS": {
         "message": "Hayır teşekkürler",
         "description": "Do not agree to submitting anonymous metrics to uProxy."

--- a/src/generic_ui/locales/vi/messages.json
+++ b/src/generic_ui/locales/vi/messages.json
@@ -327,10 +327,6 @@
         "message": "Phân tích mạng và kể cả các bản ghi",
         "description": "Label for a checkbox that indicates if the user wants uProxy to analyze their network settings and include their uProxy logs with their feedback to the uProxy team."
     },
-    "WELCOME_MESSAGE": {
-        "message": "Để bắt đầu, hãy chọn \"Truy cập\" hoặc \"Chia sẻ truy cập\" và sau đó nhấn vào một người bạn để kết nối.",
-        "description": "Text in a popup that appears when the user first uses uProxy. Explains that the user needs to choose either the Get or Share tab appropriately."
-    },
     "NO_THANKS": {
         "message": "Không, cảm ơn",
         "description": "Do not agree to submitting anonymous metrics to uProxy."

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -39,7 +39,8 @@
     h1 {
       color: #34AFCE;  /* blue */
       font-weight: 400;
-      font-size: 23px;
+      font-size: 20px;
+      line-height: 30px;
     }
     h2 {
       font-weight: 400;

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -21,7 +21,7 @@
       }
       .acceptInvite {
         text-align: left;
-        margin: 1em;
+        margin: 18px 24px 14px 24px;
         padding-bottom: 1em;
       }
       .acceptInvite paper-input-decorator {
@@ -154,15 +154,17 @@
         text-align: left;
         padding: 1em 2em 1em 2em;
         background-color: rgb(225,246,244);  /* light aqua green */
-        color: #12A391;  /* dark green */
+        color: rgba(0,0,0,0.54);
+        line-height: 22px;
       }
       #cloudInstall {
         color: white;
         background-color: #34AFCE;  /* blue */;
-        margin: 1em;
+        margin: 14px 24px 14px 24px;
         padding: 2em 1em 2em 2em;
         cursor: pointer;
-        line-height
+        line-height: 30px;
+        border-radius: 3px;
       }
       #cloudInstall .content {
         width: 85%;
@@ -175,6 +177,8 @@
       #cloudInstall h1 {
         font-weight: 300;
         margin-top: 0;
+        font-size: 20px;
+        line-height: 30px;
       }
       #cloudInstall img {
         height: 50px;

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -76,7 +76,7 @@
         cursor: pointer;
         vertical-align: top;
         padding: 1em 2em 1em 2em;
-        border-bottom: 1px solid rgb(221,221,221);
+        border-bottom: 1px solid rgba(0, 0, 0, .10);
       }
       .networkLoginButton:last-child {
         border-bottom: none;

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -348,17 +348,6 @@
           </div>
         </core-toolbar>
 
-        <!--
-          core-header class ensures this gets inserted in the header portion of
-          core-header-panel and it is positioned below the toolbar (see
-          https://www.polymer-project.org/0.5/docs/elements/core-header-panel.html)
-        -->
-        <uproxy-bubble class='core-header' on-closed='{{ closedWelcome }}' active='{{ !model.globalSettings.hasSeenWelcome }}' noclear="true">
-          <p>
-            {{ "WELCOME_MESSAGE" | $$ }}
-          </p>
-        </uproxy-bubble>
-
         <div class='content' fit>
 
           <div id='rosterContainer' vertical layout>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -35,9 +35,16 @@ Polymer({
     // event indicating the user has logged in. roster.ts listens for
     // this event.
     if (newView == ui_types.View.ROSTER && oldView == ui_types.View.SPLASH) {
+      // TODO: can this be removed now that roster-before-login has launched?
       this.fire('core-signal', {name: "login-success"});
       this.closeSettings();
       this.$.modeTabs.updateBar();
+
+      // User has now seen the welcome messages - this used to be a
+      // uproxy-bubble, now the only welcome content is on the splash screen
+      // and the empty roster text.
+      model.globalSettings.hasSeenWelcome = true;
+      core.updateGlobalSettings(model.globalSettings);
     }
   },
   statsIconClicked: function() {
@@ -53,8 +60,6 @@ Polymer({
     ui.setMode(ui_types.Mode.SHARE);
   },
   closedWelcome: function() {
-    model.globalSettings.hasSeenWelcome = true;
-    core.updateGlobalSettings(model.globalSettings);
   },
   closedSharing: function() {
     model.globalSettings.hasSeenSharingEnabledScreen = true;

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -59,7 +59,7 @@
     }
     .instructions {
       padding-right: 1em;  /* no left padding so img is properly centered */
-      height: 166px;
+      height: 156px;
     }
     .instructions.cloud {
       background-color: rgba(51,187,206,0.15);
@@ -106,7 +106,7 @@
     }
     #orWrapper {
       position: absolute;
-      top: 146px;  /* instructions height - (.5 * orCircle height) */
+      top: 136px;  /* instructions height - (.5 * orCircle height) */
       width: 100%;
       text-align: center;
     }


### PR DESCRIPTION
* Get rid of get/share welcome popup
* Make help text areas on the empty roster shorter, so there isn't ugly overlap with the + button
* Make the lines lighter color on the invite-user screen

![screen shot 2016-03-25 at 3 18 14 pm](https://cloud.githubusercontent.com/assets/6494307/14051947/d7015dbc-f29c-11e5-849d-0ddef08ead43.png)

![screen shot 2016-03-25 at 3 18 22 pm](https://cloud.githubusercontent.com/assets/6494307/14051950/dcb91b0a-f29c-11e5-890b-b3239a4613ef.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2321)
<!-- Reviewable:end -->
