### PR TITLE
Remove hidden attribute from wrapper div in instance

### DIFF
--- a/src/generic_ui/polymer/instance.html
+++ b/src/generic_ui/polymer/instance.html
@@ -54,8 +54,7 @@
     }
     </style>
 
-    <div id='wrapper' class='{{ instance.isOnline ? "online" : "offline" }}'
-         hidden?='{{model.globalSettings.mode!=ui_constants.Mode.GET}}'>
+    <div id='wrapper' class='{{ instance.isOnline ? "online" : "offline" }}'>
       <p id='description' hidden?='{{ !instance.description }}'>
         <bdi style='display:inline'>{{ instance.description }}</bdi>
         <span class='verified'

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -26,7 +26,6 @@ Polymer({
     this.ui = ui;
     this.ui_constants = ui_constants;
     this.GettingState = social.GettingState;
-    this.model = model;
     this.sas = null;
     // Whether this is the side that started verification.  The sides
     // of the verification show different UIs.


### PR DESCRIPTION
The wrapper div in instance.html had a hidden field that was redundant
with one in contact.html, this probably won't have a noticable effect,
but would potentially speed things up if a user had a lot of instances
visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2554)
<!-- Reviewable:end -->
