### PR TITLE
Stop using state sharing for gettingStatus/sharingStatus

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -287,11 +287,13 @@
     </style>
     <uproxy-state id="state"></uproxy-state>
 
-    <core-signals on-core-signal-close-settings="{{ closeSettings }}"></core-signals>
-
-    <core-signals on-core-signal-open-dialog="{{ openDialog }}"></core-signals>
-
-    <core-signals on-core-signal-show-toast="{{ showToast }}"></core-signal>
+    <core-signals
+        on-core-signal-close-settings="{{ closeSettings }}"
+        on-core-signal-open-dialog="{{ openDialog }}"
+        on-core-signal-show-toast="{{ showToast }}"
+        on-core-signal-update-getting-status="{{ updateGettingStatus }}"
+        on-core-signal-update-sharing-status="{{ updateSharingStatus }}">
+    </core-signal>
 
     <div id='browserElementContainer' hidden?='{{ui_constants.View.BROWSER_ERROR !== ui.view}}'></div>
 
@@ -383,16 +385,16 @@
                   <a href='#' on-tap='{{ openProxyError }}'>GET HELP</a>
                 </div>
               </div>
-              <div class='statusRow' hidden?='{{!ui.gettingStatus}}'>
+              <div class='statusRow' hidden?='{{!gettingStatus}}'>
                 <div class='statusText'>
                   <core-icon icon='uproxy-icons:receive'></core-icon>
-                  {{ui.gettingStatus}}
+                  {{gettingStatus}}
                 </div>
               </div>
-              <div class='statusRow' hidden?='{{!ui.sharingStatus}}'>
+              <div class='statusRow' hidden?='{{!sharingStatus}}'>
                 <div class='statusText'>
                   <core-icon icon='uproxy-icons:share'></core-icon>
