### PR TITLE
initialize language setting based on browser settings

### DIFF
--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -49,7 +49,7 @@ export var settings :uproxy_core_api.GlobalSettings = {
   splashState: 0,
   statsReportingEnabled: false,
   consoleFilter: loggingprovider.Level.warn,
-  language: 'en',
+  language: null,  // sentinel indicating lang should be calculated from browser settings
   force_message_version: 0, // zero means "don't override"
   quiverUserName: '',
   showCloud: false,

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -2,6 +2,7 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='../../../../third_party/typings/browser.d.ts' />
 
+import _ = require('lodash');
 import social = require('../../interfaces/social');
 import translator = require('../scripts/translator');
 import ui_types = require('../../interfaces/ui');
@@ -148,7 +149,7 @@ Polymer({
       var browserCustomElement = document.createElement(ui.browserApi.browserSpecificElement);
       this.$.browserElementContainer.appendChild(browserCustomElement);
     }
-    this.updateDirectionality();
+    this.setDirectionality();
   },
   tabSelected: function(e :Event) {
     if (this.ui.isSharingDisabled &&
@@ -219,15 +220,15 @@ Polymer({
       this.isSharingEnabledWithOthers = trustedContacts.length > 0;
     }
   },
-  updateDirectionality: function() {
-    // Update the directionality of the UI.
-    for (var i = 0; i < RTL_LANGUAGES.length; i++) {
-      if (RTL_LANGUAGES[i] == model.globalSettings.language.substring(0,2)) {
-        this.dir = 'rtl';
-        return;
-      }
+  /*
+   * Set our `dir` value to 'ltr' or 'rtl' based on current language.
+   */
+  setDirectionality: function() {
+    if (_.includes(RTL_LANGUAGES, model.globalSettings.language)) {
+      this.dir = 'rtl';
+    } else {
+      this.dir = 'ltr';
     }
-    this.dir = 'ltr';
   },
   languageChanged: function(oldLanguage :string, newLanguage :string) {
     if (oldLanguage && oldLanguage !== newLanguage) {

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -63,7 +63,7 @@ export class Model {
     allowNonUnicast: false,
     statsReportingEnabled: false,
     consoleFilter: 0,
-    language: 'en',
+    language: null,  // sentinel indicating lang should be calculated from browser settings
     force_message_version: 0,
     quiverUserName: '',
     showCloud: false,

--- a/src/generic_ui/scripts/translator.ts
+++ b/src/generic_ui/scripts/translator.ts
@@ -59,3 +59,5 @@ export const i18n_t = (placeholder :string, params ?:any): string => {
 };
 
 export const i18n_setLng = i18next.setLng;
+
+export const i18n_languagesAvailable :string[] = Object.keys(window.i18nResources);


### PR DESCRIPTION
Suppose your browser language settings are set as follows:

![screen shot 2016-07-08 at 16 22 14](https://cloud.githubusercontent.com/assets/64992/16700463/2f4e1b62-4528-11e6-9474-8519df526641.png)

i.e. Your first preferences is for Farsi, your second is for US English, and your last preference is for any kind of English.

This results in `navigator.languages` in your browser's javascript environment getting set to:
```javascript
["fa", "en-US", "en"]
```

With this change, rather than always initializing the user's language setting to `"en"`, we now initialize it to the first language in `navigator.languages` which we have available, falling back to `"en"` if none match.

Fixes #1693.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2539)
<!-- Reviewable:end -->
