### PR TITLE
Added restart cloud option when connection fails

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -756,6 +756,16 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
           log.error('error destroying cloud server:', e.message);
           return Promise.reject(e);
         });
+      case uproxy_core_api.CloudOperationType.CLOUD_REBOOT:
+        // OAuth into provider and reboot cloud server
+        return provisioner.reboot(DROPLET_NAME).then(() => {
+          destroyModules();
+          log.debug('rebooted cloud server on', args.providerName);
+        }, (e: Error) => {
+          destroyModules();
+          log.error('error rebooting cloud server:', e.message);
+          return Promise.reject(e);
+        });
       default:
         return Promise.reject(new Error('cloud operation not supported'));
     }

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1400,7 +1400,7 @@
     "message": "If you get this error repeatedly, try restarting your server."
   },
   "RESTART_SERVER": {
-    "description": "Text shown on dialog button that allows you to restart a server.",
+    "description": "Label for button that confirms user wants to restart a server.",
     "message": "Restart now"
   },
   "RESTARTING_SERVER": {

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1390,5 +1390,33 @@
   "CLOUD_INSTALL_CANCEL_FAILURE": {
     "description": "Message shown on toast when a could server install fails.",
     "message": "We cannot cancel the creation of your cloud server right now. You can delete the server once it's ready."
+  },
+  "RESTART_SERVER_TITLE": {
+    "description": "Title shown on dialog when connecting to a server fails.",
+    "message": "Oops! We had trouble getting access."
+  },
+  "RESTART_SERVER_TEXT": {
+    "description": "Text shown on dialog when connecting to a server fails.",
+    "message": "If you get this error repeatedly, try restarting your server."
+  },
+  "RESTART_SERVER": {
+    "description": "Text shown on dialog button that allows you to restart a server.",
+    "message": "Restart now"
+  },
+  "RESTARTING_SERVER": {
+    "description": "Toast message to confirm that server is restarting.",
+    "message": "Restarting server..."
+  },
+  "RESTART_SUCCESS": {
+    "description": "Toast indicating a successful server restart.",
+    "message": "Successfully restarted server!"
+  },
+  "RESTART_FAILURE_TITLE": {
+    "description": "Dialog title indicating a failure to restart server.",
+    "message": "Uh oh! We could not restart your server."
+  },
+  "RESTART_FAILURE_TEXT": {
+    "description": "Dialog text indicating a failure to restart server.",
+    "message": "You may want to delete your cloud server and create a new one."
   }
 }

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -121,7 +121,7 @@ Polymer({
       isRequesting: false,
       userId: this.contact.userId // Cloud instance userId
     }).then((cloudInviteUrl: string) => {
-      this.ui.showDialog(this.ui.i18n_t("CLOUD_SHARE_INSTRUCTIONS"), '', this.ui.i18n_t("OK"),
+      this.ui.showDialog(this.ui.i18n_t('CLOUD_SHARE_INSTRUCTIONS'), '', this.ui.i18n_t('OK'),
         undefined, cloudInviteUrl);
     });
   },
