### PR TITLE
Force us to use web-animations-js#1.0.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,10 +17,12 @@
     "core-overlay": "https://github.com/lucyhe/core-overlay.git#0.1.1",
     "paper-toast": "Polymer/paper-toast#^0.5.6",
     "paper-dropdown": "Polymer/paper-dropdown#~0.5.6",
-    "paper-fab": "Polymer/paper-fab#~0.5.6"
+    "paper-fab": "Polymer/paper-fab#~0.5.6",
+    "web-animations-js": "^1.0.8"
   },
   "resolutions": {
     "webcomponentsjs": "^0.6.0",
-    "core-overlay": "0.1.1"
+    "core-overlay": "0.1.1",
+    "web-animations-js": "^1.0.8"
   }
 }


### PR DESCRIPTION
The web-animations library was broken due to
https://bugs.chromium.org/p/chromium/issues/detail?id=601672

With this change, we will use a version of the library that has been
backported with the fix.

Fixes #2465

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2466)
<!-- Reviewable:end -->
