### PR TITLE
Allow handover when starting a connection without stopping the previous

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -680,11 +680,13 @@ export class UserInterface implements ui_constants.UiApi {
 
       // regardless, let the user know
       this.bringUproxyToFront();
-    } else {
-      // Clear the browser proxy settings.  This is necessary in case the
-      // proxy was stopped when the user was signed out of the social network.
-      // In the case where the user clicked stop, this will have no effect
-      // (this function is idempotent).
+    } else if (this.instanceGettingAccessFrom_ === null) {
+      // Clear the browser proxy settings only if there is no active connection.
+      // Otherwise, this is a connection handover and clearing the proxy
+      // settings will interrupt the active session.
+      // This is necessary in case the proxy was stopped when the user was
+      // signed out of the social network. In the case where the user clicked
+      // stop, this will have no effect (this function is idempotent).
       this.browserApi.stopUsingProxy();
     }
 


### PR DESCRIPTION
* Fixes #2740 by only clearing the proxy settings (in Chrome) and stopping the VPN (in Android) when there is no connection switch, i.e. the user hits stop or the proxy gets disconnected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2749)
<!-- Reviewable:end -->
