### PR TITLE
Fix bad close tag for core-signals

### DIFF
--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -293,7 +293,7 @@
         on-core-signal-show-toast="{{ showToast }}"
         on-core-signal-update-getting-status="{{ updateGettingStatus }}"
         on-core-signal-update-sharing-status="{{ updateSharingStatus }}">
-    </core-signal>
+    </core-signals>
 
     <div id='browserElementContainer' hidden?='{{ui_constants.View.BROWSER_ERROR !== ui.view}}'></div>
 


### PR DESCRIPTION
Probably my fault since I remember consolidating all the signals into one element...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2621)
<!-- Reviewable:end -->
