### PR TITLE
replace negative array index with backwards-compatible spelling

### DIFF
--- a/replace_xwalk_in_apk.sh
+++ b/replace_xwalk_in_apk.sh
@@ -64,6 +64,6 @@ jarsigner -keystore "$KEY_DIR/$storeFile" -storepass $storePassword -keypass $ke
 # Overwrite the aligned apk with a new one.  zipalign isn't on the path, and
 # more than one might be installed, so first we have to pick one.
 ZIPALIGN_TOOLS=( $ANDROID_HOME/build-tools/*/zipalign )
-ZIPALIGN="${ZIPALIGN_TOOLS[-1]}"
+ZIPALIGN="${ZIPALIGN_TOOLS[${#ZIPALIGN_TOOLS[@]}-1]}"
 $ZIPALIGN -f 4 $APK_UNALIGNED $APK_FINAL
 


### PR DESCRIPTION
According to the [changelog](http://tiswww.case.edu/php/chet/bash/NEWS) negative array indices were only added to bash in the most recent minor version (i.e. 4.3, see item `x.`).

Even the latest version OS X (10.11.6 as of this moment) ships an ancient version of bash in `/bin/bash` (3.2.57).

As a result, our current use of the array index `-1` causes `replace_xwalk_in_apk.sh` (and consequently `grunt build_android`) to fail on OS X:
```
./replace_xwalk_in_apk.sh: line 69: ZIPALIGN_TOOLS: bad array subscript
```

Rather than force OS X users to upgrade to a newer bash (and change our shebang to `#!/usr/bin/env bash` if we don't want to force them to clobber their system bash), we can spell "last element" in the more verbose but backwards-compatible way here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2638)
<!-- Reviewable:end -->
