### PR TITLE
Completely remove support for roster search queries

### DIFF
--- a/src/generic_ui/polymer/roster-group.html
+++ b/src/generic_ui/polymer/roster-group.html
@@ -2,7 +2,7 @@
 <link rel='import' href='contact.html'>
 
 <polymer-element name='uproxy-roster-group'
-    attributes='contacts, groupTitle, searchQuery, mode'>
+    attributes='contacts, groupTitle, mode'>
 
   <template>
     <style>
@@ -24,7 +24,6 @@
 
     <template repeat='{{ c in sortedContacts }}' vertical layout>
       <uproxy-contact contact='{{ c }}'
-          hidden?='{{ hideForSearch(c.name, searchQuery) }}'
           isOnline='{{ c.isOnline }}'
           on-contact-changed='{{ contactsChanged }}'
           mode='{{ mode }}'>

--- a/src/generic_ui/polymer/roster-group.ts
+++ b/src/generic_ui/polymer/roster-group.ts
@@ -10,12 +10,6 @@ var model = ui_context.model;
 
 Polymer({
   sortedContacts: [],
-  hideForSearch: function(name :string, query :string) {
-    if (query.length === 0) {
-      return false;
-    }
-    return name.toLowerCase().indexOf(query.toLowerCase()) === -1;
-  },
   created: function() {
     // this gets expensive, especially during initialization, if we are calling
     // it on every event, so throttle it

--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -119,14 +119,11 @@
     <div class='downArrow' hidden?="{{ hasContacts }}">▼</div>
 
     <div hidden?='{{ !hasContacts }}'>
-      <!-- Intentionally hiding search box. May decide to readd it later. -->
-      <input type='text' id='search' placeholder='Search' value='{{ searchQuery }}' hidden></input>
 
       <!-- uProxy contacts offering access to or requesting access from user -->
       <uproxy-roster-group
           groupTitle='{{ (mode == ui_constants.Mode.GET ? "OFFERS" : "REQUESTS") | $$ }}'
           contacts='{{ contacts.pending }}'
-          searchQuery='{{ searchQuery }}'
           mode='{{ mode }}'></uproxy-roster-group>
 
       <!-- Hide HR above Trusted if there are no Trusted contacts, or if there are no Pending contacts -->
@@ -137,7 +134,6 @@
       <uproxy-roster-group
           groupTitle='{{ (mode == ui_constants.Mode.GET ? "FRIENDS_WHO_SHARE" : "FRIENDS_WHO_CAN_GET") | $$ }}'
           contacts='{{ contacts.trustedUproxy }}'
-          searchQuery='{{ searchQuery }}'
           mode='{{ mode }}'></uproxy-roster-group>
 
       <!-- Hide HR above Untrusted if there are no Untrusted contacts, or if there are no Trusted & Pending contacts -->
@@ -148,7 +144,6 @@
       <uproxy-roster-group
           groupTitle='{{ "UPROXY_FRIENDS" | $$ }}'
           contacts='{{ contacts.untrustedUproxy }}'
-          searchQuery='{{ searchQuery }}'
           mode='{{ mode }}'></uproxy-roster-group>
     </div>
 

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -4,7 +4,6 @@
 import ui_constants = require('../../interfaces/ui');
 
 Polymer({
-  searchQuery: '',
   ready: function() {
     this.ui_constants = ui_constants;
   },


### PR DESCRIPTION
This has been pseudo-removed for a while, I'd like to just kill it while
we're here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2559)
<!-- Reviewable:end -->
