### PR TITLE
Use same structure for build and dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ out
 test_output
 tmp
 keys
+third_party/bower
 third_party/typings

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,7 +10,7 @@ path = require 'path'
 #-------------------------------------------------------------------------
 
 # Location of where src is copied into and compiled.
-devBuildPath = 'build/dev/uproxy'
+devBuildPath = 'build/src'
 distBuildPath = 'build/dist'
 # Location of where to copy/build third_party source/libs.
 thirdPartyBuildPath = 'build/third_party'
@@ -316,7 +316,7 @@ module.exports = (grunt) ->
       installFreedomForNodeForZork: {
         # This allows our Docker containers, which do not have access to the
         # git repo's "top-level" node_modules/ folder find freedom-for-node.
-        command: 'npm install --prefix build/dev/uproxy/lib/samples/zork-node freedom-for-node'
+        command: 'npm install --prefix build/src/lib/samples/zork-node freedom-for-node'
       }
     }
 
@@ -898,7 +898,7 @@ module.exports = (grunt) ->
     #-------------------------------------------------------------------------
     jasmine:
       chrome_extension: Rule.jasmineSpec('chrome/extension/scripts/',
-          [path.join('build/dev/uproxy/mocks/chrome_mocks.js')])
+          [path.join('build/src/mocks/chrome_mocks.js')])
 
     jasmine_chromeapp: {
       all: {
@@ -914,7 +914,7 @@ module.exports = (grunt) ->
                   'core.spec.static.js'
         ],
         options: {
-          outdir: 'build/dev/uproxy/integration/'
+          outdir: 'build/src/integration/'
           # Uncomment this for debugging
           # keepRunner: true,
         }

--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ Sublime Text 3 provides a good development experience:
 
 Now, TypeScript files will have syntax highlighting and include support for "jump to definition" and refactoring (renaming).
 
-Several compile errors will remain, namely imports from `../../../third_party`. To workaround, Unix (and OSX) users can create a symlink:
-
- * `cd` to the directory containing the repo
- * `ln -s uproxy-lib/build/third_party ../third_party`
-
-Re-compile, with F7 (and perhaps restart Sublime, just to be sure) to resolve these errors.
-
 ## Run
 
 ### uProxy
@@ -75,8 +68,8 @@ Re-compile, with F7 (and perhaps restart Sublime, just to be sure) to resolve th
 These are the steps to try uProxy in the Chrome browser.
 
 - In Chrome, go to `chrome://extensions`, make sure 'Developer mode' is enabled
-- Click 'Load unpacked extension...' and select `build/dev/uproxy/chrome/app`
-- Click 'Load unpacked extension...' and select `build/dev/uproxy/chrome/extension`
+- Click 'Load unpacked extension...' and select `build/src/chrome/app`
+- Click 'Load unpacked extension...' and select `build/src/chrome/extension`
 
 You need both the uProxy Chrome App and the uProxy Extension.
 
@@ -90,7 +83,7 @@ These are the steps to try uProxy in the Firefox browser.
 Instructions can be found here: https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Installation
     - A quick way to get started is to download/extract the zip mentioned in "Prerequisites"
 
-- Run `cd build/dev/uproxy/firefox`
+- Run `cd build/src/firefox`
 
 - Run `cfx run` and Firefox should launch with the uProxy add-on installed
 
@@ -98,20 +91,20 @@ You can use `grunt build_firefox` from the root directory of the repository to c
 
 ### Demo apps
 
-These can be found at `build/dev/uproxy-lib/samples/`. They are a mix of web sites, browser extensions (Chrome and Firefox), and Node.js apps.
+These can be found at `build/src/samples/`. They are a mix of web sites, browser extensions (Chrome and Firefox), and Node.js apps.
 
 To run web apps:
  * start a webserver, e.g. `python -m SimpleHTTPServer`
- * open the relevant HTML file in your browser, e.g. http://localhost:8000/build/dev/uproxy-lib/samples/simple-freedom-chat/main.html.
+ * open the relevant HTML file in your browser, e.g. http://localhost:8000/build/src/samples/simple-freedom-chat/main.html.
 
 To run Chrome apps:
- - open `chrome://extensions`, enable check Developer Mode, and load the unpacked extension from the relevant directory, e.g. `build/dev/uproxy-lib/samples/simple-socks-chromeapp/`.
+ - open `chrome://extensions`, enable check Developer Mode, and load the unpacked extension from the relevant directory, e.g. `build/src/samples/simple-socks-chromeapp/`.
 
 To run Firefox add-ons:
-- install [jpm](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm) via NPM, e.g. `npm install jpm -g`, `cd` to the relevant directory, e.g. `build/dev/uproxy-lib/samples/simple-socks-firefoxapp/`, and execute ``jpm run -b `which firefox` ``.
+- install [jpm](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/jpm) via NPM, e.g. `npm install jpm -g`, `cd` to the relevant directory, e.g. `build/src/samples/simple-socks-firefoxapp/`, and execute ``jpm run -b `which firefox` ``.
 
 To run Node.js apps:
- - Directly run `node` with the entry point, e.g. `node build/dev/uproxy-lib/samples/zork-node/index.js`
+ - Directly run `node` with the entry point, e.g. `node build/src/samples/zork-node/index.js`
 
 **Note: until freedom-for-node supports core.rtcpeerconnection, this sample will not work**
 

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
   },
   "scripts": {
     "build": "grunt",
-    "clean": "rm -rf node_modules/ build/ .tscache/ third_party/typings/",
+    "clean": "rm -rf node_modules/ build/ third_party/{typings,bower}/",
     "install": "npm run install-bower && npm run install-typings && npm run setup-third-party && npm run build-grunt-deps",
-    "install-bower": "bower install --allow-root --config.interactive=false --config.directory=build/third_party/bower",
+    "install-bower": "bower install --allow-root --config.interactive=false --config.directory=third_party/bower",
     "install-typings": "cd third_party && typings install",
     "setup-third-party": "mkdir -p build/third_party && cp -r third_party/* build/third_party/ && npm run setup-freedom-port-control",
     "build-grunt-deps": "mkdir -p build/tools && cp src/lib/build-tools/*.ts build/tools/ && tsc --module commonjs --noImplicitAny build/tools/*.ts",

--- a/package.json
+++ b/package.json
@@ -79,12 +79,12 @@
   },
   "scripts": {
     "build": "grunt",
-    "clean": "rm -rf node_modules/ build/ third_party/{typings,bower}/",
-    "install": "npm run install-bower && npm run install-typings && npm run setup-third-party && npm run build-grunt-deps",
+    "clean": "rm -rf node_modules/ build/ third_party/{typings,bower}/ .tscache/",
+    "install": "npm run install-bower && npm run install-typings && npm run build-grunt-deps && npm run setup-third-party",
     "install-bower": "bower install --allow-root --config.interactive=false --config.directory=third_party/bower",
     "install-typings": "cd third_party && typings install",
     "setup-third-party": "mkdir -p build/third_party && cp -r third_party/* build/third_party/ && npm run setup-freedom-port-control",
-    "build-grunt-deps": "mkdir -p build/tools && cp src/lib/build-tools/*.ts build/tools/ && tsc --module commonjs --noImplicitAny build/tools/*.ts",
+    "build-grunt-deps": "tsc --project src/lib/build-tools --outDir build/tools/",
     "setup-freedom-port-control": "mkdir -p build/third_party/freedom-port-control && cp -r node_modules/freedom-port-control/dist build/third_party/freedom-port-control/",
     "test": "grunt test"
   }

