### PR TITLE
Android VPN

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -236,7 +236,7 @@ gruntConfig = {
 
   # Create commands to run in different directories
   ccaPlatformAndroidCmd: '<%= ccaJsPath %> platform add android'
-  ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git'
+  ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git cordova-plugin-device https://github.com/albertolalama/cordova-plugin-tun2socks.git#alalama-tun2socks'
 
   # Temporarily remove cordova-plugin-chrome-apps-proxy and add the MobileChromeApps version until the new version is released
   ccaAddPluginsIosCmd: '<%= ccaJsPath %> plugin remove cordova-plugin-chrome-apps-proxy && <%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/gitlaura/cordova-plugin-iosrtc.git https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-proxy.git'

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -180,6 +180,7 @@ class CordovaBrowserApi implements BrowserAPI {
       console.error('Tun2Socks onDisconnect, unexpected callback error: ', err);
     });
 
+    // Convert local endpoint ipv6 address ("::") to ipv4 for tun2socks.
     var socksServerAddress = '127.0.0.1:' + endpoint.port;
     window.tun2socks.start(socksServerAddress).then(function(msg: string) {
       console.log('Tun2Socks start: ', msg);

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -33,7 +33,9 @@ function deviceSupportsVpn() : boolean {
     // Other platforms should fail here.
     return false;
   }
-  // tun2socks requires Android version >= Marshmallow (6)
+  // tun2socks calls bindProcessToNetwork so that the application traffic
+  // bypasses the VPN in order to avoid a loop-back.
+  // This API requires Android version >= Marshmallow (6).
   let majorVersionMatch = window.device.version.match(/^[0-9]+/);
   if (majorVersionMatch === null) {
     return false;

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -26,6 +26,22 @@ enum PopupState {
 
 declare var Notification :any; //TODO remove this
 
+// Returns whether the device supports VPN mode.
+function deviceSupportsVpn() : boolean {
+  if (window.tun2socks === undefined || window.device === undefined) {
+    // We only add the device and tun2socks plugins to Android.
+    // Other platforms should fail here.
+    return false;
+  }
+  // tun2socks requires Android version >= Marshmallow (6)
+  let majorVersionMatch = window.device.version.match(/^[0-9]+/);
+  if (majorVersionMatch === null) {
+    return false;
+  }
+  let majorVersion = parseInt(majorVersionMatch[0]);
+  return majorVersion >= 6;
+};
+
 class CordovaBrowserApi implements BrowserAPI {
 
   public browserSpecificElement = '';
@@ -36,11 +52,7 @@ class CordovaBrowserApi implements BrowserAPI {
   // https://github.com/uProxy/uproxy/issues/1832
   public hasInstalledThenLoggedIn = true;
 
-  // If tun2socks is in namespace and Android version is >= Marshmallow (6), we
-  // have VPN support. Note that we only add the device plugin to Android.
-  public supportsVpn = window.tun2socks !== undefined
-                       && window.device !== undefined
-                       && window.device.version.match(/^[6-9]/) != null;
+  public supportsVpn = deviceSupportsVpn();
 
   // Mode to start/stop proxying.
   private proxyAccessMode_ = ProxyAccessMode.NONE;

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -36,7 +36,7 @@ function deviceSupportsVpn() : boolean {
   }
   // tun2socks calls bindProcessToNetwork so that the application traffic
   // bypasses the VPN in order to avoid a loop-back.
-  // This API requires Android version >= Marshmallow (6).
+  // This API requires Android version >= Marshmallow (6.0, API 23).
   return compareVersion(window.device.version, '6.0.0') >= 0;
 };
 

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -25,6 +25,7 @@ class ChromeBrowserApi implements BrowserAPI {
 
   public canProxy = true;
   public hasInstalledThenLoggedIn = true;
+  public supportsVpn = false;
 
   // For browser action.
 
@@ -96,7 +97,9 @@ class ChromeBrowserApi implements BrowserAPI {
            level === 'controlled_by_this_extension';
   }
 
-  public startUsingProxy = (endpoint:net.Endpoint, bypass :string[]) => {
+  public startUsingProxy =
+      (endpoint: net.Endpoint, bypass: string[],
+       opts: browser_api.ProxyConnectOptions) => {
     var config = {
       mode: 'fixed_servers',
       rules: {

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -22,6 +22,7 @@ class FirefoxBrowserApi implements BrowserAPI {
   public browserSpecificElement :string;
   public canProxy = true;
   public hasInstalledThenLoggedIn = true;
+  public supportsVpn = false;
 
   // Global unique promise ID.
   private promiseId_ :number = 1;
@@ -55,7 +56,9 @@ class FirefoxBrowserApi implements BrowserAPI {
     port.emit('launchTabIfNotOpen', url);
   }
 
-  public startUsingProxy = (endpoint:net.Endpoint, bypass :string[]) => {
+  public startUsingProxy =
+      (endpoint: net.Endpoint, bypass: string[],
+       opts: browser_api.ProxyConnectOptions) => {
     //TODO actually use bypass list
     port.emit('startUsingProxy', endpoint);
   }

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1340,9 +1340,11 @@
     "message": "Other (please specify below)"
   },
   "START_VPN": {
+    "description": "Button label for starting a connection in VPN mode, where all device traffic is routed through uProxy.",
     "message": "Start VPN"
   },
   "START_BROWSING": {
+    "description": "Button label for starting an in-app browser connected to a uProxy peer.",
     "message": "Start browsing"
   }
 }

--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -1310,33 +1310,39 @@
   "NO_CUSTOM_ERROR_PLACEHOLDER": {
     "description": "Error that apears if you do not select any feedback in the dropdown menu.",
     "message": "Please choose feedback most similar to yours"
-  }, 
+  },
   "CLOUD_CONNECTIONS_DISCONNECTED": {
     "descripton": "One of the feedback options in the dropdown menu",
     "message": "My cloud connections get disconnected."
-  }, 
+  },
   "CLOUD_SERVER_NO_CONNECT": {
-    "description": "One of the feedback options in the dropdown menu", 
+    "description": "One of the feedback options in the dropdown menu",
     "message": "My cloud server fails to connect."
-  }, 
+  },
   "TROUBLE_SIGNING_IN": {
-    "description": "One of the feedback options in the dropdown menu", 
+    "description": "One of the feedback options in the dropdown menu",
     "message": "I'm having trouble signing in."
-  }, 
+  },
   "NO_FRIENDS": {
     "description": "One of the feedback options in the dropdown menu",
     "message": "I don't have any friends to proxy from."
-  }, 
+  },
   "TROUBLE_STARTING_CONNECTION": {
-    "description": "One of the feedback options in the dropdown menu", 
-    "message": "I can't start a connection." 
-  }, 
-  "DISCONNECTED_FROM_FRIEND": { 
+    "description": "One of the feedback options in the dropdown menu",
+    "message": "I can't start a connection."
+  },
+  "DISCONNECTED_FROM_FRIEND": {
     "description": "One of the feedback options in the dropdown menu",
     "message": "I get disconnected from my friend."
-  }, 
+  },
   "OTHER_FEEDBACK": {
-    "description": "One of the feedback options in the dropdown menu", 
+    "description": "One of the feedback options in the dropdown menu",
     "message": "Other (please specify below)"
+  },
+  "START_VPN": {
+    "message": "Start VPN"
+  },
+  "START_BROWSING": {
+    "message": "Start browsing"
   }
 }

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -49,6 +49,9 @@
       color: red;
       display: inline-block;
     }
+    .button-wrapper div {
+      display: inline;
+    }
     </style>
 
     <div id='wrapper' class='{{ instance.isOnline ? "online" : "offline" }}'
@@ -92,28 +95,37 @@
 
       <!-- It is assumed that all uproxy-instances are taken from
          user.offeringInstances and are therefore giving us access -->
+      <div class="button-wrapper">
+        <!-- not getting or trying to get access -->
+        <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
+          <uproxy-button raised on-tap='{{ startBrowsing }}' disabled?='{{ !ui.browserApi.canProxy  }}'>
+            <!-- TODO(alalama): localize {{ "START_GETTING" | $$ }} -->
+            Start browsing
+          </uproxy-button>
+        </div>
 
-      <!-- not getting or trying to get access -->
-      <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
-        <uproxy-button raised on-tap='{{ start }}' disabled?='{{ !ui.browserApi.canProxy }}'>
-          {{ "START_GETTING" | $$ }}
-        </uproxy-button>
-      </div>
+        <!-- VPN mode -->
+        <div hidden?='{{ !ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
+          <uproxy-button raised on-tap='{{ startVpn }}' disabled?='{{ !ui.browserApi.canProxy }}'>
+            <!-- TODO(alalama): localize -->
+            Start VPN
+          </uproxy-button>
+        </div>
 
-      <!-- trying to get access -->
-      <div hidden?='{{ instance.localGettingFromRemote != GettingState.TRYING_TO_GET_ACCESS }}'>
-        <uproxy-button class='grey' raised on-tap='{{ stop }}'>
-          {{ "CANCEL" | $$ }}
-        </uproxy-button>
-      </div>
+        <!-- trying to get access -->
+        <div hidden?='{{ instance.localGettingFromRemote != GettingState.TRYING_TO_GET_ACCESS }}'>
+          <uproxy-button class='grey' raised on-tap='{{ stop }}'>
+            {{ "CANCEL" | $$ }}
+          </uproxy-button>
+        </div>
 
-      <!-- currently getting access -->
-      <div hidden?='{{ instance.localGettingFromRemote != GettingState.GETTING_ACCESS }}'>
-        <uproxy-button class='grey' raised on-tap='{{ stop }}'>
-          {{ "STOP_GETTING" | $$ }}
-        </uproxy-button>
-      </div>
-
+        <!-- currently getting access -->
+        <div hidden?='{{ instance.localGettingFromRemote != GettingState.GETTING_ACCESS }}'>
+          <uproxy-button class='grey' raised on-tap='{{ stop }}'>
+            {{ "STOP_GETTING" | $$ }}
+          </uproxy-button>
+        </div>
+      </div> <!-- end of button-wrapper -->
     </div> <!-- end of wrapper -->
 
   </template>

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -97,23 +97,20 @@
          user.offeringInstances and are therefore giving us access -->
       <div class="button-wrapper">
         <!-- not getting or trying to get access -->
-        <div hidden?='{{ ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
+        <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
+          <!-- Browsing mode -->
           <uproxy-button raised on-tap='{{ startBrowsing }}' disabled?='{{ !ui.browserApi.canProxy }}'>
-            {{ "START_GETTING" | $$ }}
+            <span hidden?='{{ ui.browserApi.supportsVpn }}'>
+              {{ "START_GETTING" | $$ }}
+            </span>
+            <span hidden?='{{ !ui.browserApi.supportsVpn }}'>
+              <!-- TODO(alalama): localize -->
+              Start browsing
+            </span>
           </uproxy-button>
-        </div>
 
-        <!-- Browsing mode -->
-        <div hidden?='{{ !ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
-          <uproxy-button raised on-tap='{{ startBrowsing }}' disabled?='{{ !ui.browserApi.canProxy  }}'>
-            <!-- TODO(alalama): localize -->
-            Start browsing
-          </uproxy-button>
-        </div>
-
-        <!-- VPN mode -->
-        <div hidden?='{{ !ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
-          <uproxy-button raised on-tap='{{ startVpn }}' disabled?='{{ !ui.browserApi.canProxy }}'>
+          <!-- VPN mode -->
+          <uproxy-button raised on-tap='{{ startVpn }}' hidden?='{{ !ui.browserApi.supportsVpn }}' disabled?='{{ !ui.browserApi.canProxy }}'>
             <!-- TODO(alalama): localize -->
             Start VPN
           </uproxy-button>

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -104,14 +104,12 @@
               {{ "START_GETTING" | $$ }}
             </span>
             <span hidden?='{{ !ui.browserApi.supportsVpn }}'>
-              <!-- TODO(alalama): localize -->
               {{ "START_BROWSING" | $$ }}
             </span>
           </uproxy-button>
 
           <!-- VPN mode -->
           <uproxy-button raised on-tap='{{ startVpn }}' hidden?='{{ !ui.browserApi.supportsVpn }}' disabled?='{{ !ui.browserApi.canProxy }}'>
-            <!-- TODO(alalama): localize -->
             {{ "START_VPN" | $$ }}
           </uproxy-button>
         </div>

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -105,14 +105,14 @@
             </span>
             <span hidden?='{{ !ui.browserApi.supportsVpn }}'>
               <!-- TODO(alalama): localize -->
-              Start browsing
+              {{ "START_BROWSING" | $$ }}
             </span>
           </uproxy-button>
 
           <!-- VPN mode -->
           <uproxy-button raised on-tap='{{ startVpn }}' hidden?='{{ !ui.browserApi.supportsVpn }}' disabled?='{{ !ui.browserApi.canProxy }}'>
             <!-- TODO(alalama): localize -->
-            Start VPN
+            {{ "START_VPN" | $$ }}
           </uproxy-button>
         </div>
 

--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -97,9 +97,16 @@
          user.offeringInstances and are therefore giving us access -->
       <div class="button-wrapper">
         <!-- not getting or trying to get access -->
-        <div hidden?='{{ instance.localGettingFromRemote != GettingState.NONE }}'>
+        <div hidden?='{{ ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
+          <uproxy-button raised on-tap='{{ startBrowsing }}' disabled?='{{ !ui.browserApi.canProxy }}'>
+            {{ "START_GETTING" | $$ }}
+          </uproxy-button>
+        </div>
+
+        <!-- Browsing mode -->
+        <div hidden?='{{ !ui.browserApi.supportsVpn || instance.localGettingFromRemote != GettingState.NONE }}'>
           <uproxy-button raised on-tap='{{ startBrowsing }}' disabled?='{{ !ui.browserApi.canProxy  }}'>
-            <!-- TODO(alalama): localize {{ "START_GETTING" | $$ }} -->
+            <!-- TODO(alalama): localize -->
             Start browsing
           </uproxy-button>
         </div>

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -7,6 +7,7 @@ import net = require('../../lib/net/net.types');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 import translator = require('../scripts/translator');
 import user_interface = require('../scripts/ui');
+import browser_api = require('../../interfaces/browser_api');
 
 // generic_ui/scripts/ui.ts: UserInterface
 var ui = ui_context.ui;
@@ -36,7 +37,7 @@ Polymer({
       model.globalSettings.enabledExperiments.indexOf(
         uproxy_core_api.FEATURE_VERIFY) >= 0;
   },
-  start: function() {
+  start_: function(accessMode: browser_api.ProxyAccessMode) {
     if (!this.instance.isOnline) {
       this.fire('core-signal', {
         name: 'show-toast',
@@ -49,9 +50,10 @@ Polymer({
     }
 
     this.sas = null;
-    ui.startGettingFromInstance(this.instance.instanceId).catch((e: Error) => {
-      console.error('could not get access: ' + e.message);
-    });
+    ui.startGettingFromInstance(this.instance.instanceId, accessMode)
+      .catch((e: Error) => {
+        console.error('could not get access: ' + e.message);
+      });
   },
   stop: function() {
     if (this.instance.localGettingFromRemote ==
@@ -61,6 +63,12 @@ Polymer({
       ui.stopUsingProxy();
     }
     ui.stopGettingFromInstance(this.instance.instanceId);
+  },
+  startBrowsing: function() {
+    this.start_(browser_api.ProxyAccessMode.IN_APP);
+  },
+  startVpn: function() {
+    this.start_(browser_api.ProxyAccessMode.VPN);
   },
   fireChanged: function() {
     this.fire('instance-changed');

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -291,7 +291,8 @@ describe('UI.UserInterface', () => {
       // if the core.start promise fulfills. (see polymer/instance.ts)
       syncUserAndInstance('userId', 'userName', 'testInstanceId');
       ui.startGettingInUiAndConfig(
-          'testInstanceId', { address : 'testAddress' , port : 0 });
+          'testInstanceId', { address : 'testAddress' , port : 0 },
+          browser_api.ProxyAccessMode.IN_APP);
       expect(mockBrowserApi.setIcon)
           .toHaveBeenCalledWith(Constants.GETTING_ICON);
       ui.stoppedGetting({instanceId: null, error: false});
@@ -300,7 +301,8 @@ describe('UI.UserInterface', () => {
     it('Extension icon changes when you stop getting access', () => {
       syncUserAndInstance('userId', 'userName', 'testGiverId');
       ui.startGettingInUiAndConfig(
-          'testGiverId', { address : 'testAddress' , port : 0 });
+          'testGiverId', { address : 'testAddress' , port : 0 },
+          browser_api.ProxyAccessMode.IN_APP);
       ui['instanceGettingAccessFrom_'] = 'testGiverId';
       expect(mockBrowserApi.setIcon)
           .toHaveBeenCalledWith(Constants.GETTING_ICON);

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -756,7 +756,7 @@ export class UserInterface implements ui_constants.UiApi {
     }
 
     if (!accessMode || accessMode === ProxyAccessMode.NONE) {
-      console.log('Cannot start using proxy: unknown proxy acccess mode.');
+      console.error('Cannot start using proxy: unknown proxy acccess mode.');
       return;
     }
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -756,7 +756,7 @@ export class UserInterface implements ui_constants.UiApi {
     }
 
     if (!accessMode || accessMode === ProxyAccessMode.NONE) {
-      console.log("Cannot start using proxy: unknown proxy acccess mode.");
+      console.log('Cannot start using proxy: unknown proxy acccess mode.');
       return;
     }
 

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -7,7 +7,8 @@ import net = require('../lib/net/net.types');
 
 export interface BrowserAPI {
   // Configuration and control of the browsers proxy settings.
-  startUsingProxy(endpoint:net.Endpoint, bypass :string[]) :void;
+  startUsingProxy(
+    endpoint: net.Endpoint, bypass: string[], opts: ProxyConnectOptions): void;
   stopUsingProxy() :void;
   // Set the browser icon for the extension/add-on.
   setIcon(iconFile :string) :void;
@@ -23,6 +24,8 @@ export interface BrowserAPI {
   canProxy :boolean;
   // Whether user has installed and logged into uProxy.
   hasInstalledThenLoggedIn :boolean;
+  // Whether platform supports VPN mode.
+  supportsVpn: boolean;
 
   /*
    * tag is used to uniquely identify notifications.  If it is a json-encoded
@@ -52,6 +55,19 @@ export interface BrowserAPI {
   // passed, a message will be supplied instead, which will be emitted with
   // the given response data.
   respond(data :any, callback ?:Function, msg ?:string) :void;
+}
+
+// Describes the user-initiated mode to access a proxy.
+export enum ProxyAccessMode {
+  NONE = 100,
+  IN_APP,
+  VPN
+};
+
+// User options for connecting to a proxy.
+// Packaged as an interface for forward-compatibility.
+export interface ProxyConnectOptions {
+  accessMode: ProxyAccessMode;
 }
 
 // Info associated with the 'proxyDisconnect' event.

--- a/third_party/typings/cordova/device.d.ts
+++ b/third_party/typings/cordova/device.d.ts
@@ -1,0 +1,16 @@
+
+// Interface definition for cordova-plugin-device
+interface Device {
+  cordova: string;
+  model: string;
+  platform: string;
+  uuid: string;
+  version: string;
+  manufacturer: string;
+  isVirtual: boolean;
+  serial: string;
+}
+
+interface Window {
+  device: Device;
+}

--- a/third_party/typings/cordova/tun2socks.d.ts
+++ b/third_party/typings/cordova/tun2socks.d.ts
@@ -1,0 +1,11 @@
+
+// Interface definition for cordova-plugin-tun2socks
+interface Tun2Socks {
+  start(socksServerAddress:string) : Promise<string>;
+  stop(): Promise<string>;
+  onDisconnect(): Promise<string>;
+}
+
+interface Window {
+  tun2socks: Tun2Socks;
+}


### PR DESCRIPTION
This PR adds VPN support for Android.

* Added two Cordova plugins: 
  * tun2socks: intercepts all device traffic through VPN and forwards it to uProxy's SOCKS local server. 
  * device: provides software/hardware information about the device.
* UI changes:
  * Show a 'Start VPN' button for Android VPN-enabled devices.
  * User can select whether to start browsing in-app or whole device VPN.
* TODOs
  * Localize button strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2535)
<!-- Reviewable:end -->
