### PR TITLE
Adding functionality to cancel cloud creation

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1374,5 +1374,21 @@
   "REMOVING_UPROXY_CLOUD_STATUS": {
     "description": "Label to indicate that we are removing a uproxy cloud server.",
     "message": "Removing uProxy cloud server..."
+  },
+  "CLOUD_INSTALL_CANCEL_TITLE": {
+    "description": "Title shown on overlay when user cancels a cloud server install.",
+    "message": "Hold tight! We're canceling the creation of a cloud server."
+  },
+  "CLOUD_INSTALL_CANCEL_MESSAGE": {
+    "description": "Message shown on overlay when user cancels a cloud server install.",
+    "message": "Canceling the creation of a cloud server can take up to 2 minutes. Sorry for the wait."
+  },
+  "CLOUD_INSTALL_CANCEL_SUCCESS": {
+    "description": "Message shown on toast when a could server install is completed.",
+    "message": "Successfully canceled cloud server creation."
+  },
+  "CLOUD_INSTALL_CANCEL_FAILURE": {
+    "description": "Message shown on toast when a could server install fails.",
+    "message": "We cannot cancel the creation of your cloud server right now. You can delete the server once it's ready."
   }
 }

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -163,6 +163,7 @@
           <paper-progress id='installProgress' value='{{ ui.cloudInstallProgress }}'></paper-progress>
         </div>
         <p>{{ ui.cloudInstallStatus }}</p>
+        <uproxy-button disabled?='{{ ui.cloudInstallCancelDisabled }}' on-tap='{{ cancelCloudInstall }}'>{{ 'CANCEL' | $$ }}</uproxy-button>
       </div>
     </core-overlay>
 
@@ -220,6 +221,21 @@
         <uproxy-button raised on-tap='{{ closeOverlays }}'>
           {{ 'CANCEL' | $$ }}
         </uproxy-button>
+      </div>
+    </core-overlay>
+
+
+    <core-overlay id='cancelingOverlay'>
+      <uproxy-app-bar color='#34AFCE' disableback="true">
+        {{ 'CREATE_A_CLOUD_SERVER' | $$ }}
+      </uproxy-app-bar>
+
+      <div class='content'>
+        <div class='imgWrapper'>
+          <img src='../../icons/cloud/error-circle-ic.svg'>
+        </div>
+        <h1>{{ 'CLOUD_INSTALL_CANCEL_TITLE' | $$ }}</h1>
+        <p>{{ 'CLOUD_INSTALL_CANCEL_MESSAGE' | $$ }}</p>
       </div>
     </core-overlay>
 

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -26,7 +26,8 @@ Polymer({
     this.injectBoundHTML(
         ui.i18nSanitizeHtml(ui.i18n_t('CLOUD_INSTALL_LOGIN_MESSAGE')),
         this.$.loginMessage);
-
+    
+    ui.cloudInstallCancelDisabled = false;
     this.$.getStartedOverlay.open();
   },
   showDigitalOceanAccountHelpOverlay: function() {
@@ -66,7 +67,6 @@ Polymer({
     if (!this.$.installingOverlay.opened) {
       this.closeOverlays();
       ui.cloudInstallStatus = '';
-      ui.cloudInstallCancelDisabled = false;
       this.$.installingOverlay.open();
     }
     ui.cloudUpdate({

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -132,6 +132,7 @@ export class UserInterface implements ui_constants.UiApi {
 
   public cloudInstallStatus :string = '';
   public cloudInstallProgress = 0;
+  public cloudInstallCancelDisabled :boolean = false;
 
   /**
    * UI must be constructed with hooks to Notifications and Core.
@@ -311,6 +312,9 @@ export class UserInterface implements ui_constants.UiApi {
 
     core.onUpdate(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, (progress: number) => {
       this.cloudInstallProgress = progress;
+      // Don't allow user to cancel during last stage of cloud install
+      // because user may have already accepted cloud invitation
+      this.cloudInstallCancelDisabled = (status === 'CLOUD_INSTALL_STATUS_CONFIGURING_SSH') ? true : false;
     });
 
     browserApi.on('copyPasteUrlData', this.handleCopyPasteUrlData);

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -308,13 +308,13 @@ export class UserInterface implements ui_constants.UiApi {
 
     core.onUpdate(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, (status: string) => {
       this.cloudInstallStatus = this.i18n_t(status);
+      // Don't allow user to cancel during last stage of cloud install
+      // because user may have already accepted cloud invitation
+      this.cloudInstallCancelDisabled = (status === 'CLOUD_INSTALL_STATUS_CONFIGURING_SSH') ? true : false;
     });
 
     core.onUpdate(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, (progress: number) => {
       this.cloudInstallProgress = progress;
-      // Don't allow user to cancel during last stage of cloud install
-      // because user may have already accepted cloud invitation
-      this.cloudInstallCancelDisabled = (status === 'CLOUD_INSTALL_STATUS_CONFIGURING_SSH') ? true : false;
     });
 
     browserApi.on('copyPasteUrlData', this.handleCopyPasteUrlData);


### PR DESCRIPTION
Recreating a pull request due to some big merge conflicts; primary review for this PR is at https://github.com/uProxy/uproxy/pull/2367

Overview:
- Keeping track of provisioners and installers in cloudInterfaces object in uproxy_core so that we can destroy them to cancel the install process
- Added cancel button to installingOverlay; button is disabled with ui.cloudInstallCancelDisabled if we are in the removing stage (if a server already existed) or the configuring ssh stage (which is the last stage and only lasts a few seconds)
- Added cancelingOverlay because canceling a cloud server can take up to a couple minutes if you try to cancel it at the very beginning. According to what I've read on Digital Ocean, you can't destroy a server while another action is in progress so we have to wait until the server is created.

Fix for issue #2360
With minor changes to uproxy-lib: uProxy/uproxy-lib#387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2380)
<!-- Reviewable:end -->
