### PR TITLE
Remove the concept of an experimental networks

### DIFF
--- a/src/generic/network-options.ts
+++ b/src/generic/network-options.ts
@@ -34,7 +34,6 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     enableMonitoring: false,
     areAllContactsUproxy: false,
     supportsReconnect: false,
-    isExperimental: true
   },
   'GitHub': {
     metricsName: 'github',
@@ -43,7 +42,6 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     enableMonitoring: false,
     areAllContactsUproxy: true,
     supportsReconnect: false,
-    isExperimental: true
   },
   'Quiver': {
     displayName: 'uProxy',
@@ -53,7 +51,6 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     enableMonitoring: true,
     areAllContactsUproxy: true,
     supportsReconnect: true,
-    isExperimental: true,
     isEncrypted: true
   },
   'Cloud': {
@@ -63,6 +60,5 @@ export var NETWORK_OPTIONS :{[name:string]:social.NetworkOptions} = {
     enableMonitoring: false,
     areAllContactsUproxy: true,
     supportsReconnect: false,
-    isExperimental: true
   }
 };

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -219,11 +219,6 @@
               <div on-tap='{{networkTapped }}' class='networkLoginButton' data-network='{{n}}'>
                 <core-icon icon='uproxy-icons:{{n}}'></core-icon>
                 <div class='networkName'>{{getNetworkDisplayName(n)}}</div>
-                <!--
-                <span class='experimental paleText' hidden?='{{!isExperimentalNetwork(n)}}'>
-                  (Experimental)
-                </span>
-                -->
                 <div class='chevronWrapper'>
                   <core-icon icon="chevron-right"></core-icon>
                 </div>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -99,9 +99,6 @@ var inviteUser = {
     }
     return ui.getNetworkDisplayName(networkName);
   },
-  isExperimentalNetwork: function(networkName :string) {
-    return ui.isExperimentalNetwork(networkName);
-  },
   closeLoginDialog: function() {
     this.$.loginToInviteFriendDialog.close();
   },
@@ -118,7 +115,6 @@ var inviteUser = {
   },
   ready: function() {
     this.selectedNetworkName = '';
-    this.ui = ui;
     this.model = ui_context.model;
     this.inviteCode = '';
   }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1142,10 +1142,6 @@ export class UserInterface implements ui_constants.UiApi {
     return this.getProperty_<boolean>(networkName, 'supportsReconnect') || false;
   }
 
-  public isExperimentalNetwork = (networkName :string) : boolean => {
-    return this.getProperty_<boolean>(networkName, 'isExperimental') || false;
-  }
-
   private getProperty_ = <T>(networkName :string, propertyName :string) : T => {
     if (NETWORK_OPTIONS[networkName]) {
       return (<any>(NETWORK_OPTIONS[networkName]))[propertyName];

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -125,7 +125,6 @@ export interface NetworkOptions {
   supportsReconnect :boolean;
   displayName ?:string;  // Network name to be displayed in the UI.
   metricsName ?:string;  // Name to use for metrics
-  isExperimental ?:boolean;
   isEncrypted ?:boolean;
   rosterFunction ?:(rosterNames:string[])=>number;
 }


### PR DESCRIPTION
We haven't really cared about experimental networks for a while, this
just finishes removing the leftover mentions of them in our code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2555)
<!-- Reviewable:end -->
