### PR TITLE
Remove splashState from global settings

### DIFF
--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -46,7 +46,6 @@ export var settings :uproxy_core_api.GlobalSettings = {
   allowNonUnicast: false,
   mode: user_interface.Mode.GET,
   version: STORAGE_VERSION,
-  splashState: 0,
   statsReportingEnabled: false,
   consoleFilter: loggingprovider.Level.warn,
   language: 'en',

--- a/src/generic_ui/polymer/splash.html
+++ b/src/generic_ui/polymer/splash.html
@@ -114,11 +114,11 @@
     </style>
 
     <div horizontal layout>
-      <core-icon icon='arrow-back' on-tap='{{prev}}' class='prevArrow'
-          hidden?='{{SPLASH_STATES.INTRO==model.globalSettings.splashState}}'></core-icon>
+      <core-icon icon='arrow-back' on-tap='{{backToIntro}}' class='prevArrow'
+          hidden?='{{SPLASH_STATES.INTRO==state}}'></core-icon>
     </div>
 
-    <div vertical layout id='intro1' hidden?='{{SPLASH_STATES.INTRO!==model.globalSettings.splashState}}'>
+    <div vertical layout id='intro1' hidden?='{{SPLASH_STATES.INTRO!==state}}'>
       <div class='view' flex>
         <core-icon id='logo' icon="uproxy-logo:logo"></core-icon>
         <h1 class='uproxyTitle'><span class='first-u'>u</span>Proxy</h1>
@@ -142,7 +142,7 @@
         </div> <!-- end of #languageLink -->
 
         <div id='nextWrapper'>
-          <uproxy-button raised on-tap='{{next}}'>{{ "NEXT" | $$ }}</uproxy-button>
+          <uproxy-button raised on-tap='{{goToStats}}'>{{ "NEXT" | $$ }}</uproxy-button>
         </div>
 
       </div> <!-- end of .view -->
@@ -155,7 +155,7 @@
 
     </div> <!-- end of #intro1 -->
 
-    <div vertical layout id="metricsOptIn" hidden?='{{SPLASH_STATES.METRICS_OPT_IN!==model.globalSettings.splashState}}'>
+    <div vertical layout id="metricsOptIn" hidden?='{{SPLASH_STATES.METRICS_OPT_IN!==state}}'>
       <div class="view" flex>
         <h1>{{ "WELCOME" | $$ }}</h1>
         <p>

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -21,28 +21,17 @@ var ui = ui_context.ui;
 var core = ui_context.core;
 var model = ui_context.model;
 
-var splash = {
+Polymer({
+  state: 0,
   SPLASH_STATES: {
     INTRO: 0,
     METRICS_OPT_IN: 1
   },
-  setState: function(state :Number) {
-    if (state < 0 || state > Object.keys(this.SPLASH_STATES).length) {
-      console.error('Invalid call to setState: ' + state);
-      return;
-    }
-    model.globalSettings.splashState = state;
-    core.updateGlobalSettings(model.globalSettings);
+  backToIntro: function() {
+    this.state = this.SPLASH_STATES.INTRO;
   },
-  next: function() {
-    if (model.globalSettings.splashState == this.SPLASH_STATES.METRICS_OPT_IN) {
-      ui.view = ui_constants.View.ROSTER;
-    } else {
-      this.setState(model.globalSettings.splashState + 1);
-    }
-  },
-  prev: function() {
-    this.setState(model.globalSettings.splashState - 1);
+  goToStats: function() {
+    this.state = this.SPLASH_STATES.METRICS_OPT_IN;
   },
   updateLanguage: function(event :Event, detail :any, sender :HTMLElement) {
     if (detail.isSelected) {
@@ -54,17 +43,17 @@ var splash = {
       }
     }
   },
-  updateSeenMetrics: function(val :Boolean) {
+  updateMetricsCollection: function(val :Boolean) {
     model.globalSettings.hasSeenMetrics = true;
     model.globalSettings.statsReportingEnabled = val;
     core.updateGlobalSettings(model.globalSettings);
-    this.next();
+    ui.view = ui_constants.View.ROSTER;
   },
   enableStats: function() {
-    return this.updateSeenMetrics(true);
+    return this.updateMetricsCollection(true);
   },
   disableStats: function() {
-    return this.updateSeenMetrics(false);
+    return this.updateMetricsCollection(false);
   },
   ready: function() {
     this.model = model;
@@ -77,6 +66,4 @@ var splash = {
       }
     }
   },
-};
-
-Polymer(splash);
+});

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -58,7 +58,6 @@ export class Model {
     hasSeenSharingEnabledScreen: false,
     hasSeenWelcome: false,
     hasSeenMetrics: false,
-    splashState : 0,
     mode : ui_constants.Mode.GET,
     allowNonUnicast: false,
     statsReportingEnabled: false,

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -40,7 +40,6 @@ export interface GlobalSettings {
   allowNonUnicast  :boolean;
   mode             :ui.Mode;
   statsReportingEnabled :boolean;
-  splashState : number;
   consoleFilter    :loggingTypes.Level;
   language         :string;
   force_message_version :number;


### PR DESCRIPTION
The only reason we would want to keep splashState in globalSettings is
to ensure that if the user closes uproxy while on the metrics screen,
they are taken back to the metrics screen instead of the screen before
it.  That takes a lot of overhead to do, so this change removes that
functionality.

This does theoretically break backwards-compatibility between the app
and the extension, however, since splashState would be in storage for
anyone who had just upgraded the app, that's even more unlikely than
usual to come up.

This is in support of #2556 and indirectly #1900 (Polymer 1.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2557)
<!-- Reviewable:end -->
