### PR TITLE
Use correct network name in v2 invites for Cloud.

### DIFF
--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -736,7 +736,7 @@ export function notifyUI(networkName :string, userId :string) {
           // social networks to generate those invites.
           var urlParams :string[] = [
             'v=2',
-            'networkName=Quiver',
+            'networkName=' + this.name,
             'userName=' + encodeURIComponent(this.myInstance.userName),
             'networkData=' + jsurl.stringify(networkData)
           ];


### PR DESCRIPTION
Without this, trying to share a Cloud instance generated invites which were marked for Quiver: e.g. uproxy.org/invite?v=2&networkName=**Quiver**&....

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2446)
<!-- Reviewable:end -->