--- a/replace_xwalk_in_apk.sh
+++ b/replace_xwalk_in_apk.sh
@@ -15,7 +15,7 @@
 ROOT_DIR="$(cd "$(dirname $0)"; pwd)";
 
 if [ "$1" = "debug" ]; then
-  APK_PATH="$ROOT_DIR/build/dev/uproxy/android/platforms/android/build/outputs/apk"
+  APK_PATH="$ROOT_DIR/build/src/android/platforms/android/build/outputs/apk"
 elif [ "$1" = "release" ]; then
   APK_PATH="$ROOT_DIR/build/dist/android/platforms/android/build/outputs/apk"
 else

--- a/src/cca/app/scripts/context.ts
+++ b/src/cca/app/scripts/context.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
 import background_ui = require('../../../generic_ui/scripts/background_ui');

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -1,8 +1,8 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
-/// <reference path='../../../../../third_party/cordova/themeablebrowser.d.ts'/>
-/// <reference path='../../../../../third_party/cordova/webintents.d.ts'/>
-/// <reference path='../../../../../third_party/cordova/tun2socks.d.ts'/>
-/// <reference path='../../../../../third_party/cordova/device.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/cordova/themeablebrowser.d.ts'/>
+/// <reference path='../../../../third_party/cordova/webintents.d.ts'/>
+/// <reference path='../../../../third_party/cordova/tun2socks.d.ts'/>
+/// <reference path='../../../../third_party/cordova/device.d.ts'/>
 
 /**
  * cordova_browser_api.ts

--- a/src/cca/app/scripts/cordova_core_connector.ts
+++ b/src/cca/app/scripts/cordova_core_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 /**
  * cordova_core_connector.ts

--- a/src/cca/app/scripts/main.core-env.ts
+++ b/src/cca/app/scripts/main.core-env.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
-/// <reference path='../../../../../third_party/cordova/splashscreen.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/cordova/splashscreen.d.ts'/>
 
 /**
  * background.ts

--- a/src/chrome/app/polymer/ext-missing.ts
+++ b/src/chrome/app/polymer/ext-missing.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 Polymer({
   downloadExt: function() {

--- a/src/chrome/app/scripts/chrome_ui_connector.ts
+++ b/src/chrome/app/scripts/chrome_ui_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 import browser_connector = require('../../../interfaces/browser_connector');
 import uproxy_core_api = require('../../../interfaces/uproxy_core_api');

--- a/src/chrome/app/scripts/main.core-env.ts
+++ b/src/chrome/app/scripts/main.core-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 /**
  * background.ts

--- a/src/chrome/extension/polymer/app-missing.ts
+++ b/src/chrome/extension/polymer/app-missing.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
 // Launch the Chrome webstore page for the uProxy app,

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 /**
  * background.ts
@@ -22,7 +22,7 @@ import compareVersion = require('compare-version');
 import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
 
 /// <reference path='../../../freedom/typings/social.d.ts' />
-/// <reference path='../../../third_party/chrome/chrome.d.ts'/>
+/// <reference path='../../third_party/chrome/chrome.d.ts'/>
 
 // --------------------- Communicating with the App ----------------------------
 export var browserConnector :ChromeCoreConnector;  // way for ui to speak to a uProxy.CoreApi

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 /**
  * chrome_browser_api.ts

--- a/src/chrome/extension/scripts/chrome_core_connector.spec.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 import background_ui = require('../../../generic_ui/scripts/background_ui');
 import ChromeCoreConnector = require('./chrome_core_connector');

--- a/src/chrome/extension/scripts/chrome_core_connector.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 /**
  * chrome_core_connector.ts

--- a/src/chrome/extension/scripts/chrome_panel_connector.ts
+++ b/src/chrome/extension/scripts/chrome_panel_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 import panel_connector = require('../../../interfaces/panel_connector');
 

--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 
 import core_connector = require('../../../generic_ui/scripts/core_connector');
 import uproxy_core_api = require('../../../interfaces/uproxy_core_api');

--- a/src/chrome/extension/scripts/context.ts
+++ b/src/chrome/extension/scripts/context.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
 import ui_model = require('../../../generic_ui/scripts/model');

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/firefox/firefox.d.ts' />
+/// <reference path='../../../../third_party/firefox/firefox.d.ts' />
 
 /**
  * firefox_browser_api.ts

--- a/src/firefox/data/scripts/firefox_connector.ts
+++ b/src/firefox/data/scripts/firefox_connector.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../../../third_party/firefox/firefox.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/firefox/firefox.d.ts' />
 
 /**
  * firefox_connector.ts

--- a/src/generic_core/constants.ts
+++ b/src/generic_core/constants.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 export const STORAGE_VERSION = 1;
 

--- a/src/generic_core/crypto.ts
+++ b/src/generic_core/crypto.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../lib/arraybuffers/arraybuffers');
 import globals = require('./globals');

--- a/src/generic_core/firewall.spec.ts
+++ b/src/generic_core/firewall.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');

--- a/src/generic_core/firewall.ts
+++ b/src/generic_core/firewall.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * firewall.ts

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * core.ts

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import _ = require('lodash');
 import constants = require('./constants');

--- a/src/generic_core/local-instance.spec.ts
+++ b/src/generic_core/local-instance.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');

--- a/src/generic_core/metrics.spec.ts
+++ b/src/generic_core/metrics.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 

--- a/src/generic_core/metrics.ts
+++ b/src/generic_core/metrics.ts
@@ -1,6 +1,6 @@
-/// <reference path='../../../third_party/random-lib/random-lib.d.ts' />
-/// <reference path='../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../third_party/freedomjs-anonymized-metrics/index.d.ts' />
+/// <reference path='../../third_party/random-lib/random-lib.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/freedomjs-anonymized-metrics/index.d.ts' />
 
 import _ = require('lodash');
 import logging = require('../lib/logging/logging');

--- a/src/generic_core/remote-connection.spec.ts
+++ b/src/generic_core/remote-connection.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /*
  * remote-connection.spec.ts

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * remote-connection.ts

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /*
  * remote-instance.spec.ts

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * remote-instance.ts

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * user.ts

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../third_party/generic/jsurl.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/generic/jsurl.d.ts' />
 
 /**
  * social.ts

--- a/src/generic_core/storage.spec.ts
+++ b/src/generic_core/storage.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 

--- a/src/generic_core/storage.ts
+++ b/src/generic_core/storage.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * storage.ts

--- a/src/generic_core/stored_value.ts
+++ b/src/generic_core/stored_value.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import globals = require('./globals');
 import _ = require('lodash');

--- a/src/generic_core/ui_connector.spec.ts
+++ b/src/generic_core/ui_connector.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
 import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');

--- a/src/generic_core/ui_connector.ts
+++ b/src/generic_core/ui_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import browser_connector = require('../interfaces/browser_connector');
 import globals = require('./globals');

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * core.spec.ts

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import bridge = require('../lib/bridge/bridge');
 import globals = require('./globals');

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='./context.d.ts' />
 
 // This class will set our global settings object as a JSON blob. It will

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -1,6 +1,6 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import translator = require('../scripts/translator');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -1,6 +1,6 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import ui_constants = require('../../interfaces/ui');
 import social = require('../../interfaces/social');

--- a/src/generic_ui/polymer/description.ts
+++ b/src/generic_ui/polymer/description.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 Polymer({
   editDescription: function() {

--- a/src/generic_ui/polymer/dialog.ts
+++ b/src/generic_ui/polymer/dialog.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 // this class covers two different cases: trying to set the dialog to be
 // offscreen and not having correct information on where the dialog should be

--- a/src/generic_ui/polymer/faq-link.ts
+++ b/src/generic_ui/polymer/faq-link.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='./context.d.ts' />
 
 Polymer({

--- a/src/generic_ui/polymer/faq.ts
+++ b/src/generic_ui/polymer/faq.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import translator = require('../scripts/translator');
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');

--- a/src/generic_ui/polymer/i18n-filter.ts
+++ b/src/generic_ui/polymer/i18n-filter.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import translator = require('../scripts/translator');
 var i18n_t = translator.i18n_t;

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import social = require('../../interfaces/social');
 import ui_constants = require('../../interfaces/ui');

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -1,6 +1,6 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import _ = require('lodash');
 import model = require('../scripts/model');

--- a/src/generic_ui/polymer/name-for-network.ts
+++ b/src/generic_ui/polymer/name-for-network.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 Polymer({
   isEmail: function(text :string) {

--- a/src/generic_ui/polymer/network-in-settings.ts
+++ b/src/generic_ui/polymer/network-in-settings.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import translator = require('../scripts/translator');
 import dialogs = require('../scripts/dialogs');

--- a/src/generic_ui/polymer/network-invite-user.ts
+++ b/src/generic_ui/polymer/network-invite-user.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import social = require('../../interfaces/social');
 import translator = require('../scripts/translator');

--- a/src/generic_ui/polymer/proxy-error.ts
+++ b/src/generic_ui/polymer/proxy-error.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 Polymer({
   error: false,

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -1,6 +1,6 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import _ = require('lodash');
 import social = require('../../interfaces/social');

--- a/src/generic_ui/polymer/roster-group.ts
+++ b/src/generic_ui/polymer/roster-group.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 /// <reference path='context.d.ts' />
 
 import _ = require('lodash');

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import ui_constants = require('../../interfaces/ui');
 

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 var ui = ui_context.ui;
 

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 /**
  * Script for the introductory splash screen.

--- a/src/generic_ui/polymer/state.ts
+++ b/src/generic_ui/polymer/state.ts
@@ -1,6 +1,6 @@
 /// <reference path='./context.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts'/>
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts'/>
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
 import panel_connector = require('../../interfaces/panel_connector');
 import social = require('../../interfaces/social');

--- a/src/generic_ui/scripts/background_ui.ts
+++ b/src/generic_ui/scripts/background_ui.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import _ = require('lodash');
 

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 /**
  * core_connector.ts

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import social = require('../../interfaces/social');
 import ui_constants = require('../../interfaces/ui');

--- a/src/generic_ui/scripts/translator.ts
+++ b/src/generic_ui/scripts/translator.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../../node_modules/i18next-client/typescript/i18next.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../node_modules/i18next-client/typescript/i18next.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import i18next = require('i18next-client');
 import xregexp = require('xregexp');

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import user_interface = require('./ui');
 import ui_constants = require('../../interfaces/ui');

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1,7 +1,7 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
-/// <reference path='../../../../third_party/generic/jdenticon.d.ts' />
-/// <reference path='../../../../third_party/generic/jsurl.d.ts' />
-/// <reference path='../../../../third_party/generic/uparams.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/generic/jdenticon.d.ts' />
+/// <reference path='../../../third_party/generic/jsurl.d.ts' />
+/// <reference path='../../../third_party/generic/uparams.d.ts' />
 
 /**
  * ui.ts

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import model = require('./model');
 import user_interface = require('./ui');

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 /**
  * user.ts

--- a/src/integration/core.spec.ts
+++ b/src/integration/core.spec.ts
@@ -1,17 +1,17 @@
-/// <reference path='../../../third_party/jasmine/jasmine.d.ts' />
-/// <reference path='../../../third_party/freedom/freedom-core-env.d.ts' />
-/// <reference path='../../../third_party/typings/lodash/lodash.d.ts' />
-/// <reference path='../../../third_party/chrome/chrome.d.ts' />
+/// <reference path='../../third_party/jasmine/jasmine.d.ts' />
+/// <reference path='../../third_party/freedom/freedom-core-env.d.ts' />
+/// <reference path='../../third_party/typings/lodash/lodash.d.ts' />
+/// <reference path='../../third_party/chrome/chrome.d.ts' />
 
 
 import _ = require('lodash');
-import arraybuffers = require('../../../third_party/uproxy-lib/arraybuffers/arraybuffers');
+import arraybuffers = require('../../third_party/uproxy-lib/arraybuffers/arraybuffers');
 import CoreConnector = require('../generic_ui/scripts/core_connector');
 import credentials = require('./gtalk_credentials');
 import IntegrationTestConnector = require('./integration_test_connector');
-import loggingTypes = require('../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
+import loggingTypes = require('../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 import mock_oauth = require('./mock_oauth');
-import net = require('../../../third_party/uproxy-lib/net/net.types');
+import net = require('../../third_party/uproxy-lib/net/net.types');
 import social = require('../interfaces/social');
 import uproxy_core_api = require('../interfaces/uproxy_core_api');
 import user_interface = require('../interfaces/ui');

--- a/src/integration/test_connection.ts
+++ b/src/integration/test_connection.ts
@@ -1,6 +1,6 @@
-import tcp = require('../../../third_party/uproxy-lib/net/tcp');
-import socks_common = require('../../../third_party/uproxy-lib/socks-common/socks-headers');
-import net = require('../../../third_party/uproxy-lib/net/net.types');
+import tcp = require('../../third_party/uproxy-lib/net/tcp');
+import socks_common = require('../../third_party/uproxy-lib/socks-common/socks-headers');
+import net = require('../../third_party/uproxy-lib/net/net.types');
 
 class ProxyTester {
   private echoServer_ :tcp.Server;

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import net = require('../lib/net/net.types');
 

--- a/src/interfaces/social2.ts
+++ b/src/interfaces/social2.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 // TODO: move this file elsewhere..  this was copied from freedom-social-github
 

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 import loggingTypes = require('../lib/loggingprovider/loggingprovider.types');
 import net = require('../lib/net/net.types');

--- a/src/lib/aqm/aqm.ts
+++ b/src/lib/aqm/aqm.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('../logging/logging');
 

--- a/src/lib/arraybuffers/arraybuffers.spec.ts
+++ b/src/lib/arraybuffers/arraybuffers.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('./arraybuffers');
 

--- a/src/lib/arraybuffers/arraybuffers.ts
+++ b/src/lib/arraybuffers/arraybuffers.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // Returns true if b1 and b2 have exactly the same bytes.
 export function byteEquality(b1: ArrayBuffer, b2: ArrayBuffer): boolean {

--- a/src/lib/bridge/bridge.spec.ts
+++ b/src/lib/bridge/bridge.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/bridge/bridge.ts
+++ b/src/lib/bridge/bridge.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import churn = require('../churn/churn');
 import churn_types = require('../churn/churn.types');

--- a/src/lib/bridge/onetime.spec.ts
+++ b/src/lib/bridge/onetime.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/bridge/onetime.ts
+++ b/src/lib/bridge/onetime.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../third_party/browserify-zlib/browserify-zlib.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/browserify-zlib/browserify-zlib.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import bridge = require('./bridge');
 import churn_types = require('../churn/churn.types');

--- a/src/lib/build-tools/common-grunt-rules.ts
+++ b/src/lib/build-tools/common-grunt-rules.ts
@@ -1,6 +1,6 @@
 // common-grunt-rules
 
-/// <reference path='../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import fs = require('fs');
 import path = require('path');

--- a/src/lib/build-tools/tsconfig.json
+++ b/src/lib/build-tools/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitAny": true
+  }
+}

--- a/src/lib/churn-pipe/churn-pipe.ts
+++ b/src/lib/churn-pipe/churn-pipe.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import aqm = require('../aqm/aqm');
 import caesar = require('../transformers/caesar');

--- a/src/lib/churn-pipe/freedom-module.interface.ts
+++ b/src/lib/churn-pipe/freedom-module.interface.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import churn_types = require('../churn/churn.types');
 import net = require('../net/net.types');

--- a/src/lib/churn-pipe/freedom-module.ts
+++ b/src/lib/churn-pipe/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import ChurnPipe = require('./churn-pipe');
 

--- a/src/lib/churn/candidate.spec.ts
+++ b/src/lib/churn/candidate.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import candidate = require('./candidate');
 import Candidate = candidate.Candidate;

--- a/src/lib/churn/candidate.ts
+++ b/src/lib/churn/candidate.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import net = require('../net/net.types');
 

--- a/src/lib/churn/churn.spec.ts
+++ b/src/lib/churn/churn.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/churn/churn.ts
+++ b/src/lib/churn/churn.ts
@@ -1,6 +1,6 @@
-/// <reference path='../../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
-/// <reference path='../../../../third_party/random-lib/random-lib.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
+/// <reference path='../../../third_party/random-lib/random-lib.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import caesar = require('../transformers/caesar');

--- a/src/lib/churn/xwalk.ts
+++ b/src/lib/churn/xwalk.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import caesar = require('../transformers/caesar');
 import candidate = require('../churn/candidate');

--- a/src/lib/cloud/deployer/freedom-module.ts
+++ b/src/lib/cloud/deployer/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import logging = require('../../logging/logging');
 import loggingTypes = require('../../loggingprovider/loggingprovider.types');

--- a/src/lib/cloud/digitalocean/freedom-module.ts
+++ b/src/lib/cloud/digitalocean/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import Provisioner = require('./provisioner');
 

--- a/src/lib/cloud/digitalocean/provisioner.ts
+++ b/src/lib/cloud/digitalocean/provisioner.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import logging = require('../../logging/logging');
 import Pinger = require('../../net/pinger');

--- a/src/lib/cloud/install/freedom-module.ts
+++ b/src/lib/cloud/install/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import CloudInstaller = require('./installer');
 

--- a/src/lib/cloud/install/installer.ts
+++ b/src/lib/cloud/install/installer.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 require('../social/monkey/process');
 

--- a/src/lib/cloud/social/freedom-module.ts
+++ b/src/lib/cloud/social/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import provider = require('./provider');
 

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 require('../social/monkey/process');
 

--- a/src/lib/copypaste-chat/freedom-module.ts
+++ b/src/lib/copypaste-chat/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import churn = require('../churn/churn');
 import logging = require('../logging/logging');

--- a/src/lib/copypaste-chat/main.core-env.ts
+++ b/src/lib/copypaste-chat/main.core-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 var startButton = document.getElementById('startButton');
 var copyTextarea = <HTMLInputElement>document.getElementById('copy');

--- a/src/lib/copypaste-socks/copypaste-api.ts
+++ b/src/lib/copypaste-socks/copypaste-api.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // 'model' object contains variables about the state of the application.
 // Polymer elements will bind to model so that the elements' style and

--- a/src/lib/copypaste-socks/freedom-module.ts
+++ b/src/lib/copypaste-socks/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import bridge = require('../bridge/bridge');

--- a/src/lib/copypaste-socks/i18n-util.ts
+++ b/src/lib/copypaste-socks/i18n-util.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/i18n/i18n.d.ts' />
+/// <reference path='../../../third_party/i18n/i18n.d.ts' />
 
 // A little utility library for managing translation strings.
 

--- a/src/lib/copypaste-socks/main.core-env.ts
+++ b/src/lib/copypaste-socks/main.core-env.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import signals = require('../webrtc/signals');

--- a/src/lib/copypaste-socks/polymer-components/connection-state.html
+++ b/src/lib/copypaste-socks/polymer-components/connection-state.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <polymer-element name='copypaste-connection-state'>
 
   <template>

--- a/src/lib/copypaste-socks/polymer-components/connection-state.ts
+++ b/src/lib/copypaste-socks/polymer-components/connection-state.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/copypaste-socks/polymer-components/crypto.html
+++ b/src/lib/copypaste-socks/polymer-components/crypto.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <polymer-element name='copypaste-crypto'>
 
   <template>

--- a/src/lib/copypaste-socks/polymer-components/crypto.ts
+++ b/src/lib/copypaste-socks/polymer-components/crypto.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/copypaste-socks/polymer-components/getter.html
+++ b/src/lib/copypaste-socks/polymer-components/getter.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <link rel="import" href='connection-state.html'>
 
 <polymer-element name='copypaste-getter'>

--- a/src/lib/copypaste-socks/polymer-components/getter.ts
+++ b/src/lib/copypaste-socks/polymer-components/getter.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/copypaste-socks/polymer-components/giver.html
+++ b/src/lib/copypaste-socks/polymer-components/giver.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <link rel="import" href='connection-state.html'>
 
 <polymer-element name='copypaste-giver'>

--- a/src/lib/copypaste-socks/polymer-components/giver.ts
+++ b/src/lib/copypaste-socks/polymer-components/giver.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/copypaste-socks/polymer-components/root.html
+++ b/src/lib/copypaste-socks/polymer-components/root.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <link rel="import" href='crypto.html'>
 <link rel="import" href='start.html'>
 <link rel="import" href='giver.html'>

--- a/src/lib/copypaste-socks/polymer-components/root.ts
+++ b/src/lib/copypaste-socks/polymer-components/root.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/copypaste-socks/polymer-components/start.html
+++ b/src/lib/copypaste-socks/polymer-components/start.html
@@ -1,4 +1,4 @@
-<link rel="import" href='../../../../../third_party/bower/polymer/polymer.html'>
+<link rel="import" href='../../../../third_party/bower/polymer/polymer.html'>
 <polymer-element name='copypaste-start'>
 
   <template>

--- a/src/lib/copypaste-socks/polymer-components/start.ts
+++ b/src/lib/copypaste-socks/polymer-components/start.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/polymer/polymer.d.ts' />
+/// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
 import copypaste_api = require('../copypaste-api');
 declare module browserified_exports {

--- a/src/lib/echo/freedom-module.ts
+++ b/src/lib/echo/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('../logging/logging');
 import loggingTypes = require('../loggingprovider/loggingprovider.types');

--- a/src/lib/freedom/mocks/mock-eventhandler.ts
+++ b/src/lib/freedom/mocks/mock-eventhandler.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 // A simple mock implementation of the freedom event handler that lets you cause
 // fake events. Useful for mocking out freedom freedom modules that will raise

--- a/src/lib/freedom/mocks/mock-freedom-in-module-env.ts
+++ b/src/lib/freedom/mocks/mock-freedom-in-module-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 export class MockModuleSelfConstructor implements freedom.ModuleSelfConstructor {
   public provideSynchronous(classFn:Function) : void {}

--- a/src/lib/freedom/mocks/mock-rtcdatachannel.ts
+++ b/src/lib/freedom/mocks/mock-rtcdatachannel.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import RTCConfiguration = freedom.RTCPeerConnection.RTCConfiguration;
 import RTCDataChannelInit = freedom.RTCPeerConnection.RTCDataChannelInit;

--- a/src/lib/freedom/mocks/mock-rtcpeerconnection.ts
+++ b/src/lib/freedom/mocks/mock-rtcpeerconnection.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import RTCConfiguration = freedom.RTCPeerConnection.RTCConfiguration;
 import RTCDataChannelInit = freedom.RTCPeerConnection.RTCDataChannelInit;

--- a/src/lib/handler/aggregate.ts
+++ b/src/lib/handler/aggregate.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // The |Aggregator| interface aggregates objects of type |T| to form a
 // compound object of type |T2|. It may have internal data, including time

--- a/src/lib/handler/events.ts
+++ b/src/lib/handler/events.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // A Handler abstraction for events. This abstraction allows all event handlers
 // to produce an output that can be passed back to the code that causes the

--- a/src/lib/handler/queue.spec.ts
+++ b/src/lib/handler/queue.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import HandlerQueue = require('./queue');
 import Aggregate = require('./aggregate');

--- a/src/lib/handler/queue.ts
+++ b/src/lib/handler/queue.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // This file defines 'handler queues'. These are an abstraction for a stream of
 // events (but think of an event as an element of data to be handled) along with

--- a/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
+++ b/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../../arraybuffers/arraybuffers');
 import socks_headers = require('../../socks/headers');

--- a/src/lib/integration-tests/socks-echo/freedom-module.ts
+++ b/src/lib/integration-tests/socks-echo/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import AbstractProxyIntegrationTest = require('./proxy-integration-test');
 import loggingTypes = require('../../loggingprovider/loggingprovider.types');

--- a/src/lib/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/lib/integration-tests/socks-echo/proxy-integration-test.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../../arraybuffers/arraybuffers');
 import bridge = require('../../bridge/bridge');

--- a/src/lib/integration-tests/socks-echo/slow.core-env.spec.ts
+++ b/src/lib/integration-tests/socks-echo/slow.core-env.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import socks_headers = require('../../socks/headers');
 

--- a/src/lib/integration-tests/tcp/freedom-module.ts
+++ b/src/lib/integration-tests/tcp/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../../arraybuffers/arraybuffers');
 import tcp = require('../../net/tcp');

--- a/src/lib/integration-tests/tcp/tcp.core-env.spec.ts
+++ b/src/lib/integration-tests/tcp/tcp.core-env.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 declare const freedom: freedom.FreedomInCoreEnv;
 

--- a/src/lib/logging/logging.spec.ts
+++ b/src/lib/logging/logging.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 import MockFreedomEventHandler = require('../freedom/mocks/mock-eventhandler');

--- a/src/lib/logging/logging.ts
+++ b/src/lib/logging/logging.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import loggingProviderTypes = require('../loggingprovider/loggingprovider.types');
 import CircularJSON = require('circular-json');

--- a/src/lib/loggingprovider/freedom-module.ts
+++ b/src/lib/loggingprovider/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 export import logging_provider = require('./loggingprovider');
 

--- a/src/lib/loggingprovider/loggingprovider.spec.ts
+++ b/src/lib/loggingprovider/loggingprovider.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // Setup freedom mock environment.
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');

--- a/src/lib/loggingprovider/loggingprovider.ts
+++ b/src/lib/loggingprovider/loggingprovider.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('./loggingprovider.types');
 

--- a/src/lib/nat/probe.ts
+++ b/src/lib/nat/probe.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import logging = require('../logging/logging');

--- a/src/lib/net/counter.spec.ts
+++ b/src/lib/net/counter.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import counter = require('./counter');
 

--- a/src/lib/net/counter.ts
+++ b/src/lib/net/counter.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // Wraps asycnronous function calls, tracking the number of calls still
 // resolving and invoking a function once that number reaches zero *and* a

--- a/src/lib/net/linefeeder.spec.ts
+++ b/src/lib/net/linefeeder.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import linefeeder = require('./linefeeder');

--- a/src/lib/net/linefeeder.ts
+++ b/src/lib/net/linefeeder.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import queue = require('../handler/queue');

--- a/src/lib/net/pinger.ts
+++ b/src/lib/net/pinger.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('../logging/logging');
 import promises = require('../promises/promises');

--- a/src/lib/net/tcp.spec.ts
+++ b/src/lib/net/tcp.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/net/tcp.ts
+++ b/src/lib/net/tcp.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('../logging/logging');
 import handler = require('../handler/queue');

--- a/src/lib/pool/pool.spec.ts
+++ b/src/lib/pool/pool.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/pool/pool.ts
+++ b/src/lib/pool/pool.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // This module provides a pool for managing data channels.  It mimics the
 // interface for creating data channels in uproxy-lib's PeerConnection,

--- a/src/lib/promises/promises.spec.ts
+++ b/src/lib/promises/promises.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import promises = require('./promises');
 

--- a/src/lib/promises/promises.ts
+++ b/src/lib/promises/promises.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // Invokes f up to maxAttempts number of times, resolving with its result
 // on the first success and rejecting on the maxAttempts-th failure, waiting,

--- a/src/lib/queue/queue.spec.ts
+++ b/src/lib/queue/queue.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import queue = require('./queue');
 import Queue = queue.Queue;

--- a/src/lib/rtc-to-net/proxyconfig.ts
+++ b/src/lib/rtc-to-net/proxyconfig.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import uproxy_core_api = require('../../interfaces/uproxy_core_api');
 

--- a/src/lib/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -1,7 +1,7 @@
 // Server which handles SOCKS connections over WebRTC datachannels and send them
 // out to the internet and sending back over WebRTC the responses.
 
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import handler = require('../handler/queue');

--- a/src/lib/samples/freedom-module-runner-chromeapp/background.core-env.ts
+++ b/src/lib/samples/freedom-module-runner-chromeapp/background.core-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../../third_party/typings/index.d.ts' />
 
 declare const freedom: freedom.FreedomInCoreEnv;
 

--- a/src/lib/simple-chat/freedom-module.ts
+++ b/src/lib/simple-chat/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import churn = require('../churn/churn');
 import logging = require('../logging/logging');

--- a/src/lib/simple-chat/main.core-env.ts
+++ b/src/lib/simple-chat/main.core-env.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 var sendButtonA = document.getElementById('sendButtonA');
 var sendButtonB = document.getElementById('sendButtonB');

--- a/src/lib/simple-socks/freedom-module.ts
+++ b/src/lib/simple-socks/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import bridge = require('../bridge/bridge');
 import logging = require('../logging/logging');

--- a/src/lib/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/lib/socks-to-rtc/socks-to-rtc.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/socks-to-rtc/socks-to-rtc.ts
+++ b/src/lib/socks-to-rtc/socks-to-rtc.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import handler = require('../handler/queue');

--- a/src/lib/socks/headers.spec.ts
+++ b/src/lib/socks/headers.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import Socks = require('./headers');
 

--- a/src/lib/socks/headers.ts
+++ b/src/lib/socks/headers.ts
@@ -2,7 +2,7 @@
   For the RFC for socks, see:
     http://tools.ietf.org/html/rfc1928
 */
