### PR TITLE
Prevent user from accidentally logging out of cloud social network

### DIFF
--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -227,6 +227,9 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     if (null === network) {
       log.warn('Could not logout of network', networkName);
       return;
+    } else if (network.name === 'Cloud') {
+      log.error('Cannot logout from Cloud');
+      return Promise.reject(new Error('Cannot logout from Cloud'));
     }
 
     return network.logout().then(() => {

--- a/src/generic_ui/polymer/settings.html
+++ b/src/generic_ui/polymer/settings.html
@@ -10,9 +10,8 @@
 <link rel='import' href='network-in-settings.html'>
 
 <polymer-element name='uproxy-settings'>
-
   <template>
-    <style>
+    <style is='custom-style'>
     :host {
       position: absolute;
       display: inline-block;
@@ -129,9 +128,25 @@
       border-bottom: solid 1px;
       border-color: rgb(238, 238, 238);
     }
-
     #accountChooser div {
       margin-top: 30px;
+    }
+    #languageLink paper-dropdown-menu {
+      border-bottom: 0px;
+      font-size: 14px;
+      margin: 0;
+      padding-left: 7px;
+      padding-bottom: 0px;
+    }
+    #languageLink core-icon {
+      height: 18px !important;
+      width: 18px !important;
+    }
+    #languageLink paper-item {
+      font-size: 15px;
+    }
+    #languageLink paper-item::shadow .button-content {
+      padding: 0;
     }
     </style>
     <uproxy-state id="state"></uproxy-state>
@@ -185,6 +200,20 @@
           <core-icon icon="help"></core-icon>
           <span class='label'>{{ "GET_HELP" | $$(model.globalSettings.language) }}</span>
         </uproxy-faq-link>
+        <div id='languageLink'>
+          <core-icon icon='language'></core-icon>
+          <paper-dropdown-menu label='{{ "LANGUAGE" | $$ }}'>
+            <paper-dropdown class="dropdown" valign="bottom">
+                <core-menu class="menu" on-core-select='{{ updateLanguage }}'>
+                    <template repeat='{{ l in languages }}'>
+                      <paper-item languageCode='{{ l.languageCode }}'>
+                        <bdi>{{ l.language }}</bdi>
+                      </paper-item>
+                    </template>
+                </core-menu>
+            </paper-dropdown>
+          </paper-dropdown-menu>
+        </div> <!-- end of #languageLink -->
 
         <uproxy-link on-tap='{{ openAdvancedSettingsForm }}' role='button'>
           <core-icon icon="settings"></core-icon>
@@ -205,7 +234,7 @@
           <span class='label'>{{ "RESTART" | $$(model.globalSettings.language) }}</span>
         </uproxy-link>
 
-        <uproxy-link on-tap='{{ logOut }}' hidden?="{{model.onlineNetworks.length==0}}" role='button'>
+        <uproxy-link on-tap='{{ logOut }}' hidden?="{{ !showLogoutButton }}" role='button'>
           <core-icon icon="uproxy-icons:logout"></core-icon>
           <span class='label'>{{ "LOGOUT" | $$(model.globalSettings.language) }}</span>
         </uproxy-link>


### PR DESCRIPTION
Fix https://github.com/uProxy/uproxy/issues/2349:
* The "Log-out of uProxy" button should not appear if the user's only logged-in network is cloud
* If the user does click "Log-out of uProxy" (available when they are logged into a non-cloud social network), this should log out of all networks except cloud
* Added a sanity check in the logout method uproxy_core.ts to fail if the UI attempts to logout of cloud.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2747)
<!-- Reviewable:end -->
