### PR TITLE
fix broken generic_core tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1196,11 +1196,6 @@ module.exports = function(grunt) {
     Rule.getTests('src', 'generic_core'),
     Rule.getTests('src', 'generic_ui/scripts')
   ).map((test) => {
-      // TODO: Fix and re-enable these tests (Issue #2727).
-      if (test === 'generic_core/remote-connection' ||
-          test === 'generic_core/remote-instance') {
-        return [];
-      }
       return Rule.buildAndRunTest(test, grunt);
     })
   ));

--- a/src/generic_core/remote-connection.spec.ts
+++ b/src/generic_core/remote-connection.spec.ts
@@ -146,8 +146,8 @@ describe('remote_connection.RemoteConnection', () => {
 
       start.then(() => {
         // trigger the events
-        socksToRtc.events['bytesReceivedFromPeer'](1234);
-        socksToRtc.events['bytesSentToPeer'](4321);
+        socksToRtc.bytesReceivedFromPeer.handle(1234);
+        socksToRtc.bytesSentToPeer.handle(4321);
 
         // updateSpy should not get called immediately for byte updates
         jasmine.clock().tick(1);

--- a/src/mocks/rtc-to-net.ts
+++ b/src/mocks/rtc-to-net.ts
@@ -1,9 +1,11 @@
+import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
 import handler_queue = require('../lib/handler/queue');
 
 export class RtcToNetMock { // TODO implements rtc_to_net.RtcToNet {
   public signalsForPeer = new handler_queue.Queue<Object, void>();
   public bytesReceivedFromPeer = new handler_queue.Queue<number, void>();
   public bytesSentToPeer = new handler_queue.Queue<number, void>();
+  public statusUpdates = new handler_queue.Queue<rtc_to_net.Status, void>();
 
   public resolveReady :() => void;
   public rejectReady :(v :Object) => void;

--- a/src/mocks/socks-to-rtc.ts
+++ b/src/mocks/socks-to-rtc.ts
@@ -2,8 +2,6 @@ import handler = require('../lib/handler/queue');
 import net = require('../lib/net/net.types');
 
 export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
-  public events :{ [event :string] :(...args :Object[]) => void } = {};
-
   public resolveStart :(v :Object) => void;
   public rejectStart :(v :Object) => void;
 
@@ -23,10 +21,6 @@ export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
   }
 
   public handleSignalFromPeer = () => {
-  }
-
-  public on = (name :string, fn :(...args :Object[]) => void) => {
-    this.events[name] = fn;
   }
 
   // TODO: remove onceStopping_ when

--- a/src/mocks/socks-to-rtc.ts
+++ b/src/mocks/socks-to-rtc.ts
@@ -1,3 +1,4 @@
+import handler = require('../lib/handler/queue');
 import net = require('../lib/net/net.types');
 
 export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
@@ -5,6 +6,11 @@ export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
 
   public resolveStart :(v :Object) => void;
   public rejectStart :(v :Object) => void;
+
+  public signalsForPeer = new handler.Queue<Object, void>();
+
+  public bytesReceivedFromPeer = new handler.Queue<number, void>();
+  public bytesSentToPeer = new handler.Queue<number, void>();
 
   public start = () => {
     return new Promise<net.Endpoint>((resolve, reject) => {


### PR DESCRIPTION
Fixes:
https://github.com/uProxy/uproxy/issues/2727

A few things had happened:
 * incomplete removal of `SocksToRtc`'s freedom.js wrapper forgot to update the `SocksToRtc` mock https://github.com/uProxy/uproxy/pull/2635
 * Tor re-proxy UX work forgot to update the `RtcToNet` mock https://github.com/uProxy/uproxy/pull/2602

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2730)
<!-- Reviewable:end -->