-/// <reference path='../../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
+/// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
 
 import ipaddr = require('ipaddr.js');
 import net = require('../net/net.types');

--- a/src/lib/transformers/arithmetic.spec.ts
+++ b/src/lib/transformers/arithmetic.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/transformers/caesar.spec.ts
+++ b/src/lib/transformers/caesar.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/transformers/rc4.spec.ts
+++ b/src/lib/transformers/rc4.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
 declare let freedom: freedom.FreedomInModuleEnv;

--- a/src/lib/transformers/rc4.ts
+++ b/src/lib/transformers/rc4.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../../third_party/simple-rc4/simple-rc4.d.ts' />
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/simple-rc4/simple-rc4.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import crypto = require('crypto');
 import logging = require('../logging/logging');

--- a/src/lib/uprobe/freedom-module.ts
+++ b/src/lib/uprobe/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import logging = require('../logging/logging');
 import loggingTypes = require('../loggingprovider/loggingprovider.types');

--- a/src/lib/webrtc/datachannel.spec.ts
+++ b/src/lib/webrtc/datachannel.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import MockFreedomRtcDataChannel = require('../freedom/mocks/mock-rtcdatachannel');
 

--- a/src/lib/webrtc/datachannel.ts
+++ b/src/lib/webrtc/datachannel.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // DataPeer - a class that wraps peer connections and data channels.
 //

