### PR TITLE
Allow proxying to restart by not resetting the access mode on stop

### DIFF
--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -52,7 +52,9 @@ class CordovaBrowserApi implements BrowserAPI {
 
   public supportsVpn = deviceSupportsVpn();
 
-  // Mode to start/stop proxying.
+  // Mode to start/stop proxying. Set when starting the proxy in order to stop
+  // it accordingly, and to automatically restart proxying in case of a
+  // disconnect.
   private proxyAccessMode_ = ProxyAccessMode.NONE;
 
   public setIcon = (iconFile :string) : void => {

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -208,7 +208,6 @@ class CordovaBrowserApi implements BrowserAPI {
     } else {
       console.error('Unexpected proxy acccess mode ', this.proxyAccessMode_);
     }
-    this.proxyAccessMode_ = ProxyAccessMode.NONE;
   };
 
   public openTab = (url :string) => {

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -657,7 +657,6 @@ export class UserInterface implements ui_constants.UiApi {
       // In the case where the user clicked stop, this will have no effect
       // (this function is idempotent).
       this.browserApi.stopUsingProxy();
-      this.proxyAccessMode_ = ProxyAccessMode.NONE;
     }
 
     this.updateGettingStatusBar_();
@@ -673,7 +672,6 @@ export class UserInterface implements ui_constants.UiApi {
     }
 
     this.browserApi.stopUsingProxy();
-    this.proxyAccessMode_ = ProxyAccessMode.NONE;
     this.core.disconnectedWhileProxying = null;
     this.updateIcon_();
 

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -122,7 +122,9 @@ export class UserInterface implements ui_constants.UiApi {
   // Please note that this value is updated periodically so may not reflect current reality.
   private isConnectedToCellular_ :boolean = false;
 
-  // User-initiated proxy access mode.
+  // User-initiated proxy access mode. Set when starting the proxy in order to
+  // stop it accordingly, and to automatically restart proxying in case of a
+  // disconnect.
   private proxyAccessMode_: ProxyAccessMode = ProxyAccessMode.NONE;
 
   /**


### PR DESCRIPTION
* This change **partially** fixes #2644. 
* On Chrome, it is now possible to reconnect to a proxy through the 'Try again' button.
* No regressions introduced on Android.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2649)
<!-- Reviewable:end -->
