### PR TITLE
Tweaks for translation.

### DIFF
--- a/src/generic_ui/polymer/i18n-filter.ts
+++ b/src/generic_ui/polymer/i18n-filter.ts
@@ -1,7 +1,6 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import translator = require('../scripts/translator');
-
 var i18n_t = translator.i18n_t;
 
 declare var PolymerExpressions: any;

--- a/src/generic_ui/polymer/i18n-filter.ts
+++ b/src/generic_ui/polymer/i18n-filter.ts
@@ -1,7 +1,8 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-var ui = ui_context.ui;
-var i18n_t = ui.i18n_t;
+import translator = require('../scripts/translator');
+
+var i18n_t = translator.i18n_t;
 
 declare var PolymerExpressions: any;
 PolymerExpressions.prototype.$$ = i18n_t;

--- a/src/generic_ui/polymer/invite-user.html
+++ b/src/generic_ui/polymer/invite-user.html
@@ -5,7 +5,6 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
 <link rel='import' href='button.html'>
 <link rel='import' href='network-invite-user.html'>
-<link rel="import" href="i18n-filter.html">
 <link rel='import' href='cloud-install.html'>
 
 <polymer-element name='uproxy-invite-user'>

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -2,16 +2,10 @@
 import translator_module = require('../scripts/translator');
 
 declare var PolymerExpressions: any;
-PolymerExpressions.prototype.$$ = translator_module.i18n_t;
 
 Polymer({
   logs: '',
   loadingLogs: true,
-  created: function() {
-    // Default language to English.
-    var language = window.location.href.split('lang=')[1] || 'en';
-    translator_module.i18n_setLng(language.substring(0, 2));
-  },
   openLogs: function() {
     // Reset logs and display loading bar
     this.logs = '';

--- a/src/generic_ui/polymer/network-invite-user.html
+++ b/src/generic_ui/polymer/network-invite-user.html
@@ -5,7 +5,6 @@
 <link rel='import' href='../../bower/polymer/polymer.html'>
 <link rel='import' href='button.html'>
 <link rel='import' href='dialog.html'>
-<link rel="import" href="i18n-filter.html">
 
 <polymer-element name='uproxy-network-invite-user' attributes="network">
   <template>

--- a/src/generic_ui/scripts/translator.ts
+++ b/src/generic_ui/scripts/translator.ts
@@ -55,7 +55,6 @@ export const i18n_t = (placeholder :string, params ?:any): string => {
       params[p] = '\u200E' + params[p] + '\u200E';
     }
   }
-  console.log(i18next.t(placeholder, params));
   return i18next.t(placeholder, params);
 };
 

--- a/src/generic_ui/scripts/translator.ts
+++ b/src/generic_ui/scripts/translator.ts
@@ -55,6 +55,7 @@ export const i18n_t = (placeholder :string, params ?:any): string => {
       params[p] = '\u200E' + params[p] + '\u200E';
     }
   }
+  console.log(i18next.t(placeholder, params));
   return i18next.t(placeholder, params);
 };
 


### PR DESCRIPTION
Fixes https://github.com/uProxy/uproxy/issues/2643

Translations weren't working because there was an extra "setLng" called in logs.ts that kept setting the language back to English.

This also: changes the Polymer filter to depend on translator.ts instead of ui.ts, and removes i18n-filter.html imports where they're not needed (since it's imported at the top level in root.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2645)
<!-- Reviewable:end -->
