### PR TITLE
Added Bangalore region as option for Digital Ocean cloud server

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1335,13 +1335,13 @@
     "description": "Instructions shown for peer-to-peer when the user has an empty roster",
     "message": "Get or share access with family & friends."
   },
-  "ASIA_BANGALORE": {
-    "description": "Region option for deploying a DigitalOcean server",
-    "message": "Asia (Bangalore)"
-  },
   "ASIA_SINGAPORE": {
     "description": "Region option for deploying a DigitalOcean server",
     "message": "Asia (Singapore)"
+  },
+  "ASIA_BANGALORE": {
+    "description": "Region option for deploying a DigitalOcean server",
+    "message": "Asia (Bangalore)"
   },
   "EUROPE_AMSTERDAM": {
     "description": "Region option for deploying a DigitalOcean server",

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1335,6 +1335,10 @@
     "description": "Instructions shown for peer-to-peer when the user has an empty roster",
     "message": "Get or share access with family & friends."
   },
+  "ASIA_BANGALORE": {
+    "description": "Region option for deploying a DigitalOcean server",
+    "message": "Asia (Bangalore)"
+  },
   "ASIA_SINGAPORE": {
     "description": "Region option for deploying a DigitalOcean server",
     "message": "Asia (Singapore)"

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -142,8 +142,9 @@
         </div>
         <h1>{{ 'CLOUD_INSTALL_LOGIN_TITLE' | $$ }}</h1>
         <div>
-          <paper-radio-group id='regionMenu' selected='sgp1'>
+          <paper-radio-group id='regionMenu' selected='blr1'>
             <!-- TODO: get available regions from DigitalOcean -->
+            <paper-radio-button name='blr1' label='{{ "ASIA_BANGALORE" | $$ }}'></paper-radio-button>
             <paper-radio-button name='sgp1' label='{{ "ASIA_SINGAPORE" | $$ }}'></paper-radio-button>
             <paper-radio-button name='ams2' label='{{ "EUROPE_AMSTERDAM" | $$ }}'></paper-radio-button>
             <paper-radio-button name='nyc2' label='{{ "NORTH_AMERICA_NEW_YORK" | $$ }}'></paper-radio-button>

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -142,10 +142,10 @@
         </div>
         <h1>{{ 'CLOUD_INSTALL_LOGIN_TITLE' | $$ }}</h1>
         <div>
-          <paper-radio-group id='regionMenu' selected='blr1'>
+          <paper-radio-group id='regionMenu' selected='sgp1'>
             <!-- TODO: get available regions from DigitalOcean -->
-            <paper-radio-button name='blr1' label='{{ "ASIA_BANGALORE" | $$ }}'></paper-radio-button>
             <paper-radio-button name='sgp1' label='{{ "ASIA_SINGAPORE" | $$ }}'></paper-radio-button>
+            <paper-radio-button name='blr1' label='{{ "ASIA_BANGALORE" | $$ }}'></paper-radio-button>
             <paper-radio-button name='ams2' label='{{ "EUROPE_AMSTERDAM" | $$ }}'></paper-radio-button>
             <paper-radio-button name='nyc2' label='{{ "NORTH_AMERICA_NEW_YORK" | $$ }}'></paper-radio-button>
           </paper-radio-group>


### PR DESCRIPTION
- To maintain alphabetical order, regions are displayed as follows:
Asia (Bangalore)
Asia (Singapore)
Europe (Amsterdam)
NOrth America (New YOrk)

- Move default selection to be Bangalore to start at top of list. Thoughts? Do we want Singapore to be default? And if so, should we go away from alphabetical order so Singapore would be the first option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2471)
<!-- Reviewable:end -->