--- a/src/lib/webrtc/peerconnection.spec.ts
+++ b/src/lib/webrtc/peerconnection.spec.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import MockFreedomRtcDataChannel =
   require('../freedom/mocks/mock-rtcdatachannel');

--- a/src/lib/webrtc/peerconnection.ts
+++ b/src/lib/webrtc/peerconnection.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import datachannel = require('./datachannel');
 import handler = require('../handler/queue');

--- a/src/lib/webrtc/signals.ts
+++ b/src/lib/webrtc/signals.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 // This enum describes a simple signal message protocol for establishing P2P
 // connections. TODO: rename to more accurately describe the intended

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../../third_party/typings/index.d.ts' />
+/// <reference path='../../../third_party/typings/index.d.ts' />
 
 import arraybuffers = require('../arraybuffers/arraybuffers');
 import bridge = require('../bridge/bridge');

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -1,4 +1,4 @@
-/// <reference path='../../../third_party/typings/index.d.ts' />
+/// <reference path='../../third_party/typings/index.d.ts' />
 
 /**
  * freedom-mocks.ts


### PR DESCRIPTION
Changes:
* install the bower dependencies into the `src/third_party/bower` directory
* move the code to be built from `build/dev/uproxy` to `build/src`

The directory structure when developing becomes the same as when building, making it easier to reason about it, and getting proper editor support without the need for workarounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2655)
<!-- Reviewable:end -->
