### PR TITLE
Remove showCloud setting

### DIFF
--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -32,7 +32,6 @@ export var settings :uproxy_core_api.GlobalSettings = {
   language: null,  // sentinel indicating lang should be calculated from browser settings
   force_message_version: 0, // zero means "don't override"
   quiverUserName: '',
-  showCloud: false,
   proxyBypass: constants.DEFAULT_PROXY_BYPASS.slice(0),
   enforceProxyServerValidity: false,
   validProxyServers: [],

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -212,7 +212,7 @@
       <div id='accountChooser' class='settingsContent' hidden?='{{ !accountChooserOpen }}'>
         <span class='smalltext'>{{ "CONNECTED_ACCOUNTS" | $$ }}</span>
         <template repeat='{{ name in model.networkNames }}'>
-          <div hidden?="{{name=='Cloud' && !model.globalSettings.showCloud}}">
+          <div hidden?="{{name=='Cloud'}}">
             <uproxy-network-in-settings name='{{ name }}'></uproxy-network-in-settings>
           </div>
         </template>

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -65,7 +65,6 @@ export class Model {
     language: null,  // sentinel indicating lang should be calculated from browser settings
     force_message_version: 0,
     quiverUserName: '',
-    showCloud: false,
     proxyBypass: [],
     enforceProxyServerValidity: false,
     validProxyServers: [],

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -980,11 +980,6 @@ export class UserInterface implements ui_constants.UiApi {
   }
 
   public login = (network :string, userName ?:string) : Promise<void> => {
-    if (network === 'Cloud') {
-      this.model.globalSettings.showCloud = true;
-      this.core.updateGlobalSettings(this.model.globalSettings);
-    }
-
     return this.core.login({
         network: network,
         loginType: uproxy_core_api.LoginType.INITIAL,

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -45,7 +45,6 @@ export interface GlobalSettings {
   language         :string;
   force_message_version :number;
   quiverUserName :string;
-  showCloud :boolean;
   proxyBypass: string[];
   enforceProxyServerValidity :boolean;
   validProxyServers :ValidProxyServerIdentity[];


### PR DESCRIPTION
There is no situation under which we actually want to have the cloud
network show up in the settings page, this removes the possibility of
that happening.

Fixes #2603

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2607)
<!-- Reviewable:end -->
