### PR TITLE
Fix error with showing confirmation dialog instead of message

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -352,7 +352,7 @@ export class UserInterface implements ui_constants.UiApi {
 
   public showDialog(heading :string, message :string, buttonText ?:string,
       displayData ?:string) {
-    return this.backgroundUi.openDialog(dialogs.getConfirmationDialogDescription(
+    return this.backgroundUi.openDialog(dialogs.getMessageDialogDescription(
         heading, message, buttonText, displayData));
   }
 


### PR DESCRIPTION
We were mistakenly calling the code to get a description of a
confirmation dialog when we only actually wanted a mesagge dialog, this
fixes that issue.

Fixes #2577

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2587)
<!-- Reviewable:end -->
