### PR TITLE
bump minor version number, for uproxy-lib merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uProxy",
   "description": "Internet without borders",
-  "version": "0.8.42",
+  "version": "0.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uproxy/uproxy"


### PR DESCRIPTION
Still not semantic versioning or anything but figured this wouldn't hurt, since we just imported >1000 commits from uproxy-lib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2468)
<!-- Reviewable:end -->
