### PR TITLE
add an install step to install freedom-for-node for zork-node

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -315,6 +315,11 @@ module.exports = (grunt) ->
       androidReplaceXwalkDist: {
         command: './replace_xwalk_in_apk.sh release'
       }
+      installFreedomForNodeForZork: {
+        # This allows our Docker containers, which do not have access to the
+        # git repo's "top-level" node_modules/ folder find freedom-for-node.
+        command: 'npm install --prefix build/dev/uproxy/lib/samples/zork-node freedom-for-node'
+      }
     }
 
     copy: {
@@ -620,7 +625,6 @@ module.exports = (grunt) ->
           localDestPath: 'lib/samples/zork-firefoxapp/data/'
       libsForZorkNode:
         Rule.copyLibs
-          npmLibNames: ['freedom-for-node']
           pathsFromDevBuild: ['lib/churn-pipe', 'lib/loggingprovider', 'lib/zork']
           pathsFromThirdPartyBuild: ['freedom-port-control']
           localDestPath: 'lib/samples/zork-node/'
@@ -1095,6 +1099,7 @@ module.exports = (grunt) ->
     'copy:libsForZorkChromeApp'
     'copy:libsForZorkFirefoxApp'
     'copy:libsForZorkNode'
+    'exec:installFreedomForNodeForZork'
   ]
 
   grunt.registerTask 'version_file', [


### PR DESCRIPTION
This is a little bit of a hack, but it's a good one. Turns out when you copy `build/dev/uproxy/lib/samples/zork-node` to a location outside of the git repo, node can't find freedom-for-node - I guess we've been implicitly relying on that top-level node_modules folder. Oops. This is bad for our Docker containers, where we copy/mount only `build/dev/uproxy/lib/samples/`.

This just-makes-it-work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2595)
<!-- Reviewable:end -->
