### PR TITLE
Add sane behaviour to the Android back button

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -236,7 +236,7 @@ module.exports = (grunt) ->
 
     # Create commands to run in different directories
     ccaPlatformAndroidCmd: '<%= ccaJsPath %> platform add android'
-    ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git cordova-plugin-device https://github.com/albertolalama/cordova-plugin-tun2socks.git#alalama-tun2socks'
+    ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git cordova-plugin-device https://github.com/albertolalama/cordova-plugin-tun2socks.git#alalama-tun2socks cordova-plugin-backbutton'
 
     # Temporarily remove cordova-plugin-chrome-apps-proxy and add the MobileChromeApps version until the new version is released
     ccaAddPluginsIosCmd: '<%= ccaJsPath %> plugin remove cordova-plugin-chrome-apps-proxy && <%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/gitlaura/cordova-plugin-iosrtc.git https://github.com/MobileChromeApps/cordova-plugin-chrome-apps-proxy.git'

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -92,6 +92,10 @@ class CordovaBrowserApi implements BrowserAPI {
       // fires.
       window.top.webintent.getUri(this.onUrl_);  // Handle URL already received.
       window.top.webintent.onNewIntent(this.onUrl_);  // Handle future URLs.
+
+      window.top.document.addEventListener('backbutton', () => {
+        this.emit_('backbutton');
+      }, false);
     }, false);
   }
 
@@ -341,6 +345,10 @@ class CordovaBrowserApi implements BrowserAPI {
       });
       delete this.pendingEvents_[name];
     }
