### PR TITLE
Remove global data dependencies from roster.*

### DIFF
--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -110,13 +110,13 @@
     }
     </style>
 
-    <div id="empty-roster-instructions-container" hidden?="{{ loadingContacts || hasContacts }}">
+    <div id="empty-roster-instructions-container" hidden?="{{ hasContacts }}">
       <div id="empty-roster-instructions">
         <img src='../../icons/emptylist.svg'>
         <h1>{{ "EMPTY_ROSTER_INSTRUCTIONS" | $$ }}</h1>
       </div>
     </div>
-    <div class='downArrow' hidden?="{{ loadingContacts || hasContacts }}">▼</div>
+    <div class='downArrow' hidden?="{{ hasContacts }}">▼</div>
 
     <div hidden?='{{ !hasContacts }}'>
       <!-- Intentionally hiding search box. May decide to readd it later. -->
@@ -124,7 +124,7 @@
 
       <!-- uProxy contacts offering access to or requesting access from user -->
       <uproxy-roster-group
-          groupTitle='{{ (model.globalSettings.mode==ui_constants.Mode.GET ? "OFFERS" : "REQUESTS") | $$ }}'
+          groupTitle='{{ (mode == ui_constants.Mode.GET ? "OFFERS" : "REQUESTS") | $$ }}'
           contacts='{{ contacts.pending }}'
           searchQuery='{{ searchQuery }}'
           mode='{{ mode }}'></uproxy-roster-group>
@@ -135,7 +135,7 @@
 
       <!-- trusted uProxy contacts -->
       <uproxy-roster-group
-          groupTitle='{{ (model.globalSettings.mode==ui_constants.Mode.GET ? "FRIENDS_WHO_SHARE" : "FRIENDS_WHO_CAN_GET") | $$ }}'
+          groupTitle='{{ (mode == ui_constants.Mode.GET ? "FRIENDS_WHO_SHARE" : "FRIENDS_WHO_CAN_GET") | $$ }}'
           contacts='{{ contacts.trustedUproxy }}'
           searchQuery='{{ searchQuery }}'
           mode='{{ mode }}'></uproxy-roster-group>

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -4,18 +4,11 @@
 import ui_constants = require('../../interfaces/ui');
 
 Polymer({
-  loadingContacts: false,
   searchQuery: '',
   ready: function() {
-    console.log('initializing roster');
-
-    this.ui = ui_context.ui;
     this.ui_constants = ui_constants;
-    this.model = ui_context.model;
   },
   computed: {
-    'hasGetContacts': '(model.contacts.getAccessContacts.pending.length + model.contacts.getAccessContacts.trustedUproxy.length + model.contacts.getAccessContacts.untrustedUproxy.length) > 0',
-    'hasShareContacts': '(model.contacts.shareAccessContacts.pending.length + model.contacts.shareAccessContacts.trustedUproxy.length + model.contacts.shareAccessContacts.untrustedUproxy.length) > 0',
-    'hasContacts': '(mode==ui_constants.Mode.GET && hasGetContacts) || (mode==ui_constants.Mode.SHARE && hasShareContacts)'
+    'hasContacts': '(contacts.pending.length + contacts.trustedUproxy.length + contacts.untrustedUproxy.length) > 0'
   },
 });


### PR DESCRIPTION
This remose the dependencies on data from ui and model in roster.html
and roster.ts.

In roster.html, we are able to remove the dependency on
model.globalSettings.mode by instead looking at the mode attribute given
to the element (which mode it is for).  We can do this because it's fine
for the get roster list to be displaying "OFFERS" even when it's hidden.

In roster.ts, we can remove the dependencies on looking at the contacts
by instead just looking at the contacts specifically passed into this
roster object.

This also removes the (now unused) loadingContacts variable.

This is in support of #2556 and indirectly #1900 (Polymer 1.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2558)
<!-- Reviewable:end -->
