### PR TITLE
Fixes intents on Android

### DIFF
--- a/src/cca/app/config.xml
+++ b/src/cca/app/config.xml
@@ -9,7 +9,7 @@
     </platform>
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="./application/activity">
+        <config-file target="AndroidManifest.xml" parent="./application/activity/[@android:name='MainActivity']">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
A change in the most recent version of cordova-custom-config imposed
additional restrictions on the intent-filter element, which resulted in
our intent-filter not being added to the final configuration.  This
change makes us conform to the new restrictions, and fixes intent
support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2613)
<!-- Reviewable:end -->
