### PR TITLE
Add invite link support for Android.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -249,7 +249,7 @@ gruntConfig = {
 
   # Create commands to run in different directories
   ccaPlatformAndroidCmd: '<%= ccaJsPath %> platform add android'
-  ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen'
+  ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git'
 
   # Temporarily remove cordova-plugin-chrome-apps-proxy and add the MobileChromeApps version until the new version is released
   ccaAddPluginsIosCmd: '<%= ccaJsPath %> plugin remove cordova-plugin-chrome-apps-proxy && <%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/gitlaura/cordova-plugin-iosrtc.git https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-proxy.git'

--- a/src/cca/app/config.xml
+++ b/src/cca/app/config.xml
@@ -1,10 +1,27 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="org.uproxy" version="0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.uproxy" version="0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <preference name="SplashScreen" value="splashscreen" />
     <preference name="SplashScreenDelay" value="20000" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <platform name="ios">
         <preference name="deployment-target" value="7.0"/> 
         <hook type="before_run" src="hooks/iosrtc-swift-support.js"/>
+    </platform>
+    <preference name="AndroidLaunchMode" value="singleInstance" />
+    <platform name="android">
+        <config-file target="AndroidManifest.xml" parent="./application/activity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="uproxy.org" />
+                <data android:host="www.uproxy.org" />
+                <data android:pathPrefix="/invite" />
+                <data android:pathPrefix="/request/" />
+                <data android:pathPrefix="/offer/" />
+            </intent-filter>
+        </config-file>
     </platform>
 </widget>

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -1,5 +1,6 @@
 /// <reference path='../../../../../third_party/typings/browser.d.ts'/>
 /// <reference path='../../../../../third_party/typings/cordova/themeablebrowser.d.ts'/>
+/// <reference path='../../../../../third_party/typings/cordova/webintents.d.ts'/>
 
 /**
  * cordova_browser_api.ts
@@ -53,6 +54,46 @@ class CordovaBrowserApi implements BrowserAPI {
     chrome.notifications.onClicked.addListener((tag) => {
       this.emit_('notificationclicked', tag);
     });
+
+    // Cordova APIs are not guaranteed to be available until after the
+    // deviceready event firest.  This is a special event: if you miss it,
+    // and add your listener after the event has already fired, Cordova
+    // guarantees that your listener will run immediately.
+    // We listen to window.top because CCA runs application code in an iframe,
+    // but deviceready never fires on the iframe.
+    window.top.document.addEventListener('deviceready', () => {
+      // We use the copy of webintent attached to the top-level window, instead
+      // of the window for this iframe, because the iframe's copy of webintent
+      // is populated asynchronously and may not be ready yet when deviceready
+      // fires.
+      window.top.webintent.getUri(this.onUrl_);  // Handle URL already received.
+      window.top.webintent.onNewIntent(this.onUrl_);  // Handle future URLs.
+    }, false);
+  }
+
+  private onUrl_ = (url:string) => {
+    // "request/" and "offer/" require trailing slashes. "invite" does not.
+    var urlMatch = /(?:http|https)\:\/\/(?:www\.)?uproxy\.org\/(request\/|offer\/|invite).*/;
+    if (!url) {
+      // This is expected because webintent.getUri() calls back with null if
+      // there is no URI for this startup, i.e. normal startup.
+      return;
+    }
+    var match = url.match(urlMatch);
+    if (!match) {
+      // Unrecognized URL.  This is an error, because only matching URLs are
+      // listed in our <intent-filter> in config.xml.
+      console.warn('Unmatched intent URL: ' + url);
+      return;
+    }
+    if (match[1] === 'invite') {
+      this.emit_('inviteUrlData', url);
+    } else if (match[1] === 'request/' || match[1] === 'offer/') {
+      this.emit_('copyPasteUrlData', url);
+    } else {
+      // This code is unreachable.
+      console.warn('Bug encountered while processing url: ' + url);
+    }
   }
 
   public isConnectedToCellular = () : Promise<boolean> => {
@@ -220,15 +261,33 @@ class CordovaBrowserApi implements BrowserAPI {
 
   private events_ :{[name :string] :Function} = {};
 
+  // Queue of any events emitted that don't have listeners yet.  This is needed
+  // for the 'inviteUrlData' event, if the invite URL caused uProxy to open,
+  // because otherwise the event would be emitted before UserInterface has a
+  // chance to set a listener on it.
+  private pendingEvents_ :{[name :string] :Object[][]} = {};
+
   public on = (name :string, callback :Function) => {
+    if (name in this.events_) {
+      console.warn('Overwriting Cordova Browser API event listener: ' + name);
+    }
     this.events_[name] = callback;
+    if (name in this.pendingEvents_) {
+      this.pendingEvents_[name].forEach((args:Object[]) => {
+        callback.apply(null, args);
+      });
+      delete this.pendingEvents_[name];
+    }
   }
 
   private emit_ = (name :string, ...args :Object[]) => {
     if (name in this.events_) {
       this.events_[name].apply(null, args);
     } else {
-      console.error('Attempted to trigger an unknown event', name);
+      if (!(name in this.pendingEvents_)) {
+        this.pendingEvents_[name] = [];
+      }
+      this.pendingEvents_[name].push(args);
     }
   }
 }

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -56,7 +56,7 @@ class CordovaBrowserApi implements BrowserAPI {
     });
 
     // Cordova APIs are not guaranteed to be available until after the
