### PR TITLE
Be much more aggressive about restart and reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "freedom-port-control": "^0.9.0",
     "freedom-social-firebase": "^2.0.0",
     "freedom-social-github": "^0.1.3",
-    "freedom-social-quiver": "^0.1.0",
+    "freedom-social-quiver": "^0.1.5",
     "freedom-social-wechat": "^0.1.5",
     "freedom-xhr": "^0.0.11",
     "freedomjs-anonymized-metrics": "^0.7.4",

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -58,13 +58,13 @@ class FirefoxBrowserApi implements BrowserAPI {
 
   public startUsingProxy =
       (endpoint: net.Endpoint, bypass: string[],
-       opts: browser_api.ProxyConnectOptions) => {
+       opts: browser_api.ProxyConnectOptions) : Promise<void> => {
     //TODO actually use bypass list
-    port.emit('startUsingProxy', endpoint);
+    return this.promiseEmit('startUsingProxy', endpoint);
   }
 
-  public stopUsingProxy = () => {
-    port.emit('stopUsingProxy');
+  public stopUsingProxy = () : Promise<void> => {
+    return this.promiseEmit('stopUsingProxy');
   }
 
   public bringUproxyToFront = () => {

--- a/src/firefox/lib/glue.js
+++ b/src/firefox/lib/glue.js
@@ -55,11 +55,11 @@ function setUpConnection(freedom, panel, button) {
     }
   }
 
-  panel.port.on('startUsingProxy', function(endpoint) {
+  onPromiseEmit('startUsingProxy', function(endpoint) {
     proxyConfig.startUsingProxy(endpoint);
   });
 
-  panel.port.on('stopUsingProxy', function() {
+  onPromiseEmit('stopUsingProxy', function() {
     proxyConfig.stopUsingProxy();
   });
 

--- a/src/generic_ui/polymer/reconnect.html
+++ b/src/generic_ui/polymer/reconnect.html
@@ -24,7 +24,9 @@
     }
     </style>
 
-    <uproxy-dialog backdrop opened='{{ model.reconnecting }}'
+    <!-- Open this dialog when reconnecting to the social network but not the peer.
+         If we are reconnecting to the peer, that dialog will show progress instead. -->
+    <uproxy-dialog backdrop opened='{{ model.reconnecting && !core.disconnectedWhileProxying}}'
         layered='false' id='reconnectDialog' autoCloseDisabled='true'>
       <div>
         <p>{{ "ATTEMPTING_RECONNECT" | $$(model.globalSettings.language) }}</p>

--- a/src/generic_ui/polymer/reconnect.ts
+++ b/src/generic_ui/polymer/reconnect.ts
@@ -8,5 +8,6 @@ Polymer({
   },
   ready: function() {
     this.model = ui_context.model;
+    this.core = ui_context.core;
   }
 });

--- a/src/generic_ui/polymer/root.html
+++ b/src/generic_ui/polymer/root.html
@@ -459,11 +459,12 @@
       <div id="disconnectDialogText">
         <h1>{{ "DISCONNECTED_TITLE" | $$(model.globalSettings.language) }}</h1>
         <div id='progressWrapper' hidden?='{{ !ui.mapInstanceIdToUser_[core.disconnectedWhileProxying] }}'>
-          <div hidden?='{{ !ui.instanceTryingToGetAccessFrom }}'>
+          <!-- Show the progress element when reconnecting to the peer or social network -->
+          <div hidden?='{{ !ui.instanceTryingToGetAccessFrom && !model.reconnecting }}'>
             <strong>{{ 'RECONNECTING' | $$(model.globalSettings.language) }}</strong>
             <paper-progress indeterminate='true'></paper-progress>
           </div>
-          <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom }}'>
+          <div hidden?='{{ !!ui.instanceTryingToGetAccessFrom || model.reconnecting }}'>
             <strong>{{ 'RECONNECT_FAILED' | $$(model.globalSettings.language) }}</strong>
             <uproxy-button class='dialogButton' on-tap='{{ restartProxying }}'>{{ 'RESTART_PROXYING' | $$(model.globalSettings.language) }}</uproxy-button>
           </div>

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -82,6 +82,11 @@ export class Model {
   // Flag for error connecting to reproxy
   public reproxyError = false;
 
+  // Each entry is a Promise if reconnection is in progress for that network.
+  // The promise resolves if reconnection succeeds, and rejects if it fails or
+  // is canceled.
+  public reconnectPending : {[socialNetwork:string] : Promise<uproxy_core_api.LoginResult>} = {};
+
   // userId is included as an optional parameter because we will eventually
   // want to use it to get an accurate network.  For now, it is ignored and
   // serves to remind us of where we still need to add the info

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -725,17 +725,70 @@ export class UserInterface implements ui_constants.UiApi {
     };
   }
 
-  public restartProxying = () => {
-    this.startGettingFromInstance(this.core.disconnectedWhileProxying,
-                                  this.proxyAccessMode_);
+  // If null, there is no pending restart.
+  // Resolves (after resetting itself to null) in a successful condition.
+  // Rejects (after resetting to null) if it fails.
+  private restartPending_ : Promise<void> = null;
+
+  public restartProxying = () : Promise<void> => {
+    if (!this.core.disconnectedWhileProxying) {
+      // Restart is no longer required.
+      this.restartPending_ = null;
+      return Promise.resolve<void>();
+    }
+    let instancePath =
+        this.getInstancePath_(this.core.disconnectedWhileProxying);
+    let network = instancePath.network.name;
+    if (this.restartPending_) {
+      // Delay the call until after all pending calls have failed.
+      // This makes this function safe to call while pending.
+      this.restartPending_ = this.restartPending_.catch(this.restartProxying);
+    } else if (this.model.reconnectPending[network] || !navigator.onLine) {
+      // Wait for the social network and network interfaces to come up before
+      // restarting the proxy connection.  If the network doesn't come back up,
+      // don't attempt to reconnect.
+      // TODO: Should we get rid of the social network case?  The social network
+      // will also call restartProxying once our sharer comes back online, so it's
+      // arguably redundant and unlikely to work (too early).
+      let networkUp :Promise<any> =
+          this.model.reconnectPending[network] || this.onceOnline_();
+      this.restartPending_ = networkUp.then(() => {
+            this.restartPending_ = null;
+            this.restartProxying();
+          }, (e) => {
+            this.restartPending_ = null;
+            throw e;
+          });
+    } else {
+      this.restartPending_ =
+          this.startGettingFromInstance(this.core.disconnectedWhileProxying,
+              this.proxyAccessMode_).then(() => {
+                this.restartPending_ = null;
+              }, (e) => {
+                this.restartPending_ = null;
+                throw e;
+              });
+    }
+    return this.restartPending_;
   }
 
   public startGettingFromInstance =
       (instanceId :string, accessMode: ProxyAccessMode): Promise<void> => {
     this.instanceTryingToGetAccessFrom = instanceId;
 
-    return this.core.start(this.getInstancePath_(instanceId))
-        .then((endpoint :net.Endpoint) => {
+    // In VPN mode, despite using Android's' VpnBuilder::addDisallowedApplications
+    // API, it seems like we can't start new connections while the VPN is active.
+    // Therefore, we have to disable the VPN before attempting a new connection.
+    // This creates a brief period where traffic can leak ... oh well.
+    // TODO: Investigate this misbehavior.  Is it real?  Is it a bug in Android or
+    // WebRTC?
+    let prepared = this.proxyAccessMode_ === ProxyAccessMode.VPN ?
+        this.browserApi.stopUsingProxy().catch((e) => {}) :
+        Promise.resolve<void>();
+
+    return prepared.then(() => {
+      return this.core.start(this.getInstancePath_(instanceId));
+    }).then((endpoint :net.Endpoint) => {
       this.instanceTryingToGetAccessFrom = null;
       // If we were getting access from some other instance
       // turn down the connection.
@@ -871,8 +924,7 @@ export class UserInterface implements ui_constants.UiApi {
         this.model.removeNetwork(networkMsg.name, networkMsg.userId);
 
         if (!existingNetwork.logoutExpected &&
-            this.supportsReconnect_(networkMsg.name) &&
-            !this.core.disconnectedWhileProxying && !this.instanceGettingAccessFrom_) {
+            this.supportsReconnect_(networkMsg.name)) {
           console.warn('Unexpected logout, reconnecting to ' + networkMsg.name);
           this.reconnect_(networkMsg.name);
         } else {
@@ -933,26 +985,35 @@ export class UserInterface implements ui_constants.UiApi {
       oldUserCategories = user.getCategories();
     }
 
-    user.update(payload);
+    // Update the state of this user to reflect the latest update.  Returns
+    // the IDs of online instances that were not previously known to be online.
+    let newOnlineInstances = user.update(payload);
 
     for (var i = 0; i < payload.allInstanceIds.length; ++i) {
       this.mapInstanceIdToUser_[payload.allInstanceIds[i]] = user;
     }
 
-    for (var i = 0; i < payload.offeringInstances.length; i++) {
-      var gettingState = payload.offeringInstances[i].localGettingFromRemote;
-      var instanceId = payload.offeringInstances[i].instanceId;
-      if (gettingState === social.GettingState.GETTING_ACCESS) {
+    newOnlineInstances.forEach((instance) => {
+      let gettingState = instance.localGettingFromRemote;
+      let instanceId = instance.instanceId;
+      if (instanceId === this.core.disconnectedWhileProxying) {
+        // We were proxying, but got disconnected from our sharer.  Now the
+        // sharer is back online, so start proxying with them again.
+        // TODO: Move this out of the UI.  Having this in the UI creates two
+        // bugs on desktop: (1) restarts won't occur while the UI is closed;
+        // (2) we'll trigger a fresh restart every time the UI is reopened.
+        this.restartProxying();
+      } else if (gettingState === social.GettingState.GETTING_ACCESS) {
+        // If the UI is closed and reopened, this code serves to figure out
+        // if it should be in the connected state or the connecting state. 
         this.startGettingInUiAndConfig(
             instanceId, payload.offeringInstances[i].activeEndpoint,
             this.proxyAccessMode_);
-        break;
       } else if (gettingState === social.GettingState.TRYING_TO_GET_ACCESS) {
         this.instanceTryingToGetAccessFrom = instanceId;
         this.updateGettingStatusBar_();
-        break;
       }
-    }
+    });
 
     for (var i = 0; i < payload.instancesSharingWithLocal.length; i++) {
       this.instancesGivingAccessTo[payload.instancesSharingWithLocal[i]] = true;
@@ -1020,35 +1081,66 @@ export class UserInterface implements ui_constants.UiApi {
     });
   }
 
-  private reconnect_ = (network :string) => {
-    this.model.reconnecting = true;
-    // TODO: add wechat, quiver, github URLs
-    var pingUrl = network == 'Facebook-Firebase-V2'
-        ? 'https://graph.facebook.com' : 'https://www.googleapis.com';
-    this.core.pingUntilOnline(pingUrl).then(() => {
-      // Ensure that the user is still attempting to reconnect (i.e. they
-      // haven't clicked to stop reconnecting while we were waiting for the
-      // ping response).
-      // TODO: this doesn't work quite right if the user is signed into multiple social networks
-      if (this.model.reconnecting) {
-        this.core.login({network: network, loginType: uproxy_core_api.LoginType.RECONNECT}).then(() => {
-          // TODO: we don't necessarily want to hide the reconnect screen, as we might only be reconnecting to 1 of multiple disconnected networks
-          this.stopReconnect();
-        }).catch((e) => {
-          // Reconnect failed, give up.
-          // TODO: this may have only failed for 1 of multiple networks
-          this.stopReconnect();
-          this.showNotification(
-              this.i18n_t('LOGGED_OUT', { network: network }));
+  private onceOnline_ = () : Promise<void> => {
+    if (navigator.onLine) {
+      return Promise.resolve<void>();
+    }
 
-          this.updateView_();
-        });
-      }
+    return new Promise<void>((F, R) => {
+      let onlineListener = () => {
+        // Only listen once.
+        window.removeEventListener('online', onlineListener);
+        // Wait 5 more seconds for DHCP, etc.  Empirically necessary for
+        // reliable reconnect to cloud.
+        // TODO: Find a better solution!
+        setTimeout(F, 5000);
+      };
+      window.addEventListener('online', onlineListener);
     });
   }
 
-  public stopReconnect = () => {
-    this.model.reconnecting = false;
+  private cancelReconnect_: {[network:string]: () => void} = {};
+
+  private reconnect_ = (network :string) => {
+    let cancelable = new Promise<void>((F, R) => {
+      this.cancelReconnect_[network] = R;
+    });
+    let startReconnect = Promise.race<void>([cancelable, this.onceOnline_()]);
+    this.model.reconnecting = true;
+    this.model.reconnectPending[network] = startReconnect.then(() => {
+      return this.core.login({
+        network: network,
+        loginType: uproxy_core_api.LoginType.RECONNECT
+      });
+    });
+    this.model.reconnectPending[network].then(() => {
+      this.stopReconnect(network);
+      if (this.core.disconnectedWhileProxying) {
+        // Retry proxying now that we're connected to the social network again
+        // TODO: Should we get rid of this case?  It's arguably redundant with
+        // the check in syncUser, and also too early (peer might not be online
+        // yet).
+        this.restartProxying();
+      }
+    }, (e) => {
+      // Reconnect failed, give up.
+      this.stopReconnect(network);
+      this.showNotification(this.i18n_t('LOGGED_OUT', { network: network }));
+
+      this.updateView_();
+      throw e;
+    });
+  }
+
+  public stopReconnect = (network:string) => {
+    if (this.cancelReconnect_[network]) {
+      this.cancelReconnect_[network]();
+      delete this.cancelReconnect_[network];
+    }
+    delete this.model.reconnectPending[network];
+    this.model.reconnecting =
+        Object.keys(this.model.reconnectPending).length > 0;
+
   }
 
   public sendFeedback =

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -76,19 +76,20 @@ describe('UI.User', () => {
   });
 
   it('does not change description if only 1 instance', () => {
-    sampleUser.update(makeUpdateMessage({
+    let newInstance = getInstance('instance1', '')
+    expect(sampleUser.update(makeUpdateMessage({
       allInstanceIds: [
         'instance1'
       ],
       offeringInstances: [
-        getInstance('instance1', '')
+        newInstance
       ]
-    }));
+    }))).toContain(newInstance);
     expect(sampleUser.offeringInstances[0].description).toEqual('');
   });
 
   it('updates empty descriptions when multiple instances', () => {
-    sampleUser.update(makeUpdateMessage({
+    expect(sampleUser.update(makeUpdateMessage({
       allInstanceIds: [
         'instance1',
         'instance2',
@@ -99,7 +100,7 @@ describe('UI.User', () => {
         getInstance('instance2', 'laptop'),
         getInstance('instance3', '')
       ]
-    }));
+    })).length).toEqual(3);
     expect(sampleUser.offeringInstances[0].description).toEqual(
         ui.i18n_t('DESCRIPTION_DEFAULT', { number: 1 }));
     expect(sampleUser.offeringInstances[1].description).toEqual('laptop');
@@ -108,14 +109,14 @@ describe('UI.User', () => {
   });
 
   it('show notification if isOffering changes when not ignoring', () => {
-    sampleUser.update(makeUpdateMessage({
+    expect(sampleUser.update(makeUpdateMessage({
       allInstanceIds: [
         'instance1'
       ],
       offeringInstances: [
         getInstance('instance1', '')
       ]
-    }));
+    })).length).toEqual(1);
 
     expect(ui.showNotification).toHaveBeenCalledWith(
         ui.i18n_t('OFFERED_ACCESS_NOTIFICATION', { name: sampleUser.name }),
@@ -142,7 +143,7 @@ describe('UI.User', () => {
   });
 
   it('shows notificaion if isRequesting changes when not ignoring', () => {
-    sampleUser.update(makeUpdateMessage({
+    expect(sampleUser.update(makeUpdateMessage({
       consent: {
         localGrantsAccessToRemote: false,
         localRequestsAccessFromRemote: false,
@@ -150,7 +151,7 @@ describe('UI.User', () => {
         ignoringRemoteUserRequest: false,
         ignoringRemoteUserOffer: false
       }
-    }));
+    })).length).toEqual(0);
     expect(ui.showNotification).toHaveBeenCalledWith(
         ui.i18n_t('REQUESTING_ACCESS_NOTIFICATION', { name: sampleUser.name }),
         { mode: 'share', user: 'fakeuser', network: 'testNetwork' });
@@ -170,7 +171,7 @@ describe('UI.User', () => {
   });
 
   it('does not replace instances', () => {
-    sampleUser.update(makeUpdateMessage({
+    expect(sampleUser.update(makeUpdateMessage({
       allInstanceIds: [
         '1',
         '2'
@@ -179,19 +180,19 @@ describe('UI.User', () => {
         getInstance('1', ''),
         getInstance('2', '')
       ]
-    }));
+    })).length).toEqual(2);
 
     var second = sampleUser.offeringInstances[1];
     expect(second.instanceId).toEqual('2');
 
-    sampleUser.update(makeUpdateMessage({
+    expect(sampleUser.update(makeUpdateMessage({
       allInstanceIds: [
         '2'
       ],
       offeringInstances: [
         getInstance('2', '')
       ]
-    }));
+    })).length).toEqual(0);
 
     expect(sampleUser.offeringInstances[0]).toBe(second);
   });

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -8,8 +8,8 @@ import net = require('../lib/net/net.types');
 export interface BrowserAPI {
   // Configuration and control of the browsers proxy settings.
   startUsingProxy(
-    endpoint: net.Endpoint, bypass: string[], opts: ProxyConnectOptions): void;
-  stopUsingProxy() :void;
+    endpoint: net.Endpoint, bypass: string[], opts: ProxyConnectOptions): Promise<void>;
+  stopUsingProxy() :Promise<void>;
   // Set the browser icon for the extension/add-on.
   setIcon(iconFile :string) :void;
   // Open a new tab if it is not already open


### PR DESCRIPTION
This is a preliminary PR for aggressive reconnection.  With these changes, in principle, uProxy should automatically recover from network disconnections (#2662).

I've only tested this on Android.  Note that Android is distinct from desktop in part because the UI can never be closed (without shutting down the whole app).

In my testing, this works well for Cloud connections.  For Quiver, the results are mixed.  During short disconnections, it seems that Quiver drops messages, which is a serious problem.  For long disconnections (long enough for Quiver to detect the failure and log out, which takes several minutes), this logic sometimes works, but often seems to run into WebRTC-related issues (e.g. no UDP candidates, or candidates only on the defunct VPN interface).

I've added extensive comments to explain the logic.  As noted in the comments, there are several codepaths that could likely be removed, pending more testing and discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2748)
<!-- Reviewable:end -->
