### PR TITLE
Improve Android build performance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1161,6 +1161,13 @@ module.exports = function(grunt) {
     'exec:ccaBuildAndroid', 
     'exec:androidReplaceXwalkDev'
   ]);
+  registerTask(grunt, 'build_android_cca', [
+    // Android build task that does not recreate the Cordova environment.
+    // Should only be used for building CCA modules and after running
+    // build_android, without cleaning, initially at least once.
+    'build_cca',
+    'exec:ccaBuildAndroid',
+  ]);
   registerTask(grunt, 'release_android', [
     'build_cca', 
     'copy:dist', 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1152,21 +1152,22 @@ module.exports = function(grunt) {
   
   // Mobile OS build tasks
   registerTask(grunt, 'build_android', [
+    // Builds Android from scratch by recreating the Cordova environment.
     'exec:cleanAndroid',
-    'build_cca', 
-    'exec:ccaCreateDev', 
+    'build_cca',
+    'exec:ccaCreateDev',
     'exec:ccaPlatformAndroidDev',
-    'exec:ccaAddPluginsAndroidDev', 
-    'copy:cca_splash_dev', 
-    'exec:ccaBuildAndroid', 
-    'exec:androidReplaceXwalkDev'
+    'exec:ccaAddPluginsAndroidDev',
+    'copy:cca_splash_dev',
+    'build_android_cca'
   ]);
-  registerTask(grunt, 'build_android_cca', [
+  registerTask(grunt, 'build_android_ui', [
     // Android build task that does not recreate the Cordova environment.
     // Should only be used for building CCA modules and after running
     // build_android, without cleaning, initially at least once.
     'build_cca',
     'exec:ccaBuildAndroid',
+    'exec:androidReplaceXwalkDev'
   ]);
   registerTask(grunt, 'release_android', [
     'build_cca', 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1159,9 +1159,9 @@ module.exports = function(grunt) {
     'exec:ccaPlatformAndroidDev',
     'exec:ccaAddPluginsAndroidDev',
     'copy:cca_splash_dev',
-    'build_android_cca'
+    'build_android_lite'
   ]);
-  registerTask(grunt, 'build_android_ui', [
+  registerTask(grunt, 'build_android_lite', [
     // Android build task that does not recreate the Cordova environment.
     // Should only be used for building CCA modules and after running
     // build_android, without cleaning, initially at least once.

--- a/src/cca/app/config.xml
+++ b/src/cca/app/config.xml
@@ -7,7 +7,11 @@
         <preference name="deployment-target" value="7.0"/>
         <hook type="before_run" src="hooks/iosrtc-swift-support.js"/>
     </platform>
+
+    <!-- This plugin allows us to select the architecture (ARM and/or x86)
+         to build the Android APK. The default is only ARM. -->
     <plugin name="cordova-build-architecture" spec="https://github.com/MBuchalik/cordova-build-architecture.git#v1.0.1" source="git" />
+
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <platform name="android">
         <config-file target="AndroidManifest.xml" parent="./application/activity/[@android:name='MainActivity']">

--- a/src/cca/app/config.xml
+++ b/src/cca/app/config.xml
@@ -4,9 +4,10 @@
     <preference name="SplashScreenDelay" value="20000" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <platform name="ios">
-        <preference name="deployment-target" value="7.0"/> 
+        <preference name="deployment-target" value="7.0"/>
         <hook type="before_run" src="hooks/iosrtc-swift-support.js"/>
     </platform>
+    <plugin name="cordova-build-architecture" spec="https://github.com/MBuchalik/cordova-build-architecture.git#v1.0.1" source="git" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
     <platform name="android">
         <config-file target="AndroidManifest.xml" parent="./application/activity/[@android:name='MainActivity']">


### PR DESCRIPTION
* Register Grunt task to build only modified CCA files (i.e. html, typescript), and not recreate the environment.
* Add [cordova-build-architecture](https://github.com/MBuchalik/cordova-build-architecture) in order to only build an ARM APK - previously, built both ARM and x86 APKs.
* Improves the first invocation of `grunt build_android` by ~20%. Subsequent `grunt build_android_cca` tasks improve the current performance by ~75%.
* See #2720 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2741)
<!-- Reviewable:end -->