-    // deviceready event firest.  This is a special event: if you miss it,
+    // deviceready event fires.  This is a special event: if you miss it,
     // and add your listener after the event has already fired, Cordova
     // guarantees that your listener will run immediately.
     // We listen to window.top because CCA runs application code in an iframe,

--- a/src/cca/app/scripts/iosrtc-register-globals.js
+++ b/src/cca/app/scripts/iosrtc-register-globals.js
@@ -1,10 +1,10 @@
 /*
   In order use WebRTC on iOS, you can call cordova.plugins.iosrtc.registerGlobals() after 'deviceready' fires.
   However, we need to set window.RTCPeerConnection, window.RTCSessionDescription, and window.RTCIceCandidate 
-  before freedom-for-chrome.js loads so we do so in the background here. This script should only be loaded for ios.
+  before freedom-for-chrome.js loads so we do so in the background here.
 */
 
-if (cordova.plugins.iosrtc) {
+if (cordova && cordova.plugins && cordova.plugins.iosrtc) {
   window.RTCPeerConnection = cordova.plugins.iosrtc.RTCPeerConnection;
   window.RTCSessionDescription = cordova.plugins.iosrtc.RTCSessionDescription;
   window.RTCIceCandidate = cordova.plugins.iosrtc.RTCIceCandidate;

--- a/src/cca/app/scripts/main.core-env.ts
+++ b/src/cca/app/scripts/main.core-env.ts
@@ -32,7 +32,6 @@ console.log('Instantiating UI');
 // This instantiation, before the core has even started, should reduce the
 // apparent startup time, but runs the risk of leaving the UI non-responsive
 // until the core catches up.
-// TODO: Add a loading screen, for slow systems.
 browserApi.bringUproxyToFront().then(() => {
   console.log('UI instantiation complete');
   if (navigator.splashscreen) {

--- a/third_party/typings/cordova/webintents.d.ts
+++ b/third_party/typings/cordova/webintents.d.ts
@@ -1,0 +1,10 @@
+// See https://github.com/Initsogar/cordova-webintent
+
+interface WebIntent {
+  getUri(callback:(url:string) => any) : void;
+  onNewIntent(callback:(url:string) => any) : void;
+}
+
+interface Window {
+  webintent: WebIntent;
+}


### PR DESCRIPTION
With this change, uProxy for Android can now process invite links
that the user taps in e-mail or chat apps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2412)
<!-- Reviewable:end -->
