### PR TITLE
don't close invite panel before showing cloud panel

### DIFF
--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -69,7 +69,6 @@ var inviteUser = {
     }
   },
   cloudInstall: function() {
-    this.closeInviteUserPanel();
     this.$.installCloud.open();
   },
   loginTapped: function() {


### PR DESCRIPTION
I can't think of or find any reason for the current behavior, but maybe I'm missing something.

Before this change:

![before](https://cloud.githubusercontent.com/assets/64992/18187316/6e3b8e76-7076-11e6-90a9-36d58bfe3054.gif)

Note the momentary display of the empty roster before showing the cloud panel, creating a briefly jarring transition. This can be worse on mobile, where hardware is less powerful and [unfortunate resize hacks](https://github.com/uProxy/uproxy/issues/2743) conspire to give UI animations quite the hard time.

Also note that after hitting back, the UI jumps all the way back to the empty roster, rather than going back to the invite screen.

After this change:

![after](https://cloud.githubusercontent.com/assets/64992/18187314/6966bdf8-7076-11e6-9497-60948a5e5023.gif)

Smoother UX, no?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2744)
<!-- Reviewable:end -->
