### PR TITLE
Delete cloud server if one already exists

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -636,15 +636,14 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
       freedom['cloudinstall'].close(installer);
     };
 
-    log.debug('deploying cloud server on %1 in %2', args.providerName, args.region);
-    ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_CREATING_SERVER');
-
     switch (args.operation) {
       case uproxy_core_api.CloudOperationType.CLOUD_INSTALL:
         if (!args.region) {
           return Promise.reject(new Error('no region specified for cloud provider'));
         }
 
+        log.debug('deploying cloud server on %1 in %2', args.providerName, args.region);
+        ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_CREATING_SERVER');
         ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, 0);
 
         return provisioner.start(DROPLET_NAME, args.region).then((serverInfo: any) => {
@@ -719,6 +718,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         return provisioner.stop(DROPLET_NAME).then(() => {
           destroyModules();
           log.debug('stopped cloud server on', args.providerName);
+          return Promise.resolve<void>();
         }, (e: Error) => {
           destroyModules();
           log.error('error destroying cloud server:', e.message);

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -693,10 +693,14 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
               networkData: JSON.stringify(cloudNetworkData)
             });
           });
-        }, (installError: Error) => {
-          log.error('install failed, cleaning up');
+        }, (installError: any) => {
+          // Tell user if the server already exists
+          if (installError.errcode === "VM_AE") {
+            return Promise.reject(new Error('server already exists'));
+          }
 
           // Destroy the server we just created so that the user isn't billed.
+          log.error('install failed, cleaning up');
           return provisioner.stop(DROPLET_NAME).then((unused: Object) => {
             log.info('destroyed server on digitalocean');
             destroyModules();

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -718,7 +718,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         return provisioner.stop(DROPLET_NAME).then(() => {
           destroyModules();
           log.debug('stopped cloud server on', args.providerName);
-          return Promise.resolve<void>();
         }, (e: Error) => {
           destroyModules();
           log.error('error destroying cloud server:', e.message);

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1346,5 +1346,17 @@
   "NORTH_AMERICA_NEW_YORK": {
     "description": "Region option for deploying a DigitalOcean server",
     "message": "North America (New York)"
+  },
+  "CLOUD_INSTALL_ERROR_EXISTING_SERVER_TITLE": {
+    "description": "Message shown after failed server deployment because uproxy-cloud-server already exists",
+    "message": "Oops! You already have a uProxy cloud server."
+  },
+  "CLOUD_INSTALL_ERROR_EXISTING_SERVER_MESSAGE": {
+    "description": "Message shown after failed server deployment because uproxy-cloud-server already exists",
+    "message": "You already have a cloud server named 'uproxy-cloud-server'. We can remove it and create a new one for you."
+  },
+  "REMOVE_SERVER_AND_TRY_AGAIN": {
+    "description": "Button text for removing cloud server and trying again (e.g. connecting to DigitalOcean)",
+    "message": "Remove server and try again"
   }
 }

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1353,10 +1353,14 @@
   },
   "CLOUD_INSTALL_ERROR_EXISTING_SERVER_MESSAGE": {
     "description": "Message shown after failed server deployment because uproxy-cloud-server already exists",
-    "message": "You already have a cloud server named 'uproxy-cloud-server'. We can remove it and create a new one for you."
+    "message": "We discovered that you already have a server named 'uproxy-cloud-server'. We can remove it and create a new one for you, or you can go back to your friend list."
   },
   "REMOVE_SERVER_AND_TRY_AGAIN": {
     "description": "Button text for removing cloud server and trying again (e.g. connecting to DigitalOcean)",
     "message": "Remove server and try again"
+  },
+  "REMOVING_UPROXY_CLOUD_STATUS": {
+    "description": "Label to indicate that we are removing a uproxy cloud server.",
+    "message": "Removing uProxy cloud server..."
   }
 }

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -203,6 +203,23 @@
       </div>
     </core-overlay>
 
+    <core-overlay id='serverExistsOverlay'>
+      <uproxy-app-bar on-go-back='{{ back }}' color='#34AFCE'>
+        {{ 'CREATE_A_CLOUD_SERVER' | $$ }}
+      </uproxy-app-bar>
+
+      <div class='content'>
+        <div class='imgWrapper'>
+          <img src='../../icons/cloud/error-circle-ic.svg'>
+        </div>
+        <h1>You already have a uProxy cloud server</h1>
+        <p>It appears you already have a cloud server named 'uproxy-cloud-server'. We can remove it and create a new one for you or you can go back to your list of friends.</p>
+        <uproxy-button raised on-tap='{{ removeServerTapped }}'>
+          REMOVE SERVER AND TRY AGAIN
+        </uproxy-button>
+      </div>
+    </core-overlay>
+
   </template>
   <script src='cloud-install.js'></script>
 </polymer-element>

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -212,10 +212,10 @@
         <div class='imgWrapper'>
           <img src='../../icons/cloud/error-circle-ic.svg'>
         </div>
-        <h1>You already have a uProxy cloud server</h1>
-        <p>It appears you already have a cloud server named 'uproxy-cloud-server'. We can remove it and create a new one for you or you can go back to your list of friends.</p>
+        <h1>{{ 'CLOUD_INSTALL_ERROR_EXISTING_SERVER_TITLE' | $$ }}</h1>
+        <p>{{ 'CLOUD_INSTALL_ERROR_EXISTING_SERVER_MESSAGE' | $$ }}</p>
         <uproxy-button raised on-tap='{{ removeServerTapped }}'>
-          REMOVE SERVER AND TRY AGAIN
+          {{ 'REMOVE_SERVER_AND_TRY_AGAIN' | $$ }}
         </uproxy-button>
       </div>
     </core-overlay>

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -214,8 +214,11 @@
         </div>
         <h1>{{ 'CLOUD_INSTALL_ERROR_EXISTING_SERVER_TITLE' | $$ }}</h1>
         <p>{{ 'CLOUD_INSTALL_ERROR_EXISTING_SERVER_MESSAGE' | $$ }}</p>
-        <uproxy-button raised on-tap='{{ removeServerTapped }}'>
+        <uproxy-button raised on-tap='{{ removeServerAndInstallAgain }}'>
           {{ 'REMOVE_SERVER_AND_TRY_AGAIN' | $$ }}
+        </uproxy-button>
+        <uproxy-button raised on-tap='{{ closeOverlays }}'>
+          {{ 'CANCEL' | $$ }}
         </uproxy-button>
       </div>
     </core-overlay>

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -59,6 +59,7 @@ Polymer({
     this.$.installingOverlay.close();
     this.$.successOverlay.close();
     this.$.failureOverlay.close();
+    this.$.serverExistsOverlay.close();
   },
   loginTapped: function() {
     this.closeOverlays();

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -84,7 +84,7 @@ Polymer({
       }
     });
   },
-  removeServerTapped: function() {
+  removeServerAndInstallAgain: function() {
     this.closeOverlays();
     ui.cloudInstallStatus = ui.i18n_t('REMOVING_UPROXY_CLOUD_STATUS');
     this.$.installingOverlay.open();
@@ -94,7 +94,7 @@ Polymer({
       providerName: DEFAULT_PROVIDER
     }).then(() => {
       // Get locally created cloud contact if there is one
-      return ui.getCloudUser().then((user: user.User) => {
+      return ui.getCloudUserCreatedByLocal().then((user: user.User) => {
         return ui_context.core.removeContact({
           networkName: user.network.name,
           userId: user.userId

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -128,8 +128,7 @@ Polymer({
         userId: this.contact.userId
       });
     }).then(() => {
-      this.ui.showDialog(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
-        this.ui.i18n_t("REMOVE_CLOUD_SERVER_SUCCESS"));
+      this.ui.toastMessage = this.ui.i18n_t("REMOVE_CLOUD_SERVER_SUCCESS");
     }).catch((e: Error) => {
       if (e.name === 'CLOUD_ERR') {
          this.ui.showDialog(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
@@ -151,6 +150,7 @@ Polymer({
   },
   destroyCloudServerIfNeeded: function() {
     if (this.contact.status === this.UserStatus.CLOUD_INSTANCE_CREATED_BY_LOCAL) {
+      this.ui.toastMessage = this.ui.i18n_t("REMOVING_UPROXY_CLOUD_STATUS");
       return ui_context.core.cloudUpdate({
         operation: uproxy_core_api.CloudOperationType.CLOUD_DESTROY,
         providerName: DEFAULT_PROVIDER

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1054,16 +1054,17 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   public getCloudUser = () : Promise<Object> => {
-    let network = this.model.getNetwork('Cloud');
+    const network = this.model.getNetwork('Cloud');
+    if (!network) {
+      return Promise.reject('not logged into cloud network');
+    }
     for (let userId in network.roster) {
-      var user = this.model.getUser(network, userId);
-      console.log(user);
-      console.log(social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL);
-      if (user.status === social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL) {
+      let user = this.model.getUser(network, userId);
+      if (user.status === social.UserStatus.CLOUD_INSTANCE_CREATED_BY_LOCAL) {
         return Promise.resolve(user);
       }
     }
-    return Promise.reject('cloud not find locally created cloud server');
+    return Promise.reject('locally created cloud contact does not exist');
   }
 
   public openTab = (url: string) => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1053,7 +1053,7 @@ export class UserInterface implements ui_constants.UiApi {
     console.log('Removed user from contacts', user);
   }
 
-  public getCloudUser = () : Promise<Object> => {
+  public getCloudUserCreatedByLocal = () : Promise<Object> => {
     const network = this.model.getNetwork('Cloud');
     if (!network) {
       return Promise.reject('not logged into cloud network');

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1053,6 +1053,19 @@ export class UserInterface implements ui_constants.UiApi {
     console.log('Removed user from contacts', user);
   }
 
+  public getCloudUser = () : Promise<Object> => {
+    let network = this.model.getNetwork('Cloud');
+    for (let userId in network.roster) {
+      var user = this.model.getUser(network, userId);
+      console.log(user);
+      console.log(social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL);
+      if (user.status === social.UserStatus.CLOUD_INSTANCE_SHARED_WITH_LOCAL) {
+        return Promise.resolve(user);
+      }
+    }
+    return Promise.reject('cloud not find locally created cloud server');
+  }
+
   public openTab = (url: string) => {
     this.browserApi.openTab(url);
   }


### PR DESCRIPTION
- If a 'uproxy-cloud-server' already exists when we are trying to create a new server, `serverExistsOverlay` in cloud-install is shown
- When user selects Remove Server and Try Again, we delete the uproxy-cloud-server then remove the locally created cloud server contact in `removeServerTapped()`
- We call `getCloudUser()` in ui.ts to find a locally created cloud user if one exists

- Updated along with: https://github.com/uProxy/uproxy-lib/pull/379

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2357)
<!-- Reviewable:end -->
