### PR TITLE
Remove Cloud from mobile builds

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -425,9 +425,9 @@ module.exports = (grunt) ->
             ].concat(uiDistFiles, coreDistFiles, universalDistFiles)
             dest: ccaDistPath
           }
-          { # CCA dist freedom-module.json
+          { # CCA freedom-module.json
             expand: true
-            cwd: 'src/generic_core/cca_dist_build/'
+            cwd: 'src/generic_core/cca_build/'
             src: ['*']
             dest: path.join(ccaDistPath, 'generic_core')
           }
@@ -589,6 +589,12 @@ module.exports = (grunt) ->
             expand: true, cwd: genericPath
             src: ['*.js']
             dest: ccaDevPath + '/generic'
+          }
+          { # CCA freedom-module.json
+            expand: true
+            cwd: 'src/generic_core/cca_build/'
+            src: ['*']
+            dest: path.join(ccaDevPath, 'generic_core')
           }
         ]
 

--- a/src/generic_core/cca_build/freedom-module.json
+++ b/src/generic_core/cca_build/freedom-module.json
@@ -38,14 +38,6 @@
     "portControl": {
       "url": "../freedom-port-control/port-control.json",
       "api": "portControl"
-    },
-    "CLOUDPROVIDER-digitalocean": {
-      "url": "../lib/cloud/digitalocean/freedom-module.json",
-      "api": "digitalocean"
-    },
-    "cloudinstall": {
-      "url": "../lib/cloud/install/freedom-module.json",
-      "api": "cloudinstall"
     }
   },
   "permissions": [

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -22,13 +22,21 @@ var inviteUser = {
         ui.i18nSanitizeHtml(ui.i18n_t('WE_WONT_POST_LEARN_MORE')),
         this.$.weWontPostLearnMore);
 
-    this.$.inviteUserPanel.open();
+    if (this.model.networkNames.length === 1) {
+      // Special case: there is only one supported network.  Skip the chooser.
+      this.loginWithNetwork(this.model.networkNames[0]);
+    } else {
+      this.$.inviteUserPanel.open();
+    }
   },
   closeInviteUserPanel: function() {
     this.$.inviteUserPanel.close();
   },
   networkTapped: function(event: Event, detail: Object, target: HTMLElement) {
     var networkName = target.getAttribute('data-network');
+    this.loginWithNetwork(networkName);
+  },
+  loginWithNetwork: function(networkName: string) {
     if (networkName === 'Cloud') {
       return this.cloudInstall();
     }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -1064,6 +1064,14 @@ export class UserInterface implements ui_constants.UiApi {
     this.model.networkNames = state.networkNames;
     this.model.cloudProviderNames = state.cloudProviderNames;
     this.availableVersion = state.availableVersion;
+
+    if (this.model.cloudProviderNames.length === 0) {
+      // No deployment provider, so remove cloud from the UI's network list.
+      this.model.networkNames = this.model.networkNames.filter((name) => {
+        return name !== 'Cloud';
+      });
+    }
+
     if (!state.globalSettings.language) {
       // Set state.globalSettings.language based on browser settings:
       // Choose the first language in navigator.languages we have available.


### PR DESCRIPTION
This change also "short-circuits" the invite pane if there is
only one network, and instead goes directly into that network's
login flow.

I've also changed to a unified freedom-module.json for mobile
dev and dist builds, to make sure we are testing the same
behavior that we are releasing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2670)

<!-- Reviewable:end -->
