### PR TITLE
up node to 4.4 LTS on shippable/travis

### DIFF
--- a/.shippable.yml
+++ b/.shippable.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '4.4'
 env:
 - secure: nKJ7N2c+hez7Qs0sNaiqxzEey5CR6QuMNHJ0k9wwm/HLJfeDut8eTe6ZeZtIsDCVed3vCLV/7tlxW8ZQTOf/vX1F8L0hSeADvAnblGi3xG18K7LTjIs5JvAuxSu1ZLRPZ9PkqpSq7Yx1WUdiza8qcYrfsZrhzre+KfzeRzkjFEp7d5DCycr28fFkxA/gXiggaE4K2l6JZrDlK5dxX4TAMIuzr4vVCCUrtzDXXoiXx6kfXF3YcBq5K6QEA08qJMPmhIqHXpBuaiWBangDlWZObnjkdksid5HGHhVkLG4AschRXE4Xh7FCAOTqKNbsPYVJGWBsQNwDXHRHSMc/b9WpUQ==
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.4"
 before_install:
   - npm install -g grunt-cli bower
 install:


### PR DESCRIPTION
See https://github.com/uProxy/uproxy/issues/2396

Seems the C++11 warning isn't really blocking, let me know if we should leave the above issue open anyway or mark it closed after this. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2398)
<!-- Reviewable:end -->
