### PR TITLE
Make dev builds use no-op stats reporting.

### DIFF
--- a/src/generic_core/dev_build/freedom-module.json
+++ b/src/generic_core/dev_build/freedom-module.json
@@ -39,10 +39,6 @@
       "url": "../lib/loggingprovider/freedom-module.json",
       "api": "logginglistener"
     },
-    "metrics": {
-      "url": "../freedomjs-anonymized-metrics/anonmetrics.json",
-      "api": "metrics"
-    },
     "churnPipe": {
       "url": "../lib/churn-pipe/freedom-module.json",
       "api": "churnPipe"

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -78,7 +78,7 @@ export var effectiveMessageVersion = () : number => {
   return settings.force_message_version || constants.MESSAGE_VERSION;
 }
 
-export var metrics = freedom['metrics'] ?
+export const metrics = freedom['metrics'] ?
     new metrics_module.FreedomMetrics(storage) :
     new metrics_module.NoOpMetrics();
 

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -78,7 +78,9 @@ export var effectiveMessageVersion = () : number => {
   return settings.force_message_version || constants.MESSAGE_VERSION;
 }
 
-export var metrics = new metrics_module.Metrics(storage);
+export var metrics = freedom['metrics'] ?
+    new metrics_module.FreedomMetrics(storage) :
+    new metrics_module.NoOpMetrics();
 
 export var publicKey :string;
 export var pgp :freedom.PgpProvider.PgpProvider = freedom['pgp']();

--- a/src/generic_core/metrics.spec.ts
+++ b/src/generic_core/metrics.spec.ts
@@ -48,10 +48,10 @@ var storageValues = {metrics: {
   on_cloud: {}
 }};
 
-describe('metrics_module.Metrics', () => {
+describe('metrics_module.FreedomMetrics', () => {
   it('Loads data from storage', (done) => {
     var storage = new MockStorage(storageValues);
-    var metrics = new metrics_module.Metrics(storage);
+    var metrics = new metrics_module.FreedomMetrics(storage);
     metrics.onceLoaded_.then(() => {
       expect(metrics.data_.successes.reduce(0,add)).toEqual(1);
       expect(metrics.data_.attempts.reduce(0,add)).toEqual(2);
@@ -61,7 +61,7 @@ describe('metrics_module.Metrics', () => {
 
   it('Sets values to 0 if no data is in storage', (done) => {
     var storage = new MockStorage({});
-    var metrics = new metrics_module.Metrics(storage);
+    var metrics = new metrics_module.FreedomMetrics(storage);
     metrics.onceLoaded_.then(() => {
       expect(metrics.data_.successes.reduce(0,add)).toEqual(0);
       expect(metrics.data_.attempts.reduce(0,add)).toEqual(0);
@@ -72,7 +72,7 @@ describe('metrics_module.Metrics', () => {
   it('Increment adds to the values in storage and saves', (done) => {
     var storage = new MockStorage(storageValues);
     spyOn(storage, 'save').and.callThrough();
-    var metrics = new metrics_module.Metrics(storage);
+    var metrics = new metrics_module.FreedomMetrics(storage);
     metrics.onceLoaded_.then(() => {
       expect(metrics.data_.successes.reduce(0,add)).toEqual(1);
       expect(metrics.data_.attempts.reduce(0,add)).toEqual(2);
@@ -87,7 +87,7 @@ describe('metrics_module.Metrics', () => {
 
   it('getReport reports obfuscated metric values', (done) => {
     var storage = new MockStorage(storageValues);
-    var metrics = new metrics_module.Metrics(storage);
+    var metrics = new metrics_module.FreedomMetrics(storage);
     metrics.getReport(networkInfo).then((payload :any) => {
       expect(payload['success-v3']).toBeDefined();
       expect(payload['success-v3']).not.toEqual(1);
@@ -114,7 +114,7 @@ describe('metrics_module.DailyMetricsReporter', () => {
 
   beforeEach(() => {
     jasmine.clock().install();
-    mockedMetrics = new metrics_module.Metrics(emptyStorage);
+    mockedMetrics = new metrics_module.FreedomMetrics(emptyStorage);
   });
 
   afterEach(() => {

--- a/src/generic_core/metrics.ts
+++ b/src/generic_core/metrics.ts
@@ -157,7 +157,23 @@ function sumMetrics(mets :NetMetrics) :number{
   }
 }
 
-export class Metrics {
+export interface Metrics {
+  increment(name :string) : void;
+  userCount(network: string, userName :string, friendCount:number) : void;
+  getReport(natInfo:uproxy_core_api.NetworkInfo) : Promise<Object>;
+  reset() : void;
+}
+
+export class NoOpMetrics implements Metrics {
+  public increment(name :string) {}
+  public userCount(network: string, userName :string, friendCount:number) {}
+  public getReport(natInfo:uproxy_core_api.NetworkInfo) {
+    return new Promise((F, R) => {});  // Never provide a report.
+  }
+  public reset() {}
+}
+
+export class FreedomMetrics implements Metrics {
   public onceLoaded_ :Promise<void>;  // Only public for tests
   private add_ :Updater<number>;
   private metricsProvider_ :freedom_AnonymizedMetrics;

--- a/src/generic_core/metrics.ts
+++ b/src/generic_core/metrics.ts
@@ -165,10 +165,18 @@ export interface Metrics {
 }
 
 export class NoOpMetrics implements Metrics {
-  public increment(name :string) {}
-  public userCount(network: string, userName :string, friendCount:number) {}
+  public increment(name :string) {
+    log.debug('No-op metrics ignoring increment for %1', name);
+  }
+  public userCount(network: string, userName :string, friendCount:number) {
+    log.debug('No-op metrics ignoring user count: %1, %2, %3',
+        network, userName, friendCount);
+  }
   public getReport(natInfo:uproxy_core_api.NetworkInfo) {
-    return new Promise((F, R) => {});  // Never provide a report.
+    log.debug('No-op metrics ignoring report request');
+    // To avoid contaminating the production metrics with empty reports, we
+    // return a promise that never resolves at all.
+    return new Promise((F, R) => {});
   }
   public reset() {}
 }

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -84,7 +84,7 @@ describe('social_network.FreedomNetwork', () => {
   beforeEach(() => {
     // Spy / override log messages to keep test output clean.
     spyOn(console, 'log');
-    metrics = new rappor_metrics.Metrics(null);
+    metrics = new rappor_metrics.FreedomMetrics(null);
   });
 
   it('initialize networks', () => {


### PR DESCRIPTION
This target produces a special release build that has metrics
reporting disabled, so that it can be used for automated or
random testing without contaminating our usage metrics.

This also introduces a mechanism for various builds to include
different default settings.

Arguably required for #2673.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2692)
<!-- Reviewable:end -->