+  }
+
+  public exit = () => {
+    (<any>navigator).app.exitApp();
   }
 
   private emit_ = (name :string, ...args :Object[]) => {

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -3,6 +3,8 @@
 /// <reference path='../../../../third_party/cordova/webintents.d.ts'/>
 /// <reference path='../../../../third_party/cordova/tun2socks.d.ts'/>
 /// <reference path='../../../../third_party/cordova/device.d.ts'/>
+/// <reference path='../../../../third_party/cordova/backbutton.d.ts'/>
+/// <reference path='../../../../third_party/cordova/app.d.ts'/>
 
 /**
  * cordova_browser_api.ts
@@ -348,11 +350,13 @@ class CordovaBrowserApi implements BrowserAPI {
   }
 
   public exit = () => {
-    (<any>navigator).Backbutton.goBack(() => { /* MT (success) */ }, () => {
-      /* We don't expect an error here, but it should be handled */
-      console.error('Could not go back, exiting app completely');
-      (<any>navigator).app.exitApp();
-    });
+    if (navigator.Backbutton) {
+      navigator.Backbutton.goBack(() => { /* MT (success) */ }, () => {
+        /* We don't expect an error here, but it should be handled */
+        console.error('Could not go back, exiting app completely');
+        navigator.app.exitApp();
+      });
+    }
   }
 
   private emit_ = (name :string, ...args :Object[]) => {

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -348,7 +348,11 @@ class CordovaBrowserApi implements BrowserAPI {
   }
 
   public exit = () => {
-    (<any>navigator).app.exitApp();
+    (<any>navigator).Backbutton.goBack(() => { /* MT (success) */ }, () => {
+      /* We don't expect an error here, but it should be handled */
+      console.error('Could not go back, exiting app completely');
+      (<any>navigator).app.exitApp();
+    });
   }
 
   private emit_ = (name :string, ...args :Object[]) => {

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -221,6 +221,10 @@ class ChromeBrowserApi implements BrowserAPI {
     this.events_[name] = callback;
   }
 
+  public exit = () => {
+    // Not necessary for in-browser versions
+  }
+
   public emit = (name :string, ...args :Object[]) => {
     this.bringUproxyToFront().then(() => {
       if (name in this.events_) {

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -83,6 +83,10 @@ class FirefoxBrowserApi implements BrowserAPI {
     port.on(name, callback);
   }
 
+  public exit = () => {
+    // Not necessary for in-browser versions
+  }
+
   public respond = (data :any, callback ?:Function, msg ?:string) : void => {
     msg && this.respond_(data, msg);
   }

--- a/src/generic_ui/polymer/cloud-install.html
+++ b/src/generic_ui/polymer/cloud-install.html
@@ -88,9 +88,10 @@
     }
     </style>
 
-    <core-signals on-core-signal-open-cloud-install='{{ open }}'></core-signals>
-    <core-signals on-core-signal-cloud-install-status="{{ updateCloudInstallStatus }}"></core-signals>
-    <core-signals on-core-signal-cloud-install-progress="{{ updateCloudInstallProgress }}"></core-signals>
+    <core-signals
+        on-core-signal-cloud-install-status="{{ updateCloudInstallStatus }}"
+        on-core-signal-cloud-install-progress="{{ updateCloudInstallProgress }}">
+    </core-signals>
 
     <core-overlay id='signUpOrSignInOverlay'>
       <uproxy-app-bar on-go-back='{{ back }}' color='#34AFCE'>

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -194,5 +194,8 @@ Polymer({
   },
   observe: {
     'ui.model.globalSettings.activePromoId': 'promoIdChanged'
+  },
+  computed: {
+    'opened': '$.signUpOrSignInOverlay.opened || $.createServerOverlay.opened || $.installingOverlay.opened || $.successOverlay.opened || $.failureOverlay.opened || $.serverExistsOverlay.opened || $.cancelingOverlay.opened'
   }
 });

--- a/src/generic_ui/polymer/faq.ts
+++ b/src/generic_ui/polymer/faq.ts
@@ -69,5 +69,8 @@ Polymer({
       }
       this.injectBoundHTML(i18nMessage, element);
     }
+  },
+  computed: {
+    'opened': '$.faqPanel.opened'
   }
 });

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -243,8 +243,8 @@
       </div>
     </uproxy-dialog>
 
-    <uproxy-network-invite-user network="{{selectedNetworkName}}"></uproxy-network-invite-user>
-    <uproxy-cloud-install></uproxy-cloud-install>
+    <uproxy-network-invite-user id="networkInviteUser" network="{{selectedNetworkName}}"></uproxy-network-invite-user>
+    <uproxy-cloud-install id="installCloud"></uproxy-cloud-install>
 
   </template>
   <script src='invite-user.js'></script>

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -27,6 +27,24 @@ var inviteUser = {
   closeInviteUserPanel: function() {
     this.$.inviteUserPanel.close();
   },
+  back: function() {
+    if (this.$.loginToInviteFriendDialog.opened) {
+      this.$.loginToInviteFriendDialog.close();
+      return;
+    }
+
+    if (this.$.installCloud.opened) {
+      this.$.installCloud.back();
+      return;
+    }
+
+    if (this.$.networkInviteUser.opened) {
+      this.$.networkInviteUser.close();
+      return;
+    }
+
+    this.closeInviteUserPanel();
+  },
   networkTapped: function(event: Event, detail: Object, target: HTMLElement) {
     var networkName = target.getAttribute('data-network');
     if (networkName === 'Cloud') {
@@ -52,7 +70,7 @@ var inviteUser = {
   },
   cloudInstall: function() {
     this.closeInviteUserPanel();
-    this.fire('core-signal', { name: 'open-cloud-install' });
+    this.$.installCloud.open();
   },
   loginTapped: function() {
     // loginTapped should only be called by the loginToInviteFriendDialog, which
@@ -72,7 +90,7 @@ var inviteUser = {
     this.selectedNetworkName = networkName;
     // After login for these networks, open another view which allows users
     // to invite their friends.
-    this.fire('core-signal', { name: 'open-network-invite-dialog' });
+    this.$.networkInviteUser.open();
   },
   loginToInviteFriendDialogOpened: function() {
     // Set confirmation message, which may include some HTML (e.g. strong, br).
@@ -120,6 +138,9 @@ var inviteUser = {
     this.selectedNetworkName = '';
     this.model = ui_context.model;
     this.inviteCode = '';
+  },
+  computed: {
+    'opened': '$.inviteUserPanel.opened || $.loginToInviteFriendDialog.opened || $.installCloud.opened || $.networkInviteUser.opened'
   }
 };
 

--- a/src/generic_ui/polymer/network-invite-user.html
+++ b/src/generic_ui/polymer/network-invite-user.html
@@ -70,10 +70,9 @@
     </style>
 
     <uproxy-state id="state"></uproxy-state>
-    <core-signals on-core-signal-open-network-invite-dialog='{{openInviteUserPanel}}'></core-signals>
 
     <core-overlay id='networkInviteUserPanel' class='{{ network }}'>
-      <uproxy-app-bar on-go-back='{{ closeInviteUserPanel }}'>
+      <uproxy-app-bar on-go-back='{{ close }}'>
         {{ 'INVITE_A_FRIEND' | $$ }}
       </uproxy-app-bar>
 

--- a/src/generic_ui/polymer/network-invite-user.ts
+++ b/src/generic_ui/polymer/network-invite-user.ts
@@ -46,7 +46,7 @@ Polymer({
       var facebookUrl = navigator.userAgent.indexOf('Mobile Safari') === -1 ?
           facebookSendUrl : facebookShareUrl;
       ui.openTab(facebookUrl);
-      this.closeInviteUserPanel();
+      this.close();
     });
   },
   sendToGMailFriend: function() {
@@ -63,7 +63,7 @@ Polymer({
           subject: ui.i18n_t('INVITE_EMAIL_SUBJECT', { name: name }),
           body: ui.i18n_t('INVITE_EMAIL_BODY', { url: this.inviteUrl, name: name })
       });
-      this.closeInviteUserPanel();
+      this.close();
       this.$.state.openDialog(dialogs.getMessageDialogDescription('', translator.i18n_t('INVITE_EMAIL_SENT')));
     });
   },
@@ -78,7 +78,7 @@ Polymer({
       isOffering: this.offerAccess,
       userId: this.gitHubUserIdInput
     }).then(() => {
-      this.closeInviteUserPanel();
+      this.close();
       this.$.state.openDialog(dialogs.getMessageDialogDescription('',
             translator.i18n_t('INVITE_SENT_CONFIRMATION', { name: this.gitHubUserIdInput })));
     }).catch(() => {
@@ -88,11 +88,11 @@ Polymer({
             translator.i18n_t('GITHUB_INVITE_SEND_FAILED')));
     });
   },
-  openInviteUserPanel: function() {
+  open: function() {
     this.initFields();
     this.$.networkInviteUserPanel.open();
   },
-  closeInviteUserPanel: function() {
+  close: function() {
     this.$.networkInviteUserPanel.close();
   },
   select: function(e :Event, d :Object, input :HTMLInputElement) {
@@ -136,6 +136,9 @@ Polymer({
   },
   ready: function() {
     this.initFields();
+  },
+  computed: {
+    'opened': '$.networkInviteUserPanel.opened'
   }
 });
 

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -292,13 +292,14 @@
         on-core-signal-open-dialog="{{ openDialog }}"
         on-core-signal-show-toast="{{ showToast }}"
         on-core-signal-update-getting-status="{{ updateGettingStatus }}"
-        on-core-signal-update-sharing-status="{{ updateSharingStatus }}">
+        on-core-signal-update-sharing-status="{{ updateSharingStatus }}"
+        on-core-signal-backbutton="{{ handleBackButton }}">
     </core-signals>
 
     <div id='browserElementContainer' hidden?='{{ui_constants.View.BROWSER_ERROR !== ui.view}}'></div>
 
     <!-- core-overlays, launched using core-signals -->
-    <uproxy-invite-user></uproxy-invite-user>
+    <uproxy-invite-user id='inviteUser'></uproxy-invite-user>
     <uproxy-google-invite></uproxy-google-invite>
     <uproxy-logs></uproxy-logs>
     <uproxy-feedback id='feedback'></uproxy-feedback>

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -260,6 +260,55 @@ Polymer({
   updateSharingStatus: function(e: Event, sharingStatus?: string) {
     this.sharingStatus = sharingStatus;
   },
+  handleBackButton: function() {
+    // If the generic dialog is open, it's the highest-level thing in the UI
+    if (this.$.dialog.opened) {
+      this.closeDialog();
+      return;
+    }
+
+    // Handle non-roster cases (browser error or splash screen)
+    if (ui.view === ui_types.View.SPLASH) {
+      if (this.$.splash.state > 0) {
+        this.$.splash.state--;
+        return;
+      }
+
+      ui.browserApi.exit();
+      return;
+    }
+
+    if (ui.view === ui_types.View.BROWSER_ERROR) {
+      ui.browserApi.exit();
+      return;
+    }
+
+    // Definitely on the roster at this point, go through views
+    const panelIds = ['faq', 'feedback', 'advancedSettings'];
+    for (let i in panelIds) {
+      const el = this.$[panelIds[i]];
+      if (el.opened) {
+        el.close();
+        return;
+      }
+    }
+
+    // InviteUser is more complicated, just calling exit would be deceptive,
+    // this seems cleaner than having a check for if back exists on each
+    // element in the above list
+    if (this.$.inviteUser.opened) {
+      this.$.inviteUser.back();
+      return;
+    }
+
+    // If we're simply on the roster, close settings if open, otherwise exit
+    if (this.$.mainPanel.selected === 'drawer') {
+      this.$.mainPanel.closeDrawer();
+      return;
+    }
+
+    ui.browserApi.exit();
+  },
   observe: {
     '$.mainPanel.selected': 'drawerToggled',
     'ui.view': 'viewChanged',

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -280,6 +280,9 @@ export class UserInterface implements ui_constants.UiApi {
     browserApi.on('promoIdDetected', this.setActivePromoId);
     browserApi.on('translationsRequest', this.handleTranslationsRequest);
     browserApi.on('globalSettingsRequest', this.handleGlobalSettingsRequest);
+    browserApi.on('backbutton', () => {
+      this.fireSignal('backbutton');
+    });
     backgroundUi.registerAsFakeBackground(this.panelMessageHandler);
 
     core.getFullState()

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -54,6 +54,9 @@ export interface BrowserAPI {
   // passed, a message will be supplied instead, which will be emitted with
   // the given response data.
   respond(data :any, callback ?:Function, msg ?:string) :void;
+
+  // This should close any uProxy UI window
+  exit(): void;
 }
 
 // Describes the user-initiated mode to access a proxy.

--- a/third_party/cordova/app.d.ts
+++ b/third_party/cordova/app.d.ts
@@ -1,0 +1,5 @@
+interface Navigator {
+  app: {
+    exitApp: () => void;
+  }
+}

--- a/third_party/cordova/backbutton.d.ts
+++ b/third_party/cordova/backbutton.d.ts
@@ -1,0 +1,6 @@
+interface Navigator {
+  Backbutton: {
+    goBack: (success: Function, failure: Function) => void;
+    goHome: (success: Function, failure: Function) => void;
+  }
+}


### PR DESCRIPTION
To start with, we add, to most of the views that include a
panel/overlay/dialog, an `opened` property that simply states whether
that panel is active and a `close` method that closes the panel.

For the `invite-user` view, we use the method back instead of close.  In
this case, there are multiple different panels that it might have open
instead of being the main panel itself and we want to make sure we close
the correct (active) one only.

In order to handle the overall functionality of the back button, we now
listen in root.ts for the backbutton core signal.  Our handler there
then cycles through the possible things that could be the top-level
element and closes whichever one that is.  If there is nothing else
open, we close the entire app with a new method that's been added to the
browser api.

Also, as a result of this change, a lot of elements that previously
handled sending open events to their direct children now do so via just
calling the open method on the child element.  It's a lot cleaner and
will hopefully remove some (rarely-suffered) overhead.

Fixes #2440

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2642)
<!-- Reviewable:end -->
