### PR TITLE
Simplify icon logic for contact icons

### DIFF
--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -28,35 +28,23 @@
     .nameRow {
       margin: 18px 24px 0px 24px;
     }
-    .nameTable {
-      width: 100%;
-    }
-    .nameTable .nameCell {
-      width: 80%;
-    }
-    .nameTable .iconCell {
-      width: 10%;
-    }
     .expandable {
       cursor: pointer;
     }
     .nameRow core-icon {
       opacity: 0.6;
-      margin: 0px;
+      margin: 0px 1px;
     }
     .nameRow core-icon.expand {
       min-width: 25px;
     }
-    .nameRow .iconWrapper {
-      text-align: end;
-      margin: 0px 1px;
+    .nameLine core-icon[icon=open-in-new] {
+      width: 16px;
+      height: 16px;
+      padding-top: 8px; /* handle alignment to 24px */
     }
-    .nameRow .iconWrapper core-icon[icon=open-in-new] {
-      width: 16px !important;
-      height: 16px !important;
-    }
-    .nameRow .iconWrapper core-icon[icon=delete] {
-      width: 20px !important;
+    .nameLine core-icon[icon=delete] {
+      width: 20px;
     }
     .nameRow:hover core-icon.expand {
       opacity: 1;
@@ -73,7 +61,6 @@
     }
     .name {
       white-space: nowrap;
-      text-overflow: ellipsis;
       font-size: 15px;
       line-height: 22px;
       color: rgba(0,0,0,0.87);
@@ -147,22 +134,30 @@
         top horizontal layout>
       <uproxy-avatar src='{{ contact.imageData }}' network='{{ contact.network.name }}' showIcon='{{ model.onlineNetworks.length > 1 }}' on-tap='{{ toggle }}'></uproxy-avatar>
       <div flex>
-        <table class="nameTable">
-          <td class="nameCell">
-            <div class='name' on-tap='{{ toggle }}'><bdi>{{ contact.name }}</bdi></div>
-          </td>
-          <td class="iconCell">
-            <div class="iconWrapper" hidden?="{{ !contact.url || (model.globalSettings.mode==ui_constants.Mode.GET && !contact.getExpanded) || (model.globalSettings.mode==ui_constants.Mode.SHARE && !contact.shareExpanded) }}">
-              <core-icon icon="open-in-new"
-          title="{{ contact.url }}" on-tap="{{ openLink }}"></core-icon>
-            </div>
-          </td>
-          <td class="iconCell">
-            <div class="iconWrapper" hidden?="{{contact.network.name!='Cloud'}}">
-              <core-icon icon="delete" title="{{ contact.url }}" on-tap="{{ removeCloudFriend }}"></core-icon>
-            </div>
-          </td>
-        </table>
+        <div horizontal layout class='nameLine' on-tap='{{ toggle }}'>
+          <div flex class='name'><bdi>{{ contact.name }}</bdi></div>
+          <core-icon icon="open-in-new"
+              hidden?="{{ !contact.url || (model.globalSettings.mode==ui_constants.Mode.GET && !contact.getExpanded) || (model.globalSettings.mode==ui_constants.Mode.SHARE && !contact.shareExpanded) }}"
+              title="{{ contact.url }}" on-tap="{{ openLink }}"></core-icon>
+
+          <core-icon icon="delete" hidden?='{{ contact.network.name !== "Cloud" }}' title="{{ contact.url }}" on-tap="{{ removeCloudFriend }}"></core-icon>
+
+          <!-- TODO: Simplify show/hide logic of getting/sharing/expand/collapse icons. E.g. Angular allowed if/else-like logic to select what is displayed. -->
+          <img src='../icons/getting_animated.gif' class='accessIcon'
+              hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.GET || !contact.isSharingWithMe }}'>
+          <img src='../icons/sharing_animated.gif' class='accessIcon'
+              hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.SHARE || !contact.isGettingFromMe }}'>
+          <!-- If you are sharing with or getting from a contact, the glowing sharing/getting icon will replace the expand/collapse chevron. -->
+          <!-- Show expand chevron in only two cases: when contact is collapsed in GET mode and you're not getting from them OR when contact is collapsed in SHARE mode and you're not sharing with them. -->
+          <core-icon icon="expand-more" class="expand"
+            hidden?='{{ (!(mode==ui_constants.Mode.GET && !contact.getExpanded && !contact.isSharingWithMe) && !(mode==ui_constants.Mode.SHARE && !contact.shareExpanded && !contact.isGettingFromMe)) || contact.status == UserStatus.REMOTE_INVITED_BY_LOCAL }}'>
+          </core-icon>
+          <!-- Show collapse chevron in only two cases: when contact is expanded in GET mode and you're not getting from them OR when contact is expanded in SHARE mode and you're not sharing with them. -->
+          <core-icon icon="expand-less" class="expand"
+            hidden?='{{ !(model.globalSettings.mode==ui_constants.Mode.GET && contact.getExpanded && !contact.isSharingWithMe) && !(model.globalSettings.mode==ui_constants.Mode.SHARE && contact.shareExpanded && !contact.isGettingFromMe) }}'>
+          </core-icon>
+        </div>
+
         <div class='{{ (isOnline || contact.status!=UserStatus.FRIEND) ? "onlineStatus" : "offlineStatus" }}'
           hidden?="{{ hideOnlineStatus }}" on-tap='{{ toggle }}'>
           <span hidden?='{{contact.status==UserStatus.LOCAL_INVITED_BY_REMOTE || contact.status==UserStatus.REMOTE_INVITED_BY_LOCAL}}'>{{ (isOnline ? "ONLINE" : "OFFLINE") | $$ }}</span>
