### PR TITLE
revert #2630 + suggested refactor

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -304,7 +304,10 @@ module.exports = (grunt) ->
         cwd: '<%= iosDistPath %>'
         command: '<%= ccaJsPath %> prepare'
       }
-      rmIosBuild: {
+      cleanAndroid: {
+        command: 'rm -rf <%= androidDevPath %>; rm -rf <%= androidDistPath %>'
+      }
+      cleanIos: {
         command: 'rm -rf <%= iosDevPath %>; rm -rf <%= iosDistPath %>'
       }
       androidReplaceXwalkDev: {
@@ -1142,6 +1145,7 @@ module.exports = (grunt) ->
 
   # Mobile OS build tasks
   grunt.registerTask 'build_android', [
+    'exec:cleanAndroid'
     'build_cca'
     'exec:ccaCreateDev'
     'exec:ccaPlatformAndroidDev'
@@ -1170,7 +1174,7 @@ module.exports = (grunt) ->
   ]
 
   grunt.registerTask 'build_ios', [
-    'exec:rmIosBuild'
+    'exec:cleanIos'
     'build_cca'
     'exec:ccaCreateIosDev'
     'exec:ccaAddPluginsIosBuild'
@@ -1233,10 +1237,10 @@ module.exports = (grunt) ->
   ]
 
   # Builds all code, including the "dist" build, but skips
-  # linting and testing which can both be annoying and slow.
+  # iOS and Android as well as
+  # ts-linting and testing which can be annoying and slow.
   # jshint is here because catches hard syntax errors, etc.
   grunt.registerTask 'build', [
-    'exec:rmIosBuild'
     'build_chrome'
     'build_firefox'
     'build_cca'


### PR DESCRIPTION
Running `grunt build_android` after a successful `grunt build_android` invariably fails, apparently due to #2630. This reverts that change, and also renames the related tasks to use the term "clean" as suggested in #2630. With this change it is again possible to run `grunt build_android` twice in a row successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2664)
<!-- Reviewable:end -->