@@ -136,36 +136,44 @@ Polymer({
         userId: this.contact.userId
       });
     }).then(() => {
-      this.ui.toastMessage = this.ui.i18n_t("REMOVE_CLOUD_SERVER_SUCCESS");
+      this.ui.toastMessage = this.ui.i18n_t('REMOVE_CLOUD_SERVER_SUCCESS');
     }).catch((e: Error) => {
       if (e.name === 'CLOUD_ERR') {
-         this.ui.showDialog(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
-           this.ui.i18n_t("DESTROY_CLOUD_SERVER_FAILURE"));
+         this.ui.showDialog(this.ui.i18n_t('REMOVE_CLOUD_SERVER'),
+           this.ui.i18n_t('DESTROY_CLOUD_SERVER_FAILURE'));
       } else {
-        this.ui.showDialog(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
-          this.ui.i18n_t("REMOVE_CLOUD_SERVER_FAILURE"));
+        this.ui.showDialog(this.ui.i18n_t('REMOVE_CLOUD_SERVER'),
+          this.ui.i18n_t('REMOVE_CLOUD_SERVER_FAILURE'));
       }
     });
   },
   displayCloudRemovalConfirmation: function() {
     if (this.contact.status === this.UserStatus.CLOUD_INSTANCE_CREATED_BY_LOCAL) {
-      return this.ui.getConfirmation(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
-        this.ui.i18n_t('DESTROY_CLOUD_SERVER_CONFIRMATION'), true);
+      return this.ui.getConfirmation(
+        this.ui.i18n_t('REMOVE_CLOUD_SERVER'),
+        this.ui.i18n_t('DESTROY_CLOUD_SERVER_CONFIRMATION'),
+        this.ui.i18n_t('CANCEL'),
+        this.ui.i18n_t('CONTINUE')
+      );
     } else {
-      return this.ui.getConfirmation(this.ui.i18n_t("REMOVE_CLOUD_SERVER"),
-        this.ui.i18n_t('REMOVE_CLOUD_SERVER_CONFIRMATION'), true);
+      return this.ui.getConfirmation(
+        this.ui.i18n_t('REMOVE_CLOUD_SERVER'),
+        this.ui.i18n_t('REMOVE_CLOUD_SERVER_CONFIRMATION'),
+        this.ui.i18n_t('CANCEL'),
+        this.ui.i18n_t('CONTINUE')
+      );
     }
   },
   destroyCloudServerIfNeeded: function() {
     if (this.contact.status === this.UserStatus.CLOUD_INSTANCE_CREATED_BY_LOCAL) {
-      this.ui.toastMessage = this.ui.i18n_t("REMOVING_UPROXY_CLOUD_STATUS");
+      this.ui.toastMessage = this.ui.i18n_t('REMOVING_UPROXY_CLOUD_STATUS');
       return ui_context.core.cloudUpdate({
         operation: uproxy_core_api.CloudOperationType.CLOUD_DESTROY,
         providerName: DEFAULT_PROVIDER
       }).catch((e: Error) => {
         return Promise.reject({
-          "name":"CLOUD_ERR",
-          "message":"Could not destroy cloud server."
+          'name':'CLOUD_ERR',
+          'message':'Could not destroy cloud server.'
         });
       });
     }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -332,19 +332,20 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   public restartServer_ = (providerName :string) => {
-    this.getConfirmationWithOptions(
+    this.getConfirmation(
       this.i18n_t('RESTART_SERVER_TITLE'),
       this.i18n_t('RESTART_SERVER_TEXT'),
+      this.i18n_t('CANCEL'),
       this.i18n_t('RESTART_SERVER')
     ).then(() => {
-      this.toastMessage = this.i18n_t("RESTARTING_SERVER");
+      this.toastMessage = this.i18n_t('RESTARTING_SERVER');
       return this.core.cloudUpdate({
         operation: uproxy_core_api.CloudOperationType.CLOUD_REBOOT,
         providerName: providerName
       }).then(() => {
-        this.toastMessage = this.i18n_t("RESTART_SUCCESS");
+        this.toastMessage = this.i18n_t('RESTART_SUCCESS');
       }).catch((e: Error) => {
-        this.showDialog(this.i18n_t("RESTART_FAILURE_TITLE"), this.i18n_t("RESTART_FAILURE_TEXT"));
+        this.showDialog(this.i18n_t('RESTART_FAILURE_TITLE'), this.i18n_t('RESTART_FAILURE_TEXT'));
       });
     }).then(() => {
       this.bringUproxyToFront();
@@ -376,7 +377,8 @@ export class UserInterface implements ui_constants.UiApi {
 
   public getConfirmation(heading :string,
                          text :string,
-                         cancelContinueButtons :boolean = false) :Promise<void> {
+                         dismissButtonText ?:string,
+                         fulfillButtonText ?:string): Promise<void> {
     return new Promise<void>((F, R) => {
       var callbackIndex = ++this.confirmationCallbackIndex_;
       this.confirmationCallbacks_[callbackIndex] = {fulfill: F, reject: R};
@@ -384,35 +386,11 @@ export class UserInterface implements ui_constants.UiApi {
         heading: heading,
         message: text,
         buttons: [{
-          text: cancelContinueButtons ?
-              this.i18n_t('CANCEL') : this.i18n_t('NO'),
+          text: dismissButtonText ? dismissButtonText : this.i18n_t('NO'),
           callbackIndex: callbackIndex,
           dismissive: true
         }, {
-          text: cancelContinueButtons ?
-              this.i18n_t('CONTINUE') : this.i18n_t('YES'),
-          callbackIndex: callbackIndex
-        }]
-      });
-    });
-  }
-
-  public getConfirmationWithOptions(heading :string,
-                                    text :string,
-                                    fulfillButtonText :string,
-                                    dismissButtonText ?:string) :Promise<void> {
-    return new Promise<void>((F, R) => {
-      var callbackIndex = ++this.confirmationCallbackIndex_;
-      this.confirmationCallbacks_[callbackIndex] = { fulfill: F, reject: R };
-      this.fireSignal('open-dialog', {
-        heading: heading,
-        message: text,
-        buttons: [{
-          text: dismissButtonText ? dismissButtonText : this.i18n_t('CANCEL'),
-          callbackIndex: callbackIndex,
-          dismissive: true
-        },{
-          text: fulfillButtonText,
+          text: fulfillButtonText ? fulfillButtonText : this.i18n_t('YES'),
           callbackIndex: callbackIndex
         }]
       });

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -346,6 +346,8 @@ export class UserInterface implements ui_constants.UiApi {
       }).catch((e: Error) => {
         this.showDialog(this.i18n_t("RESTART_FAILURE_TITLE"), this.i18n_t("RESTART_FAILURE_TEXT"));
       });
+    }).then(() => {
+      this.bringUproxyToFront();
     });
   }
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -242,7 +242,8 @@ export enum PortControlSupport {PENDING, TRUE, FALSE};
 
 export enum CloudOperationType {
   CLOUD_INSTALL = 0,
-  CLOUD_DESTROY = 1
+  CLOUD_DESTROY = 1,
+  CLOUD_REBOOT = 2
 }
 
 // Arguments to cloudUpdate


### PR DESCRIPTION
When the user fails to get access to a locally created cloud server, we give the user the option to restart the server. 

With uproxy-lib PR: https://github.com/uProxy/uproxy-lib/pull/401

Getting confirmation to restart:
![image](https://cloud.githubusercontent.com/assets/2903381/14863798/2dddb4bc-0c85-11e6-9f64-bd630a78c3e9.png)

Toast shown when server is rebooting:
![image](https://cloud.githubusercontent.com/assets/2903381/14863833/5acb63a2-0c85-11e6-83b0-2deee8d8c5e5.png)

Toast shown when restart is successful:
![image](https://cloud.githubusercontent.com/assets/2903381/14864011/2a0eb81c-0c86-11e6-9a59-8ed9d7525d6c.png)

Dialog shown if restart fails:
![image](https://cloud.githubusercontent.com/assets/2903381/14863816/43bd7376-0c85-11e6-8b72-e8c30d3c8f98.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2393)
<!-- Reviewable:end -->
