### PR TITLE
cleanup the cloud operations in core

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -738,12 +738,12 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
           // user, who just created the server.
           cloudNetworkData['isAdmin'] = true;
 
+          // We cast to any because InviteTokenData currently has a required userName
+          // field which is unused by the cloud social provider.
           // TODO: what if this fails?
-          return cloudNetwork.acceptInvitation({
+          return cloudNetwork.acceptInvitation(<any>{
             v: 2,
             networkName: 'Cloud',
-            // TODO: huh? cloud social provider doesn't use this
-            userName: cloudNetworkData['host'],
             networkData: JSON.stringify(cloudNetworkData)
           });
         });

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -694,8 +694,10 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   private createCloudServer_ = (region: string) => {
     log.debug('creating cloud server in %1', region);
 
+    // Since this step can take a while, start >0 so there's less confusion
+    // that this is a progress bar.
     ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_CREATING_SERVER');
-    ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, 0);
+    ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, CLOUD_DEPLOY_PROGRESS / 2);
 
     return this.loginIfNeeded_('Cloud').then((cloudNetwork) => {
       return oneShotModule_(CLOUD_PROVIDER_MODULE_NAME, (provider: any) => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -740,18 +740,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
             userName: cloudNetworkData['host'],
             networkData: JSON.stringify(cloudNetworkData)
           });
-        }, (e: Error) => {
-          log.error('install failed, cleaning up');
-          return this.destroyCloudServer_().then(() => {
-            log.info('removed new droplet after failed cloud install');
-            throw e;
-          }, (e: Error) => {
-            // This is bad: the user will be charged for a useless droplet.
-            // This is why the UI instructs the user to check the DigitalOcean
-            // control panel whenever install fails.
-            log.error('failed to remove droplet after failed cloud install: %1', e.message);
-            throw e;
-          });
         });
       });
     });

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -44,18 +44,58 @@ loggingController.setDefaultFilter(
 var portControl = globals.portControl;
 
 // Prefix for freedomjs modules which interface with cloud computing providers.
-const CLOUD_PROVIDER_MODULE_PREFIX: string = 'CLOUDPROVIDER-';
+const CLOUD_PROVIDER_MODULE_NAME_PREFIX: string = 'CLOUDPROVIDER-';
+const CLOUD_PROVIDER_NAME = 'digitalocean';
+const CLOUD_PROVIDER_MODULE_NAME = CLOUD_PROVIDER_MODULE_NAME_PREFIX + CLOUD_PROVIDER_NAME;
+const CLOUD_INSTALLER_MODULE_NAME = 'cloudinstall';
 
 const getCloudProviderNames = (): string[] => {
   let results: string[] = [];
   for (var dependency in freedom) {
     if (freedom.hasOwnProperty(dependency) &&
-        dependency.indexOf(CLOUD_PROVIDER_MODULE_PREFIX) === 0) {
-      results.push(dependency.substr(CLOUD_PROVIDER_MODULE_PREFIX.length));
+        dependency.indexOf(CLOUD_PROVIDER_MODULE_NAME_PREFIX) === 0) {
+      results.push(dependency.substr(CLOUD_PROVIDER_MODULE_NAME_PREFIX.length));
     }
   }
   return results;
 };
+
+// This is the name recommended by the blog post.
+const CLOUD_DROPLET_NAME = 'uproxy-cloud-server';
+
+// Percentage of cloud install progress devoted to deploying.
+// The remainder is devoted to the install script.
+const CLOUD_DEPLOY_PROGRESS = 20;
+
+// Invokes f with an instance of the specified freedomjs module.
+// The module instance will be destroyed before the function resolves
+// or rejects. Intended for use with heavy-weight modules such as
+// those used for cloud.
+function oneShotModule_<T>(moduleName: string, f: (provider: any) => Promise<T>): Promise<T> {
+  try {
+    const m = freedom[moduleName]();
+    log.debug('created ' + moduleName + ' module');
+
+    const destructor = () => {
+      try {
+        freedom[moduleName].close(m);
+        log.debug('destroyed ' + moduleName + ' module');
+      } catch (e) {
+        log.debug('error destroying ' + moduleName + ' module: ' + e.message);
+      }
+    };
+
+    return f(m).then((result: T) => {
+      destructor();
+      return result;
+    }, (e: Error) => {
+      destructor();
+      throw e;
+    });
+  } catch (e) {
+    return Promise.reject(new Error('error creating ' + moduleName + ' module: ' + e.message));
+  }
+}
 
 /**
  * Primary uProxy backend. Handles which social networks one is connected to,
@@ -69,13 +109,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
   private availableVersion_ :string = null;
 
   private connectedNetworks_ = new StoredValue<string[]>('connectedNetworks', []);
-
-  private cloudInterfaces_ :{
-    [cloudProvider: string] :{
-      installer :any,
-      provisioner :any
-    }
-  } = {};
 
   constructor() {
     log.debug('Preparing uProxy Core');
@@ -638,138 +671,105 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     ui.update(uproxy_core_api.Update.CORE_UPDATE_AVAILABLE, details);
   }
 
-  public cloudUpdate = (args :uproxy_core_api.CloudOperationArgs): Promise<void> => {
-    // This is the server name recommended by the blog post.
-    const DROPLET_NAME = 'uproxy-cloud-server';
-
-    // Percentage of cloud install progress devoted to deploying.
-    // The remainder is devoted to the install script.
-    const DEPLOY_PROGRESS = 20;
-
-    if (args.providerName !== 'digitalocean') {
+  public cloudUpdate = (args: uproxy_core_api.CloudOperationArgs): Promise<void> => {
+    if (args.providerName !== CLOUD_PROVIDER_NAME) {
       return Promise.reject(new Error('unsupported cloud provider'));
     }
-
-    this.cloudInterfaces_[args.providerName] = this.cloudInterfaces_[args.providerName] || { installer: undefined, provisioner: undefined};
-    const provisionerName = CLOUD_PROVIDER_MODULE_PREFIX + args.providerName;
-    const provisioner = this.cloudInterfaces_[args.providerName].provisioner || freedom[provisionerName]();
-    const installer = this.cloudInterfaces_[args.providerName].installer || freedom['cloudinstall']();
-    this.cloudInterfaces_[args.providerName] = { installer: installer, provisioner: provisioner};
-
-    const destroyModules = () => {
-      freedom[provisionerName].close(provisioner);
-      freedom['cloudinstall'].close(installer);
-      delete this.cloudInterfaces_[args.providerName];
-    };
 
     switch (args.operation) {
       case uproxy_core_api.CloudOperationType.CLOUD_INSTALL:
         if (!args.region) {
           return Promise.reject(new Error('no region specified for cloud provider'));
         }
+        return this.createCloudServer_(args.region);
+      case uproxy_core_api.CloudOperationType.CLOUD_DESTROY:
+        return this.destroyCloudServer_();
+      case uproxy_core_api.CloudOperationType.CLOUD_REBOOT:
+        return this.rebootCloudServer_();
+      default:
+        return Promise.reject(new Error('cloud operation not supported'));
+    }
+  }
 
-        log.debug('deploying cloud server on %1 in %2', args.providerName, args.region);
-        ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_CREATING_SERVER');
-        ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, 0);
+  private createCloudServer_ = (region: string) => {
+    log.debug('creating cloud server in %1', region);
 
-        return provisioner.start(DROPLET_NAME, args.region).then((serverInfo: any) => {
-          log.info('created server on digitalocean: %1', serverInfo);
+    ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_CREATING_SERVER');
+    ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, 0);
 
-          ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, DEPLOY_PROGRESS);
-          ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_LOGGING_IN');
+    return this.loginIfNeeded_('Cloud').then((cloudNetwork) => {
+      return oneShotModule_(CLOUD_PROVIDER_MODULE_NAME, (provider: any) => {
+        return provider.start(CLOUD_DROPLET_NAME, region);
+      }).catch((e: any) => {
+        if (e.errcode === 'VM_AE') {
+          // This string has special meaning for the polymer template.
+          return Promise.reject(new Error('server already exists'));
+        } else {
+          return Promise.reject(e);
+        }
+      }).then((serverInfo: any) => {
+        const host = serverInfo.network.ipv4;
+        const port = serverInfo.network.ssh_port;
 
-          const host = serverInfo.network.ipv4;
-          const port = serverInfo.network.ssh_port;
+        log.debug('installing cloud on new droplet at %1:%2 (server details: %3)', host, port, serverInfo);
 
-          log.debug('installing cloud on %1:%2', host, port);
+        ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS, CLOUD_DEPLOY_PROGRESS);
+        ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, 'CLOUD_INSTALL_STATUS_LOGGING_IN');
 
+        return oneShotModule_(CLOUD_INSTALLER_MODULE_NAME, (installer: any) => {
           installer.on('status', (status: number) => {
             ui.update(uproxy_core_api.Update.CLOUD_INSTALL_STATUS, status);
           });
 
-          installer.on('progress', (progress:number) => {
+          installer.on('progress', (progress: number) => {
             ui.update(uproxy_core_api.Update.CLOUD_INSTALL_PROGRESS,
-                DEPLOY_PROGRESS + (progress * ((100 - DEPLOY_PROGRESS) / 100)));
+              CLOUD_DEPLOY_PROGRESS + (progress * ((100 - CLOUD_DEPLOY_PROGRESS) / 100)));
           });
 
-          // TODO: The provisioning module should return the username!
           return installer.install(host, port, 'root', serverInfo.ssh.private);
         }).then((cloudNetworkData: any) => {
-          // TODO: make cloudNetworkData an Invite type.  This requires the cloud
-          // social provider to export the Invite interface, and also to cleanup
-          // reference paths so that uProxy doesn't need to include modules like
-          // ssh2.
-          destroyModules();
+          // Set flag so Cloud social provider knows this invite is for the admin
+          // user, who just created the server.
+          cloudNetworkData['isAdmin'] = true;
 
-          // Login to the Cloud network if the user isn't already so that
-          // we can add the new cloud server to the roster.
-          return this.loginIfNeeded_('Cloud').then((cloudNetwork) => {
-            // Set flag so Cloud social provider knows this invite is for the admin
-            // user, who just created the server.
-            cloudNetworkData['isAdmin'] = true;
-
-            // Synthesize an invite token based on cloudNetworkData.
-            // CONSIDER: if we had a social.acceptInvitation that only took
-            // networkData we wouldn't need to fake the other fields.
-            return cloudNetwork.acceptInvitation({
-              v: 2,
-              networkName: 'Cloud',
-              userName: cloudNetworkData['host'],
-              networkData: JSON.stringify(cloudNetworkData)
-            });
+          // TODO: what if this fails?
+          return cloudNetwork.acceptInvitation({
+            v: 2,
+            networkName: 'Cloud',
+            // TODO: huh? cloud social provider doesn't use this
+            userName: cloudNetworkData['host'],
+            networkData: JSON.stringify(cloudNetworkData)
           });
-        }, (installError: any) => {
-          // When we cancel the cloud install we close the connection
-          // to the installer by destroying the modules
-          if (installError === 'closed') {
-            return Promise.reject(new Error('canceled'));
-          }
-          
-          // Tell user if the server already exists
-          if (installError.errcode === "VM_AE") {
-            destroyModules();
-            return Promise.reject(new Error('server already exists'));
-          }
-
-          // Destroy the server we just created so that the user isn't billed.
+        }, (e: Error) => {
           log.error('install failed, cleaning up');
-          return provisioner.stop(DROPLET_NAME).then((unused: Object) => {
-            log.info('destroyed server on digitalocean');
-            destroyModules();
-            return Promise.reject(installError);
-          }, (destroyError: Error) => {
-            // This is bad: the user will be billed for a broken server.
-            // TODO: direct the user at the digitalocean console
-            log.error('failed to destroy new server after install failure: %1',
-              destroyError.message);
-            destroyModules();
-            return Promise.reject(installError);
+          return this.destroyCloudServer_().then(() => {
+            log.info('removed new droplet after failed cloud install');
+            throw e;
+          }, (e: Error) => {
+            // This is bad: the user will be charged for a useless droplet.
+            // This is why the UI instructs the user to check the DigitalOcean
+            // control panel whenever install fails.
+            log.error('failed to remove droplet after failed cloud install: %1', e.message);
+            throw e;
           });
         });
-      case uproxy_core_api.CloudOperationType.CLOUD_DESTROY:
-        // OAuth into provider and destroy cloud server
-        return provisioner.stop(DROPLET_NAME).then(() => {
-          destroyModules();
-          log.debug('stopped cloud server on', args.providerName);
-        }, (e: Error) => {
-          destroyModules();
-          log.error('error destroying cloud server:', e.message);
-          return Promise.reject(e);
-        });
-      case uproxy_core_api.CloudOperationType.CLOUD_REBOOT:
-        // OAuth into provider and reboot cloud server
-        return provisioner.reboot(DROPLET_NAME).then(() => {
-          destroyModules();
-          log.debug('rebooted cloud server on', args.providerName);
-        }, (e: Error) => {
-          destroyModules();
-          log.error('error rebooting cloud server:', e.message);
-          return Promise.reject(e);
-        });
-      default:
-        return Promise.reject(new Error('cloud operation not supported'));
-    }
-  }  // end of cloudUpdate
+      });
+    });
+  }
+
+  private destroyCloudServer_ = () => {
+    log.debug('destroying cloud server');
+    return oneShotModule_<void>(CLOUD_PROVIDER_MODULE_NAME, (provider: any) => {
+      return provider.stop(CLOUD_DROPLET_NAME);
+    });
+  }
+
+  private rebootCloudServer_ = () => {
+    log.debug('rebooting cloud server');
+    return oneShotModule_<void>(CLOUD_PROVIDER_MODULE_NAME, (provider: any) => {
+      return provider.reboot(CLOUD_DROPLET_NAME);
+    });
+  }
 
   // Gets a social.Network, and logs the user in if they aren't yet logged in.
   private loginIfNeeded_ = (networkName :string) : Promise<social.Network> => {

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -85,13 +85,17 @@ function oneShotModule_<T>(moduleName: string, f: (provider: any) => Promise<T>)
       }
     };
 
-    return f(m).then((result: T) => {
-      destructor();
-      return result;
-    }, (e: Error) => {
-      destructor();
-      throw e;
-    });
+    try {
+      return f(m).then((result: T) => {
+        destructor();
+        return result;
+      }, (e: Error) => {
+        destructor();
+        throw e;
+      });
+    } catch (e) {
+      return Promise.reject(e);
+    }
   } catch (e) {
     return Promise.reject(new Error('error creating ' + moduleName + ' module: ' + e.message));
   }

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -143,7 +143,10 @@ Polymer({
     this.ui = ui;
     // ID of the latest attempt to create a server, used to distinguish
     // between install failures that should be flagged to the user and
-    // failures owing to cancellation.
+    // failures owing to cancellation. We use a random number rather
+    // than a simple boolean because, in the event of cancellation, it
+    // can take *several* seconds for the installer to fail by which time
+    // the user could have initiated a whole new install.
     this.mostRecentCreateId = 0;
   }
 });

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -85,6 +85,12 @@ Polymer({
       if (e === 'Error: server already exists') {
         this.$.serverExistsOverlay.open();
       } else if (this.mostRecentCreateId === createId) {
+        // The user did not cancel: clean up the now-useless droplet
+        // and show a sad-face, rainy day dialog.
+        ui.cloudUpdate({
+          operation: uproxy_core_api.CloudOperationType.CLOUD_DESTROY,
+          providerName: DEFAULT_PROVIDER
+        });
         this.$.failureOverlay.open();
       }
     });

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -64,6 +64,9 @@ Polymer({
     this.$.cancelingOverlay.close();
   },
   loginTapped: function() {
+    const createId = Math.floor((Math.random() * 1000000)) + 1;
+    this.mostRecentCreateId = createId;
+
     if (!this.$.installingOverlay.opened) {
       this.closeOverlays();
       ui.cloudInstallStatus = '';
@@ -81,12 +84,13 @@ Polymer({
       // TODO: Figure out why e.message is not set
       if (e === 'Error: server already exists') {
         this.$.serverExistsOverlay.open();
-      } else if (e !== 'Error: canceled') {
+      } else if (this.mostRecentCreateId === createId) {
         this.$.failureOverlay.open();
       }
     });
   },
   removeServerAndInstallAgain: function() {
+    this.mostRecentCreateId = 0;
     this.closeOverlays();
     ui.cloudInstallStatus = ui.i18n_t('REMOVING_UPROXY_CLOUD_STATUS');
     ui.cloudInstallCancelDisabled = true;
@@ -112,6 +116,7 @@ Polymer({
     });
   },
   cancelCloudInstall: function() {
+    this.mostRecentCreateId = 0;
     this.$.cancelingOverlay.open();
     return ui.cloudUpdate({
       operation: uproxy_core_api.CloudOperationType.CLOUD_DESTROY,
@@ -130,5 +135,9 @@ Polymer({
   },
   ready: function() {
     this.ui = ui;
+    // ID of the latest attempt to create a server, used to distinguish
+    // between install failures that should be flagged to the user and
+    // failures owing to cancellation.
+    this.mostRecentCreateId = 0;
   }
 });

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -259,6 +259,7 @@ export interface InviteTokenPermissions {
 export interface InviteTokenData {
   v :number;  // version
   networkName :string;
+  // TODO: make this optional, it's not used by cloud social provider (and maybe others)
   userName :string;
   networkData :string|Object;
   permission ?:InviteTokenPermissions;


### PR DESCRIPTION
Several fixes to try to address https://github.com/uProxy/uproxy/issues/2397, and others.

Two main things:
 * Reduce the amount of state, particularly in the core where we were trying to keep track of the provisioner module.
 * Simplify how we cleanup the module instances, by introducing a function which guarantees to destroy the instance after using it.

Would you agree this reads better?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2420)
<!-- Reviewable:end -->
