### PR TITLE
Remove contact.html dependency on global mode

### DIFF
--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -142,24 +142,24 @@
         <div horizontal layout class='nameLine' on-tap='{{ toggle }}'>
           <div flex class='name'><bdi>{{ contact.name }}</bdi></div>
           <core-icon icon="open-in-new"
-              hidden?="{{ !contact.url || (mode==ui_constants.Mode.GET && !contact.getExpanded) || (mode==ui_constants.Mode.SHARE && !contact.shareExpanded) }}"
+              hidden?="{{ !contact.url || (isGetter && !contact.getExpanded) || (isSharer && !contact.shareExpanded) }}"
               title="{{ contact.url }}" on-tap="{{ openLink }}"></core-icon>
 
           <core-icon icon="delete" hidden?='{{ contact.network.name !== "Cloud" }}' title="{{ contact.url }}" on-tap="{{ removeCloudFriend }}"></core-icon>
 
           <!-- TODO: Simplify show/hide logic of getting/sharing/expand/collapse icons. E.g. Angular allowed if/else-like logic to select what is displayed. -->
           <img src='../icons/getting_animated.gif' class='accessIcon'
-              hidden?='{{ mode!=ui_constants.Mode.GET || !contact.isSharingWithMe }}'>
+              hidden?='{{ isSharer || !contact.isSharingWithMe }}'>
           <img src='../icons/sharing_animated.gif' class='accessIcon'
-              hidden?='{{ mode!=ui_constants.Mode.SHARE || !contact.isGettingFromMe }}'>
+              hidden?='{{ isGetter || !contact.isGettingFromMe }}'>
           <!-- If you are sharing with or getting from a contact, the glowing sharing/getting icon will replace the expand/collapse chevron. -->
           <!-- Show expand chevron in only two cases: when contact is collapsed in GET mode and you're not getting from them OR when contact is collapsed in SHARE mode and you're not sharing with them. -->
           <core-icon icon="expand-more" class="expand"
-            hidden?='{{ (!(mode==ui_constants.Mode.GET && !contact.getExpanded && !contact.isSharingWithMe) && !(mode==ui_constants.Mode.SHARE && !contact.shareExpanded && !contact.isGettingFromMe)) || contact.status == UserStatus.REMOTE_INVITED_BY_LOCAL }}'>
+            hidden?='{{ (!(isGetter && !contact.getExpanded && !contact.isSharingWithMe) && !(isSharer && !contact.shareExpanded && !contact.isGettingFromMe)) || contact.status == UserStatus.REMOTE_INVITED_BY_LOCAL }}'>
           </core-icon>
           <!-- Show collapse chevron in only two cases: when contact is expanded in GET mode and you're not getting from them OR when contact is expanded in SHARE mode and you're not sharing with them. -->
           <core-icon icon="expand-less" class="expand"
-            hidden?='{{ !(mode==ui_constants.Mode.GET && contact.getExpanded && !contact.isSharingWithMe) && !(mode==ui_constants.Mode.SHARE && contact.shareExpanded && !contact.isGettingFromMe) }}'>
+            hidden?='{{ !(isGetter && contact.getExpanded && !contact.isSharingWithMe) && !(isSharer && contact.shareExpanded && !contact.isGettingFromMe) }}'>
           </core-icon>
         </div>
 
@@ -172,7 +172,7 @@
 
         <!-- beginning of getControls -->
         <core-collapse id='getControls' class='expandedControls'
-          hidden?='{{mode!=ui_constants.Mode.GET}}'
+          hidden?='{{isSharer}}'
           opened='{{ contact.getExpanded }}'>
 
           <div class='friendControls' hidden?='{{contact.status==UserStatus.LOCAL_INVITED_BY_REMOTE || contact.status==UserStatus.REMOTE_INVITED_BY_LOCAL}}'>
@@ -233,7 +233,7 @@
 
         <!-- beginning of shareControls -->
         <core-collapse id='shareControls' class='expandedControls'
-          hidden?='{{mode!=ui_constants.Mode.SHARE}}'
+          hidden?='{{isGetter}}'
           opened='{{ contact.shareExpanded }}'>
 
           <div class='friendControls' hidden?='{{contact.status!=UserStatus.FRIEND}}'>

--- a/src/generic_ui/polymer/contact.html
+++ b/src/generic_ui/polymer/contact.html
@@ -142,16 +142,16 @@
         <div horizontal layout class='nameLine' on-tap='{{ toggle }}'>
           <div flex class='name'><bdi>{{ contact.name }}</bdi></div>
           <core-icon icon="open-in-new"
-              hidden?="{{ !contact.url || (model.globalSettings.mode==ui_constants.Mode.GET && !contact.getExpanded) || (model.globalSettings.mode==ui_constants.Mode.SHARE && !contact.shareExpanded) }}"
+              hidden?="{{ !contact.url || (mode==ui_constants.Mode.GET && !contact.getExpanded) || (mode==ui_constants.Mode.SHARE && !contact.shareExpanded) }}"
               title="{{ contact.url }}" on-tap="{{ openLink }}"></core-icon>
 
           <core-icon icon="delete" hidden?='{{ contact.network.name !== "Cloud" }}' title="{{ contact.url }}" on-tap="{{ removeCloudFriend }}"></core-icon>
 
           <!-- TODO: Simplify show/hide logic of getting/sharing/expand/collapse icons. E.g. Angular allowed if/else-like logic to select what is displayed. -->
           <img src='../icons/getting_animated.gif' class='accessIcon'
