### PR TITLE
Make syntax change in coffeescript

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -853,7 +853,7 @@ taskManager.add 'build_chrome_app', [
   'copy:chrome_app'
 ].concat fullyVulcanize('chrome/app/polymer', 'ext-missing', 'vulcanized')
 
-taskManager.add 'build_chrome_ext', [
+taskManager.add('build_chrome_ext', [
   'base'
   'ts:chrome_extension'
   'copy:chrome_extension'
@@ -861,7 +861,7 @@ taskManager.add 'build_chrome_ext', [
   'browserify:chromeExtMain'
   'browserify:chromeContext'
 ].concat fullyVulcanize('chrome/extension/generic_ui/polymer', 'root', 'vulcanized', true)
-.concat fullyVulcanize('chrome/extension/generic_ui/polymer', 'logs', 'vulcanized-view-logs', true)
+.concat fullyVulcanize('chrome/extension/generic_ui/polymer', 'logs', 'vulcanized-view-logs', true))
 
 taskManager.add 'build_chrome', [
   'build_chrome_app'
@@ -869,14 +869,14 @@ taskManager.add 'build_chrome', [
 ]
 
 # Firefox build tasks.
-taskManager.add 'build_firefox', [
+taskManager.add('build_firefox', [
   'base'
   'ts:firefox'
   'copy:firefox'
   'copy:firefox_additional'
   'browserify:firefoxContext'
 ].concat fullyVulcanize('firefox/data/generic_ui/polymer', 'root', 'vulcanized', true)
-.concat fullyVulcanize('firefox/data/generic_ui/polymer', 'logs', 'vulcanized-view-logs', true)
+.concat fullyVulcanize('firefox/data/generic_ui/polymer', 'logs', 'vulcanized-view-logs', true))
 
 # CCA build tasks.
 taskManager.add 'build_cca', [


### PR DESCRIPTION
Some parts of our Gruntfile seem to have issues with different versions
of coffeescript.

I'm very open to better ways of writing that...I think it just looks weird no matter what.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2384)
<!-- Reviewable:end -->
