### PR TITLE
Measure bandwidth for each individual session in a connection

### DIFF
--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -350,6 +350,7 @@ var generateProxyingSessionId_ = (): string => {
 
     private handleBytesReceived_ = (bytes :number) => {
       this.bytesReceived_ += bytes;
+      log.debug('testing: new amount of bytes Received' + this.bytesReceived_);
       this.delayedUpdate_();
     }
 

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -350,7 +350,6 @@ var generateProxyingSessionId_ = (): string => {
 
     private handleBytesReceived_ = (bytes :number) => {
       this.bytesReceived_ += bytes;
-      log.debug('testing: new amount of bytes Received' + this.bytesReceived_);
       this.delayedUpdate_();
     }
 

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -337,7 +337,7 @@ import ProxyConfig = require('./proxyconfig');
     // Records the bytes sent to and from peer, for the previous time interval in this session. 
     private prevBytesSession_:number = 0;
     // The length of each interval used to calculate bandwidth.
-    public static BANDWIDTH_MONITOR_INTERVAL = 5000;  
+    public static BANDWIDTH_MONITOR_INTERVAL = 5000;
 
     // The supplied datachannel must already be successfully established.
     constructor(
@@ -401,7 +401,7 @@ import ProxyConfig = require('./proxyconfig');
 
       this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
       //Reset bandwidth loop check.
-      this.stopBandwidthCalc_ = false; 
+      this.stopBandwidthCalc_ = false;
       this.calculateBandwidth_();
       // Shutdown once the data channel terminates.
       this.dataChannel_.onceClosed.then(() => {

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -57,8 +57,8 @@ import ProxyConfig = require('./proxyconfig');
     // Number of live sessions by user, if greater than zero.
     private static numSessions_ : { [userId:string] :number } = {};
 
-    private stopBandwidthCalcTotal:boolean = false;
-    private prevBytesTotal:number = 0;
+    private stopBandwidthCalcTotal :boolean = false;
+    private prevBytesTotal :number = 0;
 
     // Returns true if the addition was successful.
     private static addUserSession_ = (userId:string) : boolean => {
@@ -287,7 +287,6 @@ import ProxyConfig = require('./proxyconfig');
         var currBytesTotal = 0;
         for (var label in this.sessions_) {
           currBytesTotal += this.sessions_[label].currBytes_;
-          // prevBytesTotal += this.sessions_[label].prevBytes_; //TODO there might be a better way to keep track
         }
         var bitsTransferredTotal = (currBytesTotal - this.prevBytesTotal) * 8;
         // Bandwidth is measured in bits/sec.

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -54,6 +54,8 @@ import ProxyConfig = require('./proxyconfig');
     // Public for tests.
     public static SESSION_LIMIT = 10000;
 
+    public static BANDWIDTH_MONITOR_INTERVAL = 5000;
+
     // Number of live sessions by user, if greater than zero.
     private static numSessions_ : { [userId:string] :number } = {};
 
@@ -290,7 +292,7 @@ import ProxyConfig = require('./proxyconfig');
         }
         var bitsTransferredTotal = (currBytesTotal - this.prevBytesTotal) * 8;
         // Bandwidth is measured in bits/sec.
-        var bandwidthTotal  = bitsTransferredTotal / (Session.BANDWIDTH_MONITOR_INTERVAL / 1000);
+        var bandwidthTotal  = bitsTransferredTotal / (RtcToNet.BANDWIDTH_MONITOR_INTERVAL / 1000);
         log.debug('Current bandwidth for whole connection: %1 bits/sec', bandwidthTotal);
         this.prevBytesTotal = currBytesTotal;
         setTimeout(this.calculateBandwidthTotal, Session.BANDWIDTH_MONITOR_INTERVAL);
@@ -358,7 +360,7 @@ import ProxyConfig = require('./proxyconfig');
     // Records the bytes sent to and from peer, for the previous time interval. 
     public prevBytes_:number = 0;
     // The length of each interval used to calculate bandwidth, in milliseconds.
-    public static BANDWIDTH_MONITOR_INTERVAL = 5000;
+    private static BANDWIDTH_MONITOR_INTERVAL = 5000;
 
     // The supplied datachannel must already be successfully established.
     constructor(

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -58,6 +58,7 @@ import ProxyConfig = require('./proxyconfig');
     private static numSessions_ : { [userId:string] :number } = {};
 
     private stopBandwidthCalcTotal:boolean = false;
+    private prevBytesTotal:number = 0;
 
     // Returns true if the addition was successful.
     private static addUserSession_ = (userId:string) : boolean => {
@@ -284,15 +285,15 @@ import ProxyConfig = require('./proxyconfig');
     private calculateBandwidthTotal = () : void => {
       if (!this.stopBandwidthCalcTotal) {
         var currBytesTotal = 0;
-        var prevBytesTotal = 0;
         for (var label in this.sessions_) {
           currBytesTotal += this.sessions_[label].currBytes_;
-          prevBytesTotal += this.sessions_[label].prevBytes_; //TODO there might be a better way to keep track
+          // prevBytesTotal += this.sessions_[label].prevBytes_; //TODO there might be a better way to keep track
         }
-        var bitsTransferredTotal = (currBytesTotal - prevBytesTotal) * 8;
+        var bitsTransferredTotal = (currBytesTotal - this.prevBytesTotal) * 8;
         // Bandwidth is measured in bits/sec.
         var bandwidthTotal  = bitsTransferredTotal / (Session.BANDWIDTH_MONITOR_INTERVAL / 1000);
         log.debug('Current bandwidth for whole connection: %1 bits/sec', bandwidthTotal);
+        this.prevBytesTotal = currBytesTotal;
         setTimeout(this.calculateBandwidthTotal, Session.BANDWIDTH_MONITOR_INTERVAL);
       }
     }

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -295,7 +295,7 @@ import ProxyConfig = require('./proxyconfig');
         var bandwidthTotal  = bitsTransferredTotal / (RtcToNet.BANDWIDTH_MONITOR_INTERVAL / 1000);
         log.debug('Current bandwidth for whole connection: %1 bits/sec', bandwidthTotal);
         this.prevBytesTotal = currBytesTotal;
-        setTimeout(this.calculateBandwidthTotal, Session.BANDWIDTH_MONITOR_INTERVAL);
+        setTimeout(this.calculateBandwidthTotal, RtcToNet.BANDWIDTH_MONITOR_INTERVAL);
       }
     }
 


### PR DESCRIPTION
I added small amount of code that measures the bandwidth of each session in a connection every 5 seconds. It measures the bandwidth usage just over those 5 seconds, and not the whole time the session was running, because when eventually trying to limit bandwidth usage, a low average with a random high spike cannot be caught with that method. Bandwidth is calculated as bits/second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2625)
<!-- Reviewable:end -->
