### PR TITLE
Managed Chrome Policy Schema

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -358,6 +358,7 @@ gruntConfig = {
           cwd: chromeAppDevPath
           src: [
             'manifest.json'
+            'managed_policy_schema.json'
             '_locales/**'
 
             # UI for not-connected

--- a/src/chrome/app/managed_policy_schema.json
+++ b/src/chrome/app/managed_policy_schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "validProxyServers": {
+      "description": "An object mapping proxy server IP addresses to their corresponding public key in order to fingerprint before connecting.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "enforceProxyServerValidity": {
+      "description": "Control whether the app/extension checks the proxy server's public key fingerprint before connecting.",
+      "type": "boolean"
+    }
+  }
+}

--- a/src/chrome/app/manifest.json
+++ b/src/chrome/app/manifest.json
@@ -17,6 +17,9 @@
     "storage",
     "<all_urls>"
   ],
+  "storage": {
+    "managed_schema": "managed_policy_schema.json"
+  },
   "sockets": {
     "tcp": {
       "connect": ""


### PR DESCRIPTION
Got the policy schema working and tested now. This builds locally so there *shouldn't* be any issues (crosses fingers).

To test this, I did the following:

1. Made changes to manifest, managed policy schema, and grunt coffee script.
2. grunt build from local (no errors encountered).
3. Created development app and extension in Chrome web store.
4. Updated externally connectable id and key in the manifest for app and extension (the built ones under build/dev/uproxy/chrome) to match the new development web store entries.
5. Uploaded zipped app and extension folders to web store.
6. On admin console configured the app and extension to be force installed.
7. Added configured policy to the app entry.
8. Waited an hour for web store to finish publishing (they claim this could take up to 60 minutes, and it is typically much shorter than this).
9. Open up a domain enrolled Chromebook.
10. See the development app and extension got pushed down from admin console.
11. Go to chrome://policy to view policies.
12. See that the app has received the enforceProxyServerValidity and validProxyServers policies correctly and hasn't been blocked by schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2537)
<!-- Reviewable:end -->