@@ -284,20 +279,6 @@
         </core-collapse> <!-- end of shareControls -->
       </div>
 
-      <!-- TODO: Simplify show/hide logic of getting/sharing/expand/collapse icons. E.g. Angular allowed if/else-like logic to select what is displayed. -->
-      <img src='../icons/getting_animated.gif' class='accessIcon'
-          hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.GET || !contact.isSharingWithMe }}' on-tap='{{ toggle }}'>
-      <img src='../icons/sharing_animated.gif' class='accessIcon'
-          hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.SHARE || !contact.isGettingFromMe }}' on-tap='{{ toggle }}'>
-      <!-- If you are sharing with or getting from a contact, the glowing sharing/getting icon will replace the expand/collapse chevron. -->
-      <!-- Show expand chevron in only two cases: when contact is collapsed in GET mode and you're not getting from them OR when contact is collapsed in SHARE mode and you're not sharing with them. -->
-      <core-icon icon="expand-more" class="expand"
-        hidden?='{{ (!(mode==ui_constants.Mode.GET && !contact.getExpanded && !contact.isSharingWithMe) && !(mode==ui_constants.Mode.SHARE && !contact.shareExpanded && !contact.isGettingFromMe)) || contact.status == UserStatus.REMOTE_INVITED_BY_LOCAL }}' on-tap='{{ toggle }}'>
-      </core-icon>
-      <!-- Show collapse chevron in only two cases: when contact is expanded in GET mode and you're not getting from them OR when contact is expanded in SHARE mode and you're not sharing with them. -->
-      <core-icon icon="expand-less" class="expand"
-        hidden?='{{ !(model.globalSettings.mode==ui_constants.Mode.GET && contact.getExpanded && !contact.isSharingWithMe) && !(model.globalSettings.mode==ui_constants.Mode.SHARE && contact.shareExpanded && !contact.isGettingFromMe) }}' on-tap='{{ toggle }}'>
-      </core-icon>
     </div> <!-- end of #nameRow -->
 
   </template>


### PR DESCRIPTION
Move all per-contact icons onto a single line instead of having the
open/close icon be to the right of everything else.  Get rid of the
wrapper that was serving little purpose.  Remove the table that was
causing issues with responsiveness.

Fixes #2359

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2391)
<!-- Reviewable:end -->