-                  {{ui.sharingStatus}}
+                  {{sharingStatus}}
                 </div>
               </div>
               <div class='statusRow' hidden?='{{!ui.availableVersion}}'>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -33,6 +33,8 @@ Polymer({
   toastMessage: '',
   unableToGet: '',
   unableToShare: '',
+  gettingStatus: null,
+  sharingStatus: null,
   viewChanged: function(oldView :ui_types.View, newView :ui_types.View) {
     // If we're switching from the SPLASH page to the ROSTER, fire an
     // event indicating the user has logged in. roster.ts listens for
@@ -251,6 +253,12 @@ Polymer({
         });
       },
       () => { /* MT */ });
+  },
+  updateGettingStatus: function(e: Event, gettingStatus?: string) {
+    this.gettingStatus = gettingStatus;
+  },
+  updateSharingStatus: function(e: Event, sharingStatus?: string) {
+    this.sharingStatus = sharingStatus;
   },
   observe: {
     '$.mainPanel.selected': 'drawerToggled',

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -316,11 +316,17 @@ describe('UI.UserInterface', () => {
       syncUserAndInstance('userId', 'Alice', 'testInstanceId');
       updateToHandlerMap[uproxy_core_api.Update.START_GIVING_TO_FRIEND]
           .call(ui, 'testInstanceId');
-      expect(ui.sharingStatus).toEqual(ui.i18n_t('SHARING_ACCESS_WITH_ONE',
-          { name: 'Alice' }));
+      expect(mockBackgroundUi.fireSignal).toHaveBeenCalledWith(
+          'update-sharing-status',
+          ui.i18n_t('SHARING_ACCESS_WITH_ONE', { name: 'Alice' }));
       updateToHandlerMap[uproxy_core_api.Update.STOP_GIVING_TO_FRIEND]
           .call(ui, 'testInstanceId');
-      expect(ui.sharingStatus).toEqual(null);
+      expect(mockBackgroundUi.fireSignal).toHaveBeenCalledWith(
+          'update-sharing-status',
+          null);
+      expect(mockBackgroundUi.fireSignal).toHaveBeenCalledWith(
+          'update-sharing-status',
+          null);
     });
 
     it('No notification when you stop sharing and are not already proxying', () => {
@@ -343,14 +349,16 @@ describe('UI.UserInterface', () => {
       // Note that setting and clearing instanceGettingAccessFrom_ is done in
       // polymer/instance.ts.
       syncUserAndInstance('userId', 'Alice', 'testInstanceId');
-      expect(ui.gettingStatus).toEqual(null);
       ui['instanceGettingAccessFrom_'] = 'testInstanceId';
       ui['updateGettingStatusBar_']();
-      expect(ui.gettingStatus).toEqual(ui.i18n_t('GETTING_ACCESS_FROM',
-          { name: 'Alice' }));
+      expect(mockBackgroundUi.fireSignal).toHaveBeenCalledWith(
+          'update-getting-status',
+          ui.i18n_t('GETTING_ACCESS_FROM', { name: 'Alice' }));
       ui['instanceGettingAccessFrom_'] = null;
       ui['updateGettingStatusBar_']();
-      expect(ui.gettingStatus).toEqual(null);
+      expect(mockBackgroundUi.fireSignal).toHaveBeenCalledWith(
+          'update-getting-status',
+          null);
     });
   });  // Update giving and/or getting state in UI
 });  // UI.UserInterface

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -107,8 +107,6 @@ export class UserInterface implements ui_constants.UiApi {
   private mapInstanceIdToUser_ :{[instanceId :string] :User} = {};
 
   /* Getting and sharing */
-  public gettingStatus :string = null;
-  public sharingStatus :string = null;
   public isSharingDisabled :boolean = false;
   public proxyingId: string; // ID of the most recent failed proxying attempt.
   private userCancelledGetAttempt_ :boolean = false;
@@ -404,37 +402,36 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   private updateGettingStatusBar_ = () => {
-    // TODO: localize this.
+    var gettingStatus: string = null;
     if (this.instanceGettingAccessFrom_) {
-      this.gettingStatus = this.i18n_t('GETTING_ACCESS_FROM', {
+      gettingStatus = this.i18n_t('GETTING_ACCESS_FROM', {
         name: this.mapInstanceIdToUser_[this.instanceGettingAccessFrom_].name
       });
-    } else {
-      this.gettingStatus = null;
     }
+    this.fireSignal('update-getting-status', gettingStatus);
   }
 
   private updateSharingStatusBar_ = () => {
     // TODO: localize this - may require simpler formatting to work
     // in all languages.
+    var sharingStatus: string = null;
     var instanceIds = Object.keys(this.instancesGivingAccessTo);
-    if (instanceIds.length === 0) {
-      this.sharingStatus = null;
-    } else if (instanceIds.length === 1) {
-      this.sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_ONE', {
+    if (instanceIds.length === 1) {
+      sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_ONE', {
         name: this.mapInstanceIdToUser_[instanceIds[0]].name
       });
     } else if (instanceIds.length === 2) {
-      this.sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_TWO', {
+      sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_TWO', {
         name1: this.mapInstanceIdToUser_[instanceIds[0]].name,
         name2: this.mapInstanceIdToUser_[instanceIds[1]].name
       });
-    } else {
-      this.sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_MANY', {
+    } else if (instanceIds.length > 2) {
+      sharingStatus = this.i18n_t('SHARING_ACCESS_WITH_MANY', {
         name: this.mapInstanceIdToUser_[instanceIds[0]].name,
         numOthers: (instanceIds.length - 1)
       });
     }
+    this.fireSignal('update-sharing-status', sharingStatus);
   }
 
   private addUser_ = (tokenObj :social.InviteTokenData, showConfirmation :boolean) : Promise<void> => {


### PR DESCRIPTION
When updating gettingStatus and sharingStatus in the UI, we now send a
signal noting that they have changed instead of our previous behaviour
of just updating shared variables.

It seems very possible that we could reduce the complexity further by
looking at more underlying data (e.g. instanceGettingAccessFrom,
offeringInstances) but that seems unnecessary for this project.

This is in support of #2556 and indirectly #1900 (Polymer 1.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2594)
<!-- Reviewable:end -->