-              hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.GET || !contact.isSharingWithMe }}'>
+              hidden?='{{ mode!=ui_constants.Mode.GET || !contact.isSharingWithMe }}'>
           <img src='../icons/sharing_animated.gif' class='accessIcon'
-              hidden?='{{ model.globalSettings.mode!=ui_constants.Mode.SHARE || !contact.isGettingFromMe }}'>
+              hidden?='{{ mode!=ui_constants.Mode.SHARE || !contact.isGettingFromMe }}'>
           <!-- If you are sharing with or getting from a contact, the glowing sharing/getting icon will replace the expand/collapse chevron. -->
           <!-- Show expand chevron in only two cases: when contact is collapsed in GET mode and you're not getting from them OR when contact is collapsed in SHARE mode and you're not sharing with them. -->
           <core-icon icon="expand-more" class="expand"
@@ -159,7 +159,7 @@
           </core-icon>
           <!-- Show collapse chevron in only two cases: when contact is expanded in GET mode and you're not getting from them OR when contact is expanded in SHARE mode and you're not sharing with them. -->
           <core-icon icon="expand-less" class="expand"
-            hidden?='{{ !(model.globalSettings.mode==ui_constants.Mode.GET && contact.getExpanded && !contact.isSharingWithMe) && !(model.globalSettings.mode==ui_constants.Mode.SHARE && contact.shareExpanded && !contact.isGettingFromMe) }}'>
+            hidden?='{{ !(mode==ui_constants.Mode.GET && contact.getExpanded && !contact.isSharingWithMe) && !(mode==ui_constants.Mode.SHARE && contact.shareExpanded && !contact.isGettingFromMe) }}'>
           </core-icon>
         </div>
 
@@ -172,7 +172,7 @@
 
         <!-- beginning of getControls -->
         <core-collapse id='getControls' class='expandedControls'
-          hidden?='{{model.globalSettings.mode!=ui_constants.Mode.GET}}'
+          hidden?='{{mode!=ui_constants.Mode.GET}}'
           opened='{{ contact.getExpanded }}'>
 
           <div class='friendControls' hidden?='{{contact.status==UserStatus.LOCAL_INVITED_BY_REMOTE || contact.status==UserStatus.REMOTE_INVITED_BY_LOCAL}}'>
@@ -233,7 +233,7 @@
 
         <!-- beginning of shareControls -->
         <core-collapse id='shareControls' class='expandedControls'
-          hidden?='{{model.globalSettings.mode!=ui_constants.Mode.SHARE}}'
+          hidden?='{{mode!=ui_constants.Mode.SHARE}}'
           opened='{{ contact.shareExpanded }}'>
 
           <div class='friendControls' hidden?='{{contact.status!=UserStatus.FRIEND}}'>

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -33,9 +33,9 @@ Polymer({
       setTimeout(() => { this.hideOnlineStatus = false; }, 400);
     }
 
-    if (this.model.globalSettings.mode == ui_constants.Mode.SHARE) {
+    if (this.mode == ui_constants.Mode.SHARE) {
       this.contact.shareExpanded = !this.contact.shareExpanded;
-    } else if (this.model.globalSettings.mode == ui_constants.Mode.GET) {
+    } else if (this.mode == ui_constants.Mode.GET) {
       this.contact.getExpanded = !this.contact.getExpanded;
     }
   },

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -33,9 +33,9 @@ Polymer({
       setTimeout(() => { this.hideOnlineStatus = false; }, 400);
     }
 
-    if (this.mode == ui_constants.Mode.SHARE) {
+    if (this.isSharer) {
       this.contact.shareExpanded = !this.contact.shareExpanded;
-    } else if (this.mode == ui_constants.Mode.GET) {
+    } else if (this.isGetter) {
       this.contact.getExpanded = !this.contact.getExpanded;
     }
   },
@@ -216,6 +216,8 @@ Polymer({
     'contact.offeringInstances': 'offeringInstancesChanged',
   },
   computed: {
-    'isExpanded': '(mode === ui_constants.Mode.GET && contact.getExpanded) || (mode === ui_constants.Mode.SHARE && contact.shareExpanded)'
+    'isGetter': 'mode === ui_constants.Mode.GET',
+    'isSharer': 'mode === ui_constants.Mode.SHARE',
+    'isExpanded': '(isGetter && contact.getExpanded) || (isSharer && contact.shareExpanded)',
   }
 });


### PR DESCRIPTION
We pass the mode a specific uproxy-contact is being used for into the
element, use this mode when deciding how a contact should appear.

This is in support of #2556 and indirectly #1900 (Polymer 1.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2561)
<!-- Reviewable:end -->
