### PR TITLE
align down arrow in empty roster on Android properly

### DIFF
--- a/src/generic_ui/polymer/roster.html
+++ b/src/generic_ui/polymer/roster.html
@@ -70,7 +70,7 @@
       color: #fff;
       position: absolute;
       right: 54px;
-      bottom: 104px;
+      bottom: 105px;
       font-size: 20px;
       text-shadow: 0 7px 10px #ccc;
     }


### PR DESCRIPTION
Observed in latest master on a Nexus 5

Before this change:
![965968539957966465-account_id 2](https://cloud.githubusercontent.com/assets/64992/17488511/bea88ac0-5d67-11e6-9e5e-ac3bd82f43e7.png)

With this change:
![167959615178798727-account_id 2](https://cloud.githubusercontent.com/assets/64992/17488561/eb9cd720-5d67-11e6-9049-77283f86e6d6.png)


(Funny this didn't show up for me in desktop Chrome or Firefox on OS X when I "fixed" it the first time in a6e37c83.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2654)
<!-- Reviewable:end -->
