### PR TITLE
Stop showing error message after feedback sends.

### DIFF
--- a/src/generic_ui/locales/en/messages.json
+++ b/src/generic_ui/locales/en/messages.json
@@ -179,15 +179,15 @@
     "description": "",
     "message": "Thank you!"
   },
-  "FEEDBACK_TITLE_4": {
+  "TROUBLE_SIGNING_IN_TITLE": {
     "description": "",
     "message": "Trouble signing in"
   },
-  "FEEDBACK_TITLE_5": {
+  "NO_FRIENDS_TITLE": {
     "description": "",
     "message": "No friends to proxy from"
   },
-  "FEEDBACK_TITLE_6": {
+  "CANT_START_CONNECTION_TITLE": {
     "description": "",
     "message": "Can't start connection"
   },
@@ -195,15 +195,15 @@
     "description": "User feedback was successfully submitted.",
     "message": "Your feedback has been submitted to the uProxy development team."
   },
-  "FEEDBACK_SUBMITTED_4": {
+  "TROUBLE_SIGNING_IN_HELP": {
     "description": "Trouble signing in feedback error.",
     "message": "Login will fail if you try a social network that is blocked.  Thanks for your feedback! <uproxy-faq-link anchor='willUproxyWork'>Learn more.</uproxy-faq-link>"
   },
-  "FEEDBACK_SUBMITTED_5": {
+  "NO_FRIENDS_HELP": {
     "description": "No friends feedback error.",
     "message": "Consider using uProxy cloud servers.  Thanks for your feedback! <uproxy-faq-link anchor='whatAreCloudServers'>Learn more.</uproxy-faq-link>"
   },
-  "FEEDBACK_SUBMITTED_6": {
+  "CANT_START_CONNECTION_HELP": {
     "description": "Trouble connecting feedback error.",
     "message": "Sometimes uProxy relies on port control to establish a connection, but that might not be available for your network.  Thanks for your feedback! <uproxy-faq-link anchor='whatIsPortControl'>Learn more.</uproxy-faq-link>"
   },
@@ -1371,7 +1371,7 @@
   "START_BROWSING": {
     "description": "Button label for starting an in-app browser connected to a uProxy peer.",
     "message": "Start browsing"
-  }, 
+  },
   "ASK_FOR_FEEDBACK_TITLE": {
     "description": "Asks the user if they'd like to submit feedback",
     "message": "Submit feedback?"

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -52,16 +52,19 @@ Polymer({
       browserInfo: navigator.userAgent,
       feedbackType: this.feedbackType
     }).then(() => {
+    // The keys below correspond with UserFeedbackType enum values
+    // in uproxy_core_api.ts
     var messages : {[key: number]: [string, string]} = {
       0: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
       1: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
       2: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
       3: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
-      4: ['FEEDBACK_SUBMITTED_4', 'FEEDBACK_TITLE_4'],
-      5: ['FEEDBACK_SUBMITTED_5', 'FEEDBACK_TITLE_5'],
-      6: ['FEEDBACK_SUBMITTED_6', 'FEEDBACK_TITLE_6'],
-      7: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
-      8: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE']
+      4: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
+      5: ['TROUBLE_SIGNING_IN_TITLE', 'TROUBLE_SIGNING_IN_HELP'],
+      6: ['NO_FRIENDS_TITLE', 'NO_FRIENDS_HELP'],
+      7: ['CANT_START_CONNECTION_TITLE', 'CANT_START_CONNECTION_HELP'],
+      8: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE'],
+      9: ['FEEDBACK_SUBMITTED', 'FEEDBACK_TITLE']
     };
       // root.ts listens for open-dialog signals and shows a popup
       // when it receives these events.


### PR DESCRIPTION
Fixes: https://github.com/uProxy/uproxy/issues/2615

We were getting an error message because "this.$.errorInput.selected" was set to the enum value of the feedback type, rather than the index of the paper-item the user selected in the dropdown. The messages map assumed it was the index of the paper-item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2618)
<!-- Reviewable:end -->
