### PR TITLE
replace all substr() calls with substring()

### DIFF
--- a/src/generic_core/local-instance.ts
+++ b/src/generic_core/local-instance.ts
@@ -62,7 +62,7 @@ import storage = globals.storage;
         // 20 bytes for the instance ID.  This we can keep.
         // TODO: don't use Math.random; use uproxy crypto. (security higene)
         hex = Math.floor(Math.random() * 256).toString(16);
-        id += ('00'.substr(0, 2 - hex.length) + hex);
+        id += ('00'.substring(0, 2 - hex.length) + hex);
       }
       return id;
     }

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -72,7 +72,7 @@ export function initializeNetworks() :void {
         continue;
       }
 
-      var name = dependency.substr(PREFIX.length);
+      var name = dependency.substring(PREFIX.length);
       networks[name] = {};
     }
   }
@@ -499,7 +499,7 @@ export function notifyUI(networkName :string, userId :string) {
         var myKey = this.getStorePath();
         for (var i in keys) {
           if (keys[i].indexOf(myKey) === 0) {
-            var userId = keys[i].substr(myKey.length);
+            var userId = keys[i].substring(myKey.length);
             if (this.isNewFriend_(userId)) {
               this.addUser(userId);
             }
@@ -542,7 +542,7 @@ export function notifyUI(networkName :string, userId :string) {
         // If we change agent to use instanceId, we also should modify
         // Firebase code to change disconnected clients to OFFLINE, rather
         // than removing them.
-        var agent = 'uproxy' + Math.random().toString().substr(2,10);
+        var agent = 'uproxy' + Math.random().toString().substring(2, 12);
         request = {
           agent: agent,
           version: '0.1',
@@ -556,7 +556,7 @@ export function notifyUI(networkName :string, userId :string) {
           userName = globals.settings.quiverUserName;
         }
         request = {
-          agent: Math.random().toString().substr(2,10),
+          agent: Math.random().toString().substring(2, 12),
           version: '0.1',
           url: 'https://github.com/uProxy/uProxy',
           interactive: interactive,

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -493,7 +493,7 @@ export class UserInterface implements ui_constants.UiApi {
       } else {
         // Old v1 invites are base64 encoded JSON
         var lastNonCodeCharacter = Math.max(invite.lastIndexOf('/'), invite.lastIndexOf('#'));
-        var token = invite.substr(lastNonCodeCharacter + 1);
+        var token = invite.substring(lastNonCodeCharacter + 1);
 
         // Removes any non base64 characters that may appear, e.g. "%E2%80%8E"
         token = token.match('[A-Za-z0-9+/=_]+')[0];


### PR DESCRIPTION
(except for in digitalocean/provisioner.ts, which has already been
done on the jab-improve-DO-oauth branch (to be merged soon))

ref: #2553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2596)
<!-- Reviewable:end -->
