### PR TITLE
Remove calculated properties from advanced-settings.html

### DIFF
--- a/src/generic_ui/polymer/advanced-settings.html
+++ b/src/generic_ui/polymer/advanced-settings.html
@@ -158,19 +158,19 @@
               <core-icon icon='help'></core-icon>
             </uproxy-faq-link>
           </p>
-          <span class='label' hidden?='{{ ui.portControlSupport !== uproxy_core_api.PortControlSupport.TRUE }}'>
+          <span class='label' hidden?='{{ !_supportsPortControl(ui.portControlSupport) }}'>
             {{ 'PORT_CONTROL_SUPPORTED' | $$ }}
           </span>
-          <span class='label' hidden?='{{ ui.portControlSupport !== uproxy_core_api.PortControlSupport.FALSE }}'>
+          <span class='label' hidden?='{{ !_doesNotSupportPortControl(ui.portControlSupport) }}'>
             {{ 'PORT_CONTROL_NOT_SUPPORTED' | $$ }}
           </span>
-          <span class='label' hidden?='{{ ui.portControlSupport !== uproxy_core_api.PortControlSupport.PENDING }}'>
+          <span class='label' hidden?='{{ !_portControlStatusPending(ui.portControlSupport) }}'>
             {{ 'PORT_CONTROL_PENDING' | $$ }}
           </span>
           <uproxy-link on-tap='{{ refreshPortControl }}' role='button'>
             <core-icon icon='refresh'></core-icon>
           </uproxy-link>
-          <p class='label info' hidden?='{{ ui.portControlSupport !== uproxy_core_api.PortControlSupport.FALSE }}'>
+          <p class='label info' hidden?='{{ !_doesNotSupportPortControl(ui.portControlSupport) }}'>
             {{ 'PORT_CONTROL_NOT_SUPPORTED_INFO' | $$ }}
             <uproxy-faq-link anchor='whatIsPortControl'>
               {{ 'PORT_CONTROL_NOT_SUPPORTED_INFO_LINK' | $$ }}
@@ -183,13 +183,13 @@
             <textarea value='{{ settings }}' fit>
             </textarea>
           </paper-input-decorator>
-          <p id='confirmSetAdvancedSettings' class='advancedSettingsText' hidden?='{{ status !== StatusState.SET }}'>
+          <p id='confirmSetAdvancedSettings' class='advancedSettingsText' hidden?='{{ !_statusStateIsSet(status) }}'>
             {{ "SETTINGS_SAVED" | $$ }}
           </p>
-          <p id='failedSetAdvancedSettings' class='advancedSettingsText error' hidden?='{{ status !== StatusState.PARSE_ERROR }}'>
+          <p id='failedSetAdvancedSettings' class='advancedSettingsText error' hidden?='{{ !_statusStateIsParseErorr(status) }}'>
             {{ "SETTINGS_BAD_FORMAT_ERROR" | $$ }}
           </p>
-          <p id='failedKeyValueSetAdvancedSettings' class='advancedSettingsText error' hidden?='{{ status !== StatusState.KEY_VALUE_ERROR }}'>
+          <p id='failedKeyValueSetAdvancedSettings' class='advancedSettingsText error' hidden?='{{ !_statusStateIsKeyValueError(status) }}'>
             {{ "SETTINGS_JSON_ERROR" | $$ }}
           </p>
         </div> <!-- end of form container -->

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -21,7 +21,6 @@ export enum StatusState {
 };
 
 Polymer({
-  StatusState: StatusState,
   settings: '',
   status: StatusState.EMPTY,
   jsonifySettings_: function(settingsObject :Object) {
@@ -73,7 +72,6 @@ Polymer({
   },
   ready: function() {
     this.ui = ui;
-    this.uproxy_core_api = uproxy_core_api;
     this.model = model;
   },
   refreshPortControl: function() {
@@ -82,4 +80,22 @@ Polymer({
   computed: {
     'opened': '$.advancedSettingsPanel.opened'
   },
+  _supportsPortControl: function(supportStatus: uproxy_core_api.PortControlSupport) {
+    return supportStatus === uproxy_core_api.PortControlSupport.TRUE;
+  },
+  _doesNotSupportPortControl: function(supportStatus: uproxy_core_api.PortControlSupport) {
+    return supportStatus === uproxy_core_api.PortControlSupport.FALSE;
+  },
+  _portControlStatusPending: function(supportStatus: uproxy_core_api.PortControlSupport) {
+    return supportStatus === uproxy_core_api.PortControlSupport.PENDING;
+  },
+  _statusStateIsSet: function(statusState: StatusState) {
+    return statusState === StatusState.SET;
+  },
+  _statusStateIsParseErorr: function(statusState: StatusState) {
+    return statusState === StatusState.PARSE_ERROR;
+  },
+  _statusStateIsKeyValueError: function(statusState: StatusState) {
+    return statusState === StatusState.KEY_VALUE_ERROR;
+  }
 });


### PR DESCRIPTION
This is a reference commit for what should be done to remove calculated
properties from a Polymer element (necessary to the .5->1.0 transition).
Essentially, the only operation that can now be done in the element is
negation.  All other operations need to be moved to functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2475)
<!-- Reviewable:end -->
