### PR TITLE
Migrate uProxy to ES6 imports

### DIFF
--- a/src/cca/app/scripts/context.ts
+++ b/src/cca/app/scripts/context.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
-import background_ui = require('../../../generic_ui/scripts/background_ui');
-import ui_model = require('../../../generic_ui/scripts/model');
-import user_interface = require('../../../generic_ui/scripts/ui');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import CordovaCoreConnector = require('./cordova_core_connector');
-import same_context_panel_connector = require('../../../generic_ui/scripts/same_context_panel_connector');
+import * as background_ui from '../../../generic_ui/scripts/background_ui';
+import * as ui_model from '../../../generic_ui/scripts/model';
+import * as user_interface from '../../../generic_ui/scripts/ui';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import CordovaCoreConnector from './cordova_core_connector';
+import * as same_context_panel_connector from '../../../generic_ui/scripts/same_context_panel_connector';
 
 export var browserConnector = new CordovaCoreConnector({
   name: 'uproxy-ui-to-core-connector'

--- a/src/cca/app/scripts/cordova_browser_api.ts
+++ b/src/cca/app/scripts/cordova_browser_api.ts
@@ -12,12 +12,12 @@
  * Derived from chrome_browser_api.ts
  */
 
-import browser_api = require('../../../interfaces/browser_api');
+import * as browser_api from '../../../interfaces/browser_api';
 import ProxyAccessMode = browser_api.ProxyAccessMode;
 import ProxyDisconnectInfo = browser_api.ProxyDisconnectInfo;
 import BrowserAPI = browser_api.BrowserAPI;
-import net = require('../../../lib/net/net.types');
-import Constants = require('../../../generic_ui/scripts/constants');
+import * as net from '../../../lib/net/net.types';
+import * as Constants from '../../../generic_ui/scripts/constants';
 
 enum PopupState {
     NOT_LAUNCHED,
@@ -27,7 +27,7 @@ enum PopupState {
 
 declare var Notification :any; //TODO remove this
 
-class CordovaBrowserApi implements BrowserAPI {
+export class CordovaBrowserApi implements BrowserAPI {
 
   public browserSpecificElement = '';
 
@@ -385,5 +385,3 @@ class CordovaBrowserApi implements BrowserAPI {
     });
   }
 }
-
-export = CordovaBrowserApi;

--- a/src/cca/app/scripts/cordova_core_connector.ts
+++ b/src/cca/app/scripts/cordova_core_connector.ts
@@ -7,12 +7,12 @@
  * core context.
  */
 
-import browser_connector = require('../../../interfaces/browser_connector');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
+import * as browser_connector from '../../../interfaces/browser_connector';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
 
-import user_interface = require('../../../generic_ui/scripts/ui');
+import * as user_interface from '../../../generic_ui/scripts/ui';
 
-class CordovaCoreConnector implements browser_connector.CoreBrowserConnector {
+export default class CordovaCoreConnector implements browser_connector.CoreBrowserConnector {
 
   private appChannel_ :freedom.OnAndEmit<any,any>;
 
@@ -116,5 +116,3 @@ class CordovaCoreConnector implements browser_connector.CoreBrowserConnector {
     }
   }
 }  // class CordovaCoreConnector
-
-export = CordovaCoreConnector

--- a/src/cca/app/scripts/main.core-env.ts
+++ b/src/cca/app/scripts/main.core-env.ts
@@ -8,9 +8,9 @@
  * loaded.
  */
 
-import CordovaBrowserApi = require('./cordova_browser_api');
+import { CordovaBrowserApi } from './cordova_browser_api';
 
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
 
 declare const freedom: freedom.FreedomInCoreEnv;
 

--- a/src/chrome/app/scripts/chrome_oauth.ts
+++ b/src/chrome/app/scripts/chrome_oauth.ts
@@ -2,10 +2,10 @@
  * Chrome oauth provider
  **/
 
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import ChromeUIConnector = require('./chrome_ui_connector');
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import ChromeUIConnector from './chrome_ui_connector';
 
-class Chrome_oauth {
+export default class Chrome_oauth {
   constructor(private options_:{connector:ChromeUIConnector;}) {}
 
   public initiateOAuth(
@@ -48,5 +48,3 @@ class Chrome_oauth {
   }
 
 }  // class Chrome_oauth
-
-export = Chrome_oauth;

--- a/src/chrome/app/scripts/chrome_ui_connector.ts
+++ b/src/chrome/app/scripts/chrome_ui_connector.ts
@@ -1,15 +1,15 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 
-import browser_connector = require('../../../interfaces/browser_connector');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import uproxy_chrome = require('../../../interfaces/chrome');
+import * as browser_connector from '../../../interfaces/browser_connector';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import * as uproxy_chrome from '../../../interfaces/chrome';
 
 // See the ChromeCoreConnector, which communicates to this class.
 // TODO: Finish this class with tests and pull into its own file.
 var UPROXY_CHROME_EXTENSION_ID = 'pjpcdnccaekokkkeheolmpkfifcbibnj';
 var installedFreedomHooks :number[] = [];
 
-class ChromeUIConnector {
+export default class ChromeUIConnector {
 
   private extPort_:chrome.runtime.Port;    // The port that the extension connects to.
   private onCredentials_ :(credentials?:Object, error?:Object) => void;
@@ -137,5 +137,3 @@ class ChromeUIConnector {
     this.onCredentials_ = onCredentials;
   }
 }
-
-export = ChromeUIConnector;

--- a/src/chrome/app/scripts/main.core-env.ts
+++ b/src/chrome/app/scripts/main.core-env.ts
@@ -7,10 +7,10 @@
  * loaded.
  */
 
-import Chrome_oauth = require('./chrome_oauth');
-import ChromeUIConnector = require('./chrome_ui_connector');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import _ = require('lodash');
+import Chrome_oauth from './chrome_oauth';
+import ChromeUIConnector from './chrome_ui_connector';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import * as _ from 'lodash';
 
 declare const freedom: freedom.FreedomInCoreEnv;
 

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -9,17 +9,17 @@
 // Assumes that core_stub.ts has been loaded.
 // UserInterface is defined in 'generic_ui/scripts/ui.ts'.
 
-import background_ui = require('../../../generic_ui/scripts/background_ui');
-import chrome_panel_connector = require('./chrome_panel_connector');
-import ChromeBrowserApi = require('./chrome_browser_api');
-import ChromeCoreConnector = require('./chrome_core_connector');
-import ChromeTabAuth = require('./chrome_tab_auth');
-import Constants = require('../../../generic_ui/scripts/constants');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import user_interface = require('../../../generic_ui/scripts/ui');
+import * as background_ui from '../../../generic_ui/scripts/background_ui';
+import * as chrome_panel_connector from './chrome_panel_connector';
+import ChromeBrowserApi from './chrome_browser_api';
+import ChromeCoreConnector from './chrome_core_connector';
+import ChromeTabAuth from './chrome_tab_auth';
+import * as Constants from '../../../generic_ui/scripts/constants';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import * as user_interface from '../../../generic_ui/scripts/ui';
 
-import compareVersion = require('compare-version');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
+import compareVersion from 'compare-version';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
 
 /// <reference path='../../../freedom/typings/social.d.ts' />
 /// <reference path='../../third_party/chrome/chrome.d.ts'/>

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -18,7 +18,7 @@ import * as Constants from '../../../generic_ui/scripts/constants';
 import CoreConnector from '../../../generic_ui/scripts/core_connector';
 import * as user_interface from '../../../generic_ui/scripts/ui';
 
-import compareVersion from 'compare-version';
+import compareVersion = require('compare-version');
 import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
 
 /// <reference path='../../../freedom/typings/social.d.ts' />

--- a/src/chrome/extension/scripts/chrome_browser_api.ts
+++ b/src/chrome/extension/scripts/chrome_browser_api.ts
@@ -6,10 +6,10 @@
  * Chrome-specific implementation of the Browser API.
  */
 
-import browser_api = require('../../../interfaces/browser_api');
+import * as browser_api from '../../../interfaces/browser_api';
 import BrowserAPI = browser_api.BrowserAPI;
-import net = require('../../../lib/net/net.types');
-import Constants = require('../../../generic_ui/scripts/constants');
+import * as net from '../../../lib/net/net.types';
+import * as Constants from '../../../generic_ui/scripts/constants';
 
 enum PopupState {
     NOT_LAUNCHED,
@@ -19,7 +19,7 @@ enum PopupState {
 
 declare var Notification :any; //TODO remove this
 
-class ChromeBrowserApi implements BrowserAPI {
+export default class ChromeBrowserApi implements BrowserAPI {
 
   public browserSpecificElement = 'uproxy-app-missing';
 
@@ -247,5 +247,3 @@ class ChromeBrowserApi implements BrowserAPI {
     chrome.browserAction.setBadgeText({text: notification});
   }
 }
-
-export = ChromeBrowserApi;

--- a/src/chrome/extension/scripts/chrome_core_connector.spec.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.spec.ts
@@ -1,15 +1,15 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 
-import background_ui = require('../../../generic_ui/scripts/background_ui');
-import ChromeCoreConnector = require('./chrome_core_connector');
-import ChromeBrowserApi = require('./chrome_browser_api');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import UI = require('../../../generic_ui/scripts/ui');
-import chrome_api = require('../../../interfaces/chrome');
+import * as background_ui from '../../../generic_ui/scripts/background_ui';
+import ChromeCoreConnector from './chrome_core_connector';
+import ChromeBrowserApi from './chrome_browser_api';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import * as UI from '../../../generic_ui/scripts/ui';
+import * as chrome_api from '../../../interfaces/chrome';
 import ChromeMessage = chrome_api.ChromeMessage;
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import browser_connector = require('../../../interfaces/browser_connector');
-import Constants = require('../../../generic_ui/scripts/constants');
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import * as browser_connector from '../../../interfaces/browser_connector';
+import * as Constants from '../../../generic_ui/scripts/constants';
 
 var ui :UI.UserInterface;
 

--- a/src/chrome/extension/scripts/chrome_core_connector.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.ts
@@ -5,16 +5,16 @@
  *
  * Handles all connection and communication with the uProxy Chrome App.
  */
-import browser_connector = require('../../../interfaces/browser_connector');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import chrome_api = require('../../../interfaces/chrome');
+import * as browser_connector from '../../../interfaces/browser_connector';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import * as chrome_api from '../../../interfaces/chrome';
 import ChromeMessage = chrome_api.ChromeMessage;
-import Constants = require('../../../generic_ui/scripts/constants');
+import * as Constants from '../../../generic_ui/scripts/constants';
 
 var UPROXY_CHROME_APP_ID :string = 'fmdppkkepalnkeommjadgbhiohihdhii';
 var SYNC_TIMEOUT         :number = 1000;  // milliseconds.
 
-import user_interface = require('../../../generic_ui/scripts/ui');
+import * as user_interface from '../../../generic_ui/scripts/ui';
 
 /**
  * Chrome-Extension-specific uProxy Core API implementation.
@@ -31,7 +31,7 @@ import user_interface = require('../../../generic_ui/scripts/ui');
  * that the user (which is the Extension / UI) won't have to deal with
  * connectivity explicitly, but has the option to chain promises if desired.
  */
-class ChromeCoreConnector implements browser_connector.CoreBrowserConnector {
+export default class ChromeCoreConnector implements browser_connector.CoreBrowserConnector {
 
   private appId_   :string;                // ID of target Chrome App.
   private appPort_ :chrome.runtime.Port;   // For speaking to App.
@@ -274,5 +274,3 @@ class ChromeCoreConnector implements browser_connector.CoreBrowserConnector {
     }
   }
 }  // class ChromeConnector
-
-export = ChromeCoreConnector

--- a/src/chrome/extension/scripts/chrome_panel_connector.ts
+++ b/src/chrome/extension/scripts/chrome_panel_connector.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 
-import panel_connector = require('../../../interfaces/panel_connector');
+import * as panel_connector from '../../../interfaces/panel_connector';
 
 export class ChromePanelConnector implements panel_connector.BrowserPanelConnector {
   public startListening(

--- a/src/chrome/extension/scripts/chrome_tab_auth.ts
+++ b/src/chrome/extension/scripts/chrome_tab_auth.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 
-import core_connector = require('../../../generic_ui/scripts/core_connector');
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import chromeInterface = require('../../../interfaces/chrome');
-import background = require('./background');
+import * as core_connector from '../../../generic_ui/scripts/core_connector';
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import * as chromeInterface from '../../../interfaces/chrome';
+import * as background from './background';
 
 // TODO: write a similar class for Firefox that will implement a common
 // interface as Chrome
@@ -14,7 +14,7 @@ import background = require('./background');
 // - getOauthUrl(redirectUrl): returns the Oauth URL
 // - extractCode(url): returns a promise that fulfills with credentials on
 //   success.
-class ChromeTabAuth {
+export default class ChromeTabAuth {
 
   constructor() {
   }
@@ -64,5 +64,3 @@ class ChromeTabAuth {
         uproxy_core_api.Command.SEND_CREDENTIALS, url);
   }
 }
-
-export = ChromeTabAuth;

--- a/src/chrome/extension/scripts/context.ts
+++ b/src/chrome/extension/scripts/context.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../generic_ui/polymer/context.d.ts' />
 
-import ui_model = require('../../../generic_ui/scripts/model');
-import ui_constants = require('../../../interfaces/ui');
-import user_interface = require('../../../generic_ui/scripts/ui');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import ChromeCoreConnector = require('./chrome_core_connector');
-import browser_connector = require('../../../interfaces/browser_connector');
+import * as ui_model from '../../../generic_ui/scripts/model';
+import * as ui_constants from '../../../interfaces/ui';
+import * as user_interface from '../../../generic_ui/scripts/ui';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import ChromeCoreConnector from './chrome_core_connector';
+import * as browser_connector from '../../../interfaces/browser_connector';
 
 var background_context: any = (<any>chrome.extension.getBackgroundPage()).ui_context;
 export var core :CoreConnector = background_context.core;

--- a/src/firefox/data/scripts/background.ts
+++ b/src/firefox/data/scripts/background.ts
@@ -1,12 +1,12 @@
-import background_ui = require('../../../generic_ui/scripts/background_ui');
-import CoreConnector = require('../../../generic_ui/scripts/core_connector');
-import FirefoxBrowserApi = require('./firefox_browser_api');
-import FirefoxCoreConnector = require('./firefox_connector');
-import ui_model = require('../../../generic_ui/scripts/model');
-import panel_connector = require('../../../interfaces/panel_connector');
-import port = require('./port');
-import same_context_panel_connector = require('../../../generic_ui/scripts/same_context_panel_connector');
-import user_interface = require('../../../generic_ui/scripts/ui');
+import * as background_ui from '../../../generic_ui/scripts/background_ui';
+import CoreConnector from '../../../generic_ui/scripts/core_connector';
+import FirefoxBrowserApi from './firefox_browser_api';
+import FirefoxCoreConnector from './firefox_connector';
+import * as ui_model from '../../../generic_ui/scripts/model';
+import * as panel_connector from '../../../interfaces/panel_connector';
+import * as port from './port';
+import * as same_context_panel_connector from '../../../generic_ui/scripts/same_context_panel_connector';
+import * as user_interface from '../../../generic_ui/scripts/ui';
 
 export var ui   :user_interface.UserInterface;
 export var core :CoreConnector;

--- a/src/firefox/data/scripts/background.ts
+++ b/src/firefox/data/scripts/background.ts
@@ -4,7 +4,7 @@ import FirefoxBrowserApi from './firefox_browser_api';
 import FirefoxCoreConnector from './firefox_connector';
 import * as ui_model from '../../../generic_ui/scripts/model';
 import * as panel_connector from '../../../interfaces/panel_connector';
-import * as port from './port';
+import port from './port';
 import * as same_context_panel_connector from '../../../generic_ui/scripts/same_context_panel_connector';
 import * as user_interface from '../../../generic_ui/scripts/ui';
 

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -8,16 +8,16 @@
 
 import browser_api =  require('../../../interfaces/browser_api');
 import BrowserAPI = browser_api.BrowserAPI;
-import user_interface = require('../../../generic_ui/scripts/ui');
-import net = require('../../../lib/net/net.types');
-import port = require('./port');
+import * as user_interface from '../../../generic_ui/scripts/ui';
+import * as net from '../../../lib/net/net.types';
+import * as port from './port';
 
 interface FullfillAndReject {
   fulfill :Function;
   reject :Function;
 }
 
-class FirefoxBrowserApi implements BrowserAPI {
+export default class FirefoxBrowserApi implements BrowserAPI {
 
   public browserSpecificElement :string;
   public canProxy = true;
@@ -156,5 +156,3 @@ class FirefoxBrowserApi implements BrowserAPI {
     port.emit('setBadgeNotification', notification);
   }
 }
-
-export = FirefoxBrowserApi;

--- a/src/firefox/data/scripts/firefox_browser_api.ts
+++ b/src/firefox/data/scripts/firefox_browser_api.ts
@@ -6,11 +6,11 @@
  * Firefox-specific implementation of the Browser API.
  */
 
-import browser_api =  require('../../../interfaces/browser_api');
+import * as browser_api from '../../../interfaces/browser_api';
 import BrowserAPI = browser_api.BrowserAPI;
 import * as user_interface from '../../../generic_ui/scripts/ui';
 import * as net from '../../../lib/net/net.types';
-import * as port from './port';
+import port from './port';
 
 interface FullfillAndReject {
   fulfill :Function;

--- a/src/firefox/data/scripts/firefox_connector.ts
+++ b/src/firefox/data/scripts/firefox_connector.ts
@@ -7,14 +7,14 @@
  * Handles all connection and communication with the uProxy core and ui..
  */
 
-import uproxy_core_api = require('../../../interfaces/uproxy_core_api');
-import browser_connector = require('../../../interfaces/browser_connector');
-import port = require('./port');
+import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
+import * as browser_connector from '../../../interfaces/browser_connector';
+import * as port from './port';
 
 /**
  * Firefox-specific uProxy CoreBrowserConnector implementation.
  */
-class FirefoxConnector implements browser_connector.CoreBrowserConnector {
+export default class FirefoxConnector implements browser_connector.CoreBrowserConnector {
 
   public status :browser_connector.StatusObject;
   public onceConnected :Promise<void>;
@@ -62,5 +62,3 @@ class FirefoxConnector implements browser_connector.CoreBrowserConnector {
   }
 
 }  // class FirefoxConnector
-
-export = FirefoxConnector;

--- a/src/firefox/data/scripts/firefox_connector.ts
+++ b/src/firefox/data/scripts/firefox_connector.ts
@@ -9,7 +9,7 @@
 
 import * as uproxy_core_api from '../../../interfaces/uproxy_core_api';
 import * as browser_connector from '../../../interfaces/browser_connector';
-import * as port from './port';
+import port from './port';
 
 /**
  * Firefox-specific uProxy CoreBrowserConnector implementation.

--- a/src/firefox/data/scripts/port.ts
+++ b/src/firefox/data/scripts/port.ts
@@ -1,3 +1,3 @@
 declare var addon :{ port: ContentScriptPort };
 var port = addon.port;
-export = port;
+export default port;

--- a/src/generic/network-options.ts
+++ b/src/generic/network-options.ts
@@ -1,4 +1,4 @@
-import social = require('../interfaces/social');
+import * as social from '../interfaces/social';
 
 function lenMinusOne(keys:string[]) :number {
   return keys.length -1;

--- a/src/generic_core/consent.ts
+++ b/src/generic_core/consent.ts
@@ -1,6 +1,6 @@
-import logging = require('../lib/logging/logging');
-import social = require('../interfaces/social');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as logging from '../lib/logging/logging';
+import * as social from '../interfaces/social';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 //module Consent {
   var log :logging.Log = new logging.Log('consent');

--- a/src/generic_core/crypto.ts
+++ b/src/generic_core/crypto.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../lib/arraybuffers/arraybuffers');
-import globals = require('./globals');
+import * as arraybuffers from '../lib/arraybuffers/arraybuffers';
+import * as globals from './globals';
 import pgp = globals.pgp;
 
 // Sign with private key and encrypt with encryptKey

--- a/src/generic_core/firewall.spec.ts
+++ b/src/generic_core/firewall.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
-import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
+import mockFreedomRtcPeerConnection from '../lib/freedom/mocks/mock-rtcpeerconnection';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -13,8 +13,8 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import freedom_mocks = require('../mocks/freedom-mocks');
-import firewall = require('./firewall');
+import * as freedom_mocks from '../mocks/freedom-mocks';
+import * as firewall from './firewall';
 
 class MockPolicy implements firewall.ResponsePolicy {
   failures : number = 0;

--- a/src/generic_core/firewall.ts
+++ b/src/generic_core/firewall.ts
@@ -16,7 +16,7 @@
  *    visual trickery.  See http://www.unicode.org/reports/tr36/#visual_spoofing
  */
 
-import logging = require('../lib/logging/logging');
+import * as logging from '../lib/logging/logging';
 
 var log :logging.Log = new logging.Log('firewall');
 

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -50,7 +50,7 @@ var exported = {
   rtc_to_net: rtc_to_net,
   globals: globals
 };
-export = exported;
+export default exported;
 
 // Note: Our mechanism for dispatching commands requires that the
 // members of core are bound closures.  E.g.:

--- a/src/generic_core/freedom-module.ts
+++ b/src/generic_core/freedom-module.ts
@@ -12,19 +12,19 @@
  *  - Instances, which is a list of active uProxy installs.
  */
 
-import browser_connector = require('../interfaces/browser_connector');
-import globals = require('./globals');
-import logging = require('../lib/logging/logging');
-import loggingprovider = require('../lib/loggingprovider/loggingprovider.types');
-import metrics_module = require('./metrics');
-import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
-import social_network = require('./social');
-import social = require('../interfaces/social');
-import socks_to_rtc = require('../lib/socks-to-rtc/socks-to-rtc');
-import ui = require('./ui_connector');
-import uproxy_core = require('./uproxy_core');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import version = require('../generic/version');
+import * as browser_connector from '../interfaces/browser_connector';
+import * as globals from './globals';
+import * as logging from '../lib/logging/logging';
+import * as loggingprovider from '../lib/loggingprovider/loggingprovider.types';
+import * as metrics_module from './metrics';
+import * as rtc_to_net from '../lib/rtc-to-net/rtc-to-net';
+import * as social_network from './social';
+import * as social from '../interfaces/social';
+import * as socks_to_rtc from '../lib/socks-to-rtc/socks-to-rtc';
+import * as ui from './ui_connector';
+import * as uproxy_core from './uproxy_core';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as version from '../generic/version';
 
 import ui_connector = ui.connector;
 

--- a/src/generic_core/globals.ts
+++ b/src/generic_core/globals.ts
@@ -1,19 +1,25 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import _ = require('lodash');
-import constants = require('./constants');
-import local_storage = require('./storage');
-import logging = require('../lib/logging/logging');
-import loggingprovider = require('../lib/loggingprovider/loggingprovider.types');
-import metrics_module = require('./metrics');
-import user_interface = require('../interfaces/ui');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as _ from 'lodash';
+import * as constants from './constants';
+import * as local_storage from './storage';
+import * as logging from '../lib/logging/logging';
+import * as loggingprovider from '../lib/loggingprovider/loggingprovider.types';
+import * as metrics_module from './metrics';
+import * as user_interface from '../interfaces/ui';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 
 var log :logging.Log = new logging.Log('globals');
 
 export var storage = new local_storage.Storage();
+
+// Replaces the global storage for tests.
+// TODO: Use dependency injection instead of globals.
+export function setGlobalStorageForTest(newStorage: local_storage.Storage): void {
+  storage = newStorage;
+}
 
 // Initially, the STUN servers are a copy of the default.
 // We need to use slice to copy the values, otherwise modifying this
@@ -46,6 +52,12 @@ export var settings :uproxy_core_api.GlobalSettings = {
 };
 
 export var natType :string = '';
+
+// Sets the NAT type.
+// TODO: Use dependency injection rather than globals.
+export function setGlobalNatType(newNatType: string): void {
+  natType = newNatType;
+}
 
 export var loadSettings :Promise<void> =
   storage.load<uproxy_core_api.GlobalSettings>('globalSettings')

--- a/src/generic_core/key-verify.ts
+++ b/src/generic_core/key-verify.ts
@@ -1,8 +1,7 @@
 import * as crypto from 'crypto';
 import * as globals from './globals';
 import * as logging from '../lib/logging/logging';
-import loggingTypes =
-  require('../lib/loggingprovider/loggingprovider.types');
+import * as loggingTypes from '../lib/loggingprovider/loggingprovider.types';
 var log :logging.Log = new logging.Log('KeyVerify');
 
 // KeyVerify's callbacks API from ZRTP protocol.

--- a/src/generic_core/key-verify.ts
+++ b/src/generic_core/key-verify.ts
@@ -1,6 +1,6 @@
-import crypto = require('crypto');
-import globals = require('./globals');
-import logging = require('../lib/logging/logging');
+import * as crypto from 'crypto';
+import * as globals from './globals';
+import * as logging from '../lib/logging/logging';
 import loggingTypes =
   require('../lib/loggingprovider/loggingprovider.types');
 var log :logging.Log = new logging.Log('KeyVerify');

--- a/src/generic_core/local-instance.spec.ts
+++ b/src/generic_core/local-instance.spec.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
-import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
+import mockFreedomRtcPeerConnection from '../lib/freedom/mocks/mock-rtcpeerconnection';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
     'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -16,8 +16,8 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
 });
 
 
-import local_instance = require('./local-instance');
-import social = require('../interfaces/social');
+import * as local_instance from './local-instance';
+import * as social from '../interfaces/social';
 
 describe('local_instance.LocalInstance', () => {
 

--- a/src/generic_core/local-instance.ts
+++ b/src/generic_core/local-instance.ts
@@ -5,10 +5,10 @@
  * installation.
  */
 
-import globals = require('./globals');
-import logging = require('../lib/logging/logging');
-import Persistent = require('../interfaces/persistent');
-import social = require('../interfaces/social');
+import * as globals from './globals';
+import * as logging from '../lib/logging/logging';
+import Persistent from '../interfaces/persistent';
+import * as social from '../interfaces/social';
 
 import storage = globals.storage;
 

--- a/src/generic_core/metrics.spec.ts
+++ b/src/generic_core/metrics.spec.ts
@@ -1,15 +1,15 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'metrics': () => { return new freedom_mocks.MockMetrics(); },
 });
 
-import metrics_module = require('./metrics');
-import mock_storage = require('../mocks/mock-storage');
+import * as metrics_module from './metrics';
+import * as mock_storage from '../mocks/mock-storage';
 var MockStorage = mock_storage.MockStorage;
 
 var networkInfo = {

--- a/src/generic_core/metrics.ts
+++ b/src/generic_core/metrics.ts
@@ -2,11 +2,11 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 /// <reference path='../../third_party/freedomjs-anonymized-metrics/index.d.ts' />
 
-import _ = require('lodash');
-import logging = require('../lib/logging/logging');
-import random = require('random-lib');
-import storage = require('../interfaces/storage');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as _ from 'lodash';
+import * as logging from '../lib/logging/logging';
+import * as random from 'random-lib';
+import * as storage from '../interfaces/storage';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/generic_core/remote-connection.spec.ts
+++ b/src/generic_core/remote-connection.spec.ts
@@ -8,9 +8,9 @@
  * after that connection is established
  */
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -20,14 +20,14 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import constants = require('./constants');
-import remote_connection = require('./remote-connection');
-import social = require('../interfaces/social');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
-import socks_to_rtc = require('../lib/socks-to-rtc/socks-to-rtc');
-import rtc_to_net_mock = require('../mocks/rtc-to-net');
-import socks_to_rtc_mock = require('../mocks/socks-to-rtc');
+import * as constants from './constants';
+import * as remote_connection from './remote-connection';
+import * as social from '../interfaces/social';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as rtc_to_net from '../lib/rtc-to-net/rtc-to-net';
+import * as socks_to_rtc from '../lib/socks-to-rtc/socks-to-rtc';
+import * as rtc_to_net_mock from '../mocks/rtc-to-net';
+import * as socks_to_rtc_mock from '../mocks/socks-to-rtc';
 
 describe('remote_connection.RemoteConnection', () => {
   var connection :remote_connection.RemoteConnection;

--- a/src/generic_core/remote-connection.ts
+++ b/src/generic_core/remote-connection.ts
@@ -7,18 +7,18 @@
  * It handles the signaling channel between two peers, regardless of permission.
  */
 
-import bridge = require('../lib/bridge/bridge');
-import constants = require('./constants');
-import globals = require('./globals');
-import logging = require('../lib/logging/logging');
-import net = require('../lib/net/net.types');
-import peerconnection = require('../lib/webrtc/peerconnection');
-import rc4 = require('../lib/transformers/rc4');
-import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
-import social = require('../interfaces/social');
-import socks_to_rtc = require('../lib/socks-to-rtc/socks-to-rtc');
-import tcp = require('../lib/net/tcp');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as bridge from '../lib/bridge/bridge';
+import * as constants from './constants';
+import * as globals from './globals';
+import * as logging from '../lib/logging/logging';
+import * as net from '../lib/net/net.types';
+import * as peerconnection from '../lib/webrtc/peerconnection';
+import * as rc4 from '../lib/transformers/rc4';
+import * as rtc_to_net from '../lib/rtc-to-net/rtc-to-net';
+import * as social from '../interfaces/social';
+import * as socks_to_rtc from '../lib/socks-to-rtc/socks-to-rtc';
+import * as tcp from '../lib/net/tcp';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 declare var freedom: freedom.FreedomInModuleEnv;
 

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -9,9 +9,9 @@
  * correct consent values between remote instances.
  */
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -21,20 +21,20 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import remote_user = require('./remote-user');
-import consent = require('./consent');
-import remote_instance = require('./remote-instance');
-import social = require('../interfaces/social');
-import socks_to_rtc = require('../lib/socks-to-rtc/socks-to-rtc');
-import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
-import globals = require('./globals');
-import constants = require('./constants');
-import local_storage = require('./storage');
-import net = require('../lib/net/net.types');
-import local_instance = require('./local-instance');
-import bridge = require('../lib/bridge/bridge');
-import rtc_to_net_mock = require('../mocks/rtc-to-net');
-import socks_to_rtc_mock = require('../mocks/socks-to-rtc');
+import * as remote_user from './remote-user';
+import * as consent from './consent';
+import * as remote_instance from './remote-instance';
+import * as social from '../interfaces/social';
+import * as socks_to_rtc from '../lib/socks-to-rtc/socks-to-rtc';
+import * as rtc_to_net from '../lib/rtc-to-net/rtc-to-net';
+import * as globals from './globals';
+import * as constants from './constants';
+import * as local_storage from './storage';
+import * as net from '../lib/net/net.types';
+import * as local_instance from './local-instance';
+import * as bridge from '../lib/bridge/bridge';
+import * as rtc_to_net_mock from '../mocks/rtc-to-net';
+import * as socks_to_rtc_mock from '../mocks/socks-to-rtc';
 
 describe('remote_instance.RemoteInstance', () => {
 
@@ -111,8 +111,9 @@ describe('remote_instance.RemoteInstance', () => {
     var INSTANCE_ID = 'instance1';
 
     beforeEach((done) => {
-      globals.storage = new local_storage.Storage();
-      globals.storage.reset().then(() => {
+      let testStorage = new local_storage.Storage();
+      globals.setGlobalStorageForTest(testStorage);
+      testStorage.reset().then(() => {
         var network = <social.Network><any>jasmine.createSpyObj(
             'network', ['getUser']);
         network['getStorePath'] = function() { return 'networkPath'; };

--- a/src/generic_core/remote-instance.ts
+++ b/src/generic_core/remote-instance.ts
@@ -8,23 +8,23 @@
  * consent, proxying status, and any other signalling information.
  */
 
-import arraybuffers = require('../lib/arraybuffers/arraybuffers');
-import bridge = require('../lib/bridge/bridge');
-import consent = require('./consent');
-import crypto = require('./crypto');
-import globals = require('./globals');
-import key_verify = require('./key-verify');
-import _ = require('lodash');
-import logging = require('../lib/logging/logging');
-import net = require('../lib/net/net.types');
-import Persistent = require('../interfaces/persistent');
-import remote_connection = require('./remote-connection');
-import remote_user = require('./remote-user');
-import signals = require('../lib/webrtc/signals');
-import social = require('../interfaces/social');
-import ui_connector = require('./ui_connector');
-import user_interface = require('../interfaces/ui');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as arraybuffers from '../lib/arraybuffers/arraybuffers';
+import * as bridge from '../lib/bridge/bridge';
+import * as consent from './consent';
+import * as crypto from './crypto';
+import * as globals from './globals';
+import * as key_verify from './key-verify';
+import * as _ from 'lodash';
+import * as logging from '../lib/logging/logging';
+import * as net from '../lib/net/net.types';
+import Persistent from '../interfaces/persistent';
+import * as remote_connection from './remote-connection';
+import * as remote_user from './remote-user';
+import * as signals from '../lib/webrtc/signals';
+import * as social from '../interfaces/social';
+import * as ui_connector from './ui_connector';
+import * as user_interface from '../interfaces/ui';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 import storage = globals.storage;
 import ui = ui_connector.connector;

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -11,17 +11,17 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import social = require('../interfaces/social');
-import remote_user = require('./remote-user');
-import remote_instance = require('./remote-instance');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import local_storage = require('./storage');
-import consent = require('./consent');
+import * as social from '../interfaces/social';
+import * as remote_user from './remote-user';
+import * as remote_instance from './remote-instance';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as local_storage from './storage';
+import * as consent from './consent';
 
-import constants = require('./constants');
-import globals = require('./globals');
+import * as constants from './constants';
+import * as globals from './globals';
 import storage = globals.storage;
-import local_instance = require('./local-instance');
+import * as local_instance from './local-instance';
 
 describe('remote_user.User', () => {
   // Prepare a fake Social.Network object to construct User on top of.

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -23,16 +23,16 @@
  * client, but with the 'uProxy' non-human client.
  */
 
-import bridge = require('../lib/bridge/bridge');
-import consent = require('./consent');
-import globals = require('./globals');
-import _ = require('lodash');
-import logging = require('../lib/logging/logging');
-import Persistent = require('../interfaces/persistent');
-import remote_instance = require('./remote-instance');
-import social = require('../interfaces/social');
-import ui = require('./ui_connector');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as bridge from '../lib/bridge/bridge';
+import * as consent from './consent';
+import * as globals from './globals';
+import * as _ from 'lodash';
+import * as logging from '../lib/logging/logging';
+import Persistent from '../interfaces/persistent';
+import * as remote_instance from './remote-instance';
+import * as social from '../interfaces/social';
+import * as ui from './ui_connector';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 import storage = globals.storage;
 

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -11,15 +11,15 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import social = require('../interfaces/social');
-import rappor_metrics = require('./metrics');
-import social_network = require('./social');
-import local_storage = require('./storage');
-import local_instance = require('./local-instance');
-import constants = require('./constants');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as social from '../interfaces/social';
+import * as rappor_metrics from './metrics';
+import * as social_network from './social';
+import * as local_storage from './storage';
+import * as local_instance from './local-instance';
+import * as constants from './constants';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
-import ui_connector = require('./ui_connector');
+import * as ui_connector from './ui_connector';
 import ui = ui_connector.connector;
 
 

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -21,19 +21,19 @@
  *    ...
  */
 
-import firewall = require('./firewall');
-import globals = require('./globals');
-import local_instance = require('./local-instance');
-import logging = require('../lib/logging/logging');
-import metrics = require('./metrics');
-import network_options = require('../generic/network-options');
-import remote_user = require('./remote-user');
-import social = require('../interfaces/social');
-import freedom_social2 = require('../interfaces/social2');
-import ui_connector = require('./ui_connector');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as firewall from './firewall';
+import * as globals from './globals';
+import * as local_instance from './local-instance';
+import * as logging from '../lib/logging/logging';
+import * as metrics from './metrics';
+import * as network_options from '../generic/network-options';
+import * as remote_user from './remote-user';
+import * as social from '../interfaces/social';
+import * as freedom_social2 from '../interfaces/social2';
+import * as ui_connector from './ui_connector';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 import ui = ui_connector.connector;
-import jsurl = require('jsurl');
+import * as jsurl from 'jsurl';
 import storage = globals.storage;
 
 declare var freedom: freedom.FreedomInModuleEnv;

--- a/src/generic_core/storage.spec.ts
+++ b/src/generic_core/storage.spec.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -11,11 +11,9 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import local_storage = require('./storage');
-import globals = require('./globals');
+import * as local_storage from './storage';
+import * as globals from './globals';
 import storage = globals.storage;
-
-local_storage.DEBUG_STATESTORAGE = false;
 
 // Depends on the MockFreedomStorage that executes everything synchronously.
 describe('local_storage.Storage', () => {

--- a/src/generic_core/storage.ts
+++ b/src/generic_core/storage.ts
@@ -6,7 +6,7 @@
  * Provides a promise-based interface to the storage provider.
  */
 
-import logging = require('../lib/logging/logging');
+import * as logging from '../lib/logging/logging';
 
 declare var freedom: freedom.FreedomInModuleEnv;
 
@@ -14,9 +14,6 @@ var log :logging.Log = new logging.Log('storage');
 
 // Platform-independent storage provider.
 var fStorage :freedom.Storage.Storage = freedom['core.storage']();
-
-// Set false elsewhere to disable log messages (ie. from jasmine)
-export var DEBUG_STATESTORAGE = true;
 
 /**
  * Contains all state for uProxy's core.

--- a/src/generic_core/stored_value.ts
+++ b/src/generic_core/stored_value.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import globals = require('./globals');
-import _ = require('lodash');
+import * as globals from './globals';
+import * as _ from 'lodash';
 
-class StoredValue<T> {
+export default class StoredValue<T> {
   private loaded_ :Promise<void>;
 
   // accepts the name of the key to load from storage and the default value for
@@ -46,5 +46,3 @@ class StoredValue<T> {
     return saved;
   }
 }
-
-export = StoredValue;

--- a/src/generic_core/ui_connector.spec.ts
+++ b/src/generic_core/ui_connector.spec.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
-import mockFreedomRtcPeerConnection = require('../lib/freedom/mocks/mock-rtcpeerconnection');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
+import * as mockFreedomRtcPeerConnection from '../lib/freedom/mocks/mock-rtcpeerconnection';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
 });
@@ -14,9 +14,9 @@ var fakeFreedom = freedom();
 var nextCommand = 12345;
 var nextPromise = 12345;
 
-import ui_connector = require('./ui_connector');
+import * as ui_connector from './ui_connector';
 import UIConnector = ui_connector.UIConnector;
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 describe('UIConnector', () => {
   var connector :UIConnector;

--- a/src/generic_core/ui_connector.ts
+++ b/src/generic_core/ui_connector.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import browser_connector = require('../interfaces/browser_connector');
-import globals = require('./globals');
-import logging = require('../lib/logging/logging');
-import social_network = require('./social');
-import social = require('../interfaces/social');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as browser_connector from '../interfaces/browser_connector';
+import * as globals from './globals';
+import * as logging from '../lib/logging/logging';
+import * as social_network from './social';
+import * as social from '../interfaces/social';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 declare var freedom: freedom.FreedomInModuleEnv;
 

--- a/src/generic_core/uproxy_core.spec.ts
+++ b/src/generic_core/uproxy_core.spec.ts
@@ -9,9 +9,9 @@
  * requirement and ensures consistency.
  */
 
-import freedomMocker = require('../lib/freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 
-import freedom_mocks = require('../mocks/freedom-mocks');
+import * as freedom_mocks from '../mocks/freedom-mocks';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -21,14 +21,14 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import globals = require('./globals');
-import social = require('../interfaces/social');
-import social_network = require('./social');
-import remote_user = require('./remote-user');
-import local_instance = require('./local-instance');
-import remote_instance = require('./remote-instance');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import uproxy_core = require('./uproxy_core');
+import * as globals from './globals';
+import * as social from '../interfaces/social';
+import * as social_network from './social';
+import * as remote_user from './remote-user';
+import * as local_instance from './local-instance';
+import * as remote_instance from './remote-instance';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as uproxy_core from './uproxy_core';
 
 describe('Core', () => {
 

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -1,27 +1,27 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import bridge = require('../lib/bridge/bridge');
-import globals = require('./globals');
-import constants = require('./constants');
-import _ = require('lodash');
-import key_verify = require('./key-verify');
-import logging = require('../lib/logging/logging');
-import loggingTypes = require('../lib/loggingprovider/loggingprovider.types');
-import net = require('../lib/net/net.types');
-import nat_probe = require('../lib/nat/probe');
-import remote_connection = require('./remote-connection');
-import remote_instance = require('./remote-instance');
-import remote_user = require('./remote-user');
-import user = require('./remote-user');
-import social_network = require('./social');
-import social = require('../interfaces/social');
-import socks = require('../lib/socks/headers');
-import StoredValue = require('./stored_value');
-import tcp = require('../lib/net/tcp');
-import ui_connector = require('./ui_connector');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import version = require('../generic/version');
-import freedomXhr = require('freedom-xhr');
+import * as bridge from '../lib/bridge/bridge';
+import * as globals from './globals';
+import * as constants from './constants';
+import * as _ from 'lodash';
+import * as key_verify from './key-verify';
+import * as logging from '../lib/logging/logging';
+import * as loggingTypes from '../lib/loggingprovider/loggingprovider.types';
+import * as net from '../lib/net/net.types';
+import * as nat_probe from '../lib/nat/probe';
+import * as remote_connection from './remote-connection';
+import * as remote_instance from './remote-instance';
+import * as remote_user from './remote-user';
+import * as user from './remote-user';
+import * as social_network from './social';
+import * as social from '../interfaces/social';
+import * as socks from '../lib/socks/headers';
+import StoredValue from './stored_value';
+import * as tcp from '../lib/net/tcp';
+import * as ui_connector from './ui_connector';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as version from '../generic/version';
+import * as freedomXhr from 'freedom-xhr';
 
 import ui = ui_connector.connector;
 import storage = globals.storage;
@@ -477,7 +477,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
             return 'NAT classification timed out.';
           }),
           nat_probe.probe().then((natType:string) => {
-            globals.natType = natType;
+            globals.setGlobalNatType(natType);
             // Store NAT type for five minutes. This way, if the user previews
             // their logs, and then submits them shortly after, we do not need
             // to determine the NAT type once for the preview, and once for
@@ -486,7 +486,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
             // switch between networks while troubleshooting), then we might want
             // to remove caching.
             clearTimeout(this.natResetTimeout_);
-            this.natResetTimeout_ = setTimeout(() => {globals.natType = '';}, 300000);
+            this.natResetTimeout_ = setTimeout(() => {globals.setGlobalNatType('');}, 300000);
             return globals.natType;
           })
         ]);

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -7,8 +7,8 @@
 // a message from the core that overwrites while this window is open, and the
 // user clicks set, we will overwrite the core change.
 
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import translator = require('../scripts/translator');
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as translator from '../scripts/translator';
 
 export enum StatusState {
   EMPTY,

--- a/src/generic_ui/polymer/cloud-install.ts
+++ b/src/generic_ui/polymer/cloud-install.ts
@@ -2,10 +2,10 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import translator = require('../scripts/translator');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import ui_constants = require('../../interfaces/ui');
-import user = require('../scripts/user');
+import * as translator from '../scripts/translator';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as ui_constants from '../../interfaces/ui';
+import * as user from '../scripts/user';
 
 var ui = ui_context.ui;
 

--- a/src/generic_ui/polymer/contact.ts
+++ b/src/generic_ui/polymer/contact.ts
@@ -2,13 +2,13 @@
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import ui_constants = require('../../interfaces/ui');
-import social = require('../../interfaces/social');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import _ = require('lodash');
-import translator = require('../scripts/translator');
-import user = require('../scripts/user');
-import dialogs = require('../scripts/dialogs');
+import * as ui_constants from '../../interfaces/ui';
+import * as social from '../../interfaces/social';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as _ from 'lodash';
+import * as translator from '../scripts/translator';
+import * as user from '../scripts/user';
+import * as dialogs from '../scripts/dialogs';
 
 const DEFAULT_PROVIDER = 'digitalocean';
 

--- a/src/generic_ui/polymer/context.d.ts
+++ b/src/generic_ui/polymer/context.d.ts
@@ -1,5 +1,5 @@
 // TODO: figure out why this line is causing compilation to fail
-//import ui_constants = require('../../interfaces/ui');
+//import * as ui_constants from '../../interfaces/ui';
 
 // TODO: replace any types with real interfaces.
 

--- a/src/generic_ui/polymer/faq.ts
+++ b/src/generic_ui/polymer/faq.ts
@@ -1,7 +1,7 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 var ui = ui_context.ui;
 

--- a/src/generic_ui/polymer/feedback.ts
+++ b/src/generic_ui/polymer/feedback.ts
@@ -1,9 +1,9 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import translator = require('../scripts/translator');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import dialogs = require('../scripts/dialogs');
+import * as translator from '../scripts/translator';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as dialogs from '../scripts/dialogs';
 
 var ui = ui_context.ui;
 var core = ui_context.core;

--- a/src/generic_ui/polymer/i18n-filter.ts
+++ b/src/generic_ui/polymer/i18n-filter.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import translator = require('../scripts/translator');
+import * as translator from '../scripts/translator';
 var i18n_t = translator.i18n_t;
 
 declare var PolymerExpressions: any;

--- a/src/generic_ui/polymer/instance.ts
+++ b/src/generic_ui/polymer/instance.ts
@@ -1,13 +1,13 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import social = require('../../interfaces/social');
-import ui_constants = require('../../interfaces/ui');
-import net = require('../../lib/net/net.types');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import translator = require('../scripts/translator');
-import user_interface = require('../scripts/ui');
-import browser_api = require('../../interfaces/browser_api');
+import * as social from '../../interfaces/social';
+import * as ui_constants from '../../interfaces/ui';
+import * as net from '../../lib/net/net.types';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as translator from '../scripts/translator';
+import * as user_interface from '../scripts/ui';
+import * as browser_api from '../../interfaces/browser_api';
 
 // generic_ui/scripts/ui.ts: UserInterface
 var ui = ui_context.ui;

--- a/src/generic_ui/polymer/invite-user.ts
+++ b/src/generic_ui/polymer/invite-user.ts
@@ -2,11 +2,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import _ = require('lodash');
-import model = require('../scripts/model');
-import translator = require('../scripts/translator');
-import user_interface = require('../scripts/ui');
-import dialogs = require('../scripts/dialogs');
+import * as _ from 'lodash';
+import * as model from '../scripts/model';
+import * as translator from '../scripts/translator';
+import * as user_interface from '../scripts/ui';
+import * as dialogs from '../scripts/dialogs';
 
 var ui = ui_context.ui;
 var core = ui_context.core;

--- a/src/generic_ui/polymer/logs.ts
+++ b/src/generic_ui/polymer/logs.ts
@@ -1,5 +1,5 @@
 
-import translator_module = require('../scripts/translator');
+import * as translator_module from '../scripts/translator';
 
 declare var PolymerExpressions: any;
 

--- a/src/generic_ui/polymer/network-in-settings.ts
+++ b/src/generic_ui/polymer/network-in-settings.ts
@@ -1,8 +1,8 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import translator = require('../scripts/translator');
-import dialogs = require('../scripts/dialogs');
+import * as translator from '../scripts/translator';
+import * as dialogs from '../scripts/dialogs';
 
 var ui = ui_context.ui;
 var core = ui_context.core;

--- a/src/generic_ui/polymer/network-invite-user.ts
+++ b/src/generic_ui/polymer/network-invite-user.ts
@@ -1,10 +1,10 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import social = require('../../interfaces/social');
-import translator = require('../scripts/translator');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import dialogs = require('../scripts/dialogs');
+import * as social from '../../interfaces/social';
+import * as translator from '../scripts/translator';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as dialogs from '../scripts/dialogs';
 
 var ui = ui_context.ui;
 var model = ui_context.model;

--- a/src/generic_ui/polymer/reconnect.ts
+++ b/src/generic_ui/polymer/reconnect.ts
@@ -1,5 +1,5 @@
 /// <reference path='./context.d.ts' />
-import ui_constants = require('../../interfaces/ui');
+import * as ui_constants from '../../interfaces/ui';
 
 Polymer({
   logout: function() {

--- a/src/generic_ui/polymer/root.ts
+++ b/src/generic_ui/polymer/root.ts
@@ -2,14 +2,14 @@
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import _ = require('lodash');
-import social = require('../../interfaces/social');
-import translator = require('../scripts/translator');
-import ui_types = require('../../interfaces/ui');
-import user_interface = require('../scripts/ui');
-import user_module = require('../scripts/user');
-import dialogs = require('../scripts/dialogs');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import * as _ from 'lodash';
+import * as social from '../../interfaces/social';
+import * as translator from '../scripts/translator';
+import * as ui_types from '../../interfaces/ui';
+import * as user_interface from '../scripts/ui';
+import * as user_module from '../scripts/user';
+import * as dialogs from '../scripts/dialogs';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 var ui = ui_context.ui;
 var model = ui_context.model;

--- a/src/generic_ui/polymer/roster-group.ts
+++ b/src/generic_ui/polymer/roster-group.ts
@@ -2,9 +2,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 /// <reference path='context.d.ts' />
 
-import _ = require('lodash');
-import ui_constants = require('../../interfaces/ui');
-import user = require('../scripts/user');
+import * as _ from 'lodash';
+import * as ui_constants from '../../interfaces/ui';
+import * as user from '../scripts/user';
 
 var model = ui_context.model;
 

--- a/src/generic_ui/polymer/roster.ts
+++ b/src/generic_ui/polymer/roster.ts
@@ -1,7 +1,7 @@
 /// <reference path='./context.d.ts' />
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import ui_constants = require('../../interfaces/ui');
+import * as ui_constants from '../../interfaces/ui';
 
 Polymer({
   ready: function() {

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -3,13 +3,13 @@
 
 var ui = ui_context.ui;
 
-import _ = require('lodash');
+import * as _ from 'lodash';
 
-import model = require('../scripts/model');
-import translator = require('../scripts/translator');
-import user_interface = require('../scripts/ui');
-import dialogs = require('../scripts/dialogs');
-import ui_constants = require('../../interfaces/ui');
+import * as model from '../scripts/model';
+import * as translator from '../scripts/translator';
+import * as user_interface from '../scripts/ui';
+import * as dialogs from '../scripts/dialogs';
+import * as ui_constants from '../../interfaces/ui';
 
 var languages :Language[] = <Language[]>require('../locales/all/languages.json');
 var core = ui_context.core;

--- a/src/generic_ui/polymer/splash.ts
+++ b/src/generic_ui/polymer/splash.ts
@@ -7,9 +7,9 @@
 
 declare var require :(path :string) => Object;
 
-import ui_constants = require('../../interfaces/ui');
-import translator = require('../scripts/translator');
-import _ = require('lodash');
+import * as ui_constants from '../../interfaces/ui';
+import * as translator from '../scripts/translator';
+import * as _ from 'lodash';
 
 interface Language {
   description :string;

--- a/src/generic_ui/polymer/state.ts
+++ b/src/generic_ui/polymer/state.ts
@@ -2,10 +2,10 @@
 /// <reference path='../../../third_party/typings/index.d.ts'/>
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 
-import panel_connector = require('../../interfaces/panel_connector');
-import social = require('../../interfaces/social');
-import ui = require('../../interfaces/ui');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import * as panel_connector from '../../interfaces/panel_connector';
+import * as social from '../../interfaces/social';
+import * as ui from '../../interfaces/ui';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 //TODO standardize
 interface FullfillAndReject {

--- a/src/generic_ui/polymer/troubleshoot.ts
+++ b/src/generic_ui/polymer/troubleshoot.ts
@@ -1,4 +1,4 @@
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 Polymer({
   analyzingNetwork: false,

--- a/src/generic_ui/scripts/background_ui.ts
+++ b/src/generic_ui/scripts/background_ui.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import _ = require('lodash');
+import * as _ from 'lodash';
 
-import CoreConnector = require('./core_connector');
-import panel_connector = require('../../interfaces/panel_connector');
-import ui = require('../../interfaces/ui');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import CoreConnector from './core_connector';
+import * as panel_connector from '../../interfaces/panel_connector';
+import * as ui from '../../interfaces/ui';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 interface FullfillAndReject {
   fulfill: Function;

--- a/src/generic_ui/scripts/core_connector.ts
+++ b/src/generic_ui/scripts/core_connector.ts
@@ -6,10 +6,10 @@
  * Handles all connection and communication with the uProxy core.
  */
 
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import browser_connector = require('../../interfaces/browser_connector');
-import social = require('../../interfaces/social');
-import net = require('../../lib/net/net.types');
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as browser_connector from '../../interfaces/browser_connector';
+import * as social from '../../interfaces/social';
+import * as net from '../../lib/net/net.types';
 
 interface FullfillAndReject {
   fulfill :Function;
@@ -24,7 +24,7 @@ interface FullfillAndReject {
  *    Core --[ UPDATES  ]--> UI
  *    UI   --[ COMMANDS ]--> Core
  */
-class CoreConnector implements uproxy_core_api.CoreApi {
+export default class CoreConnector implements uproxy_core_api.CoreApi {
 
   // Global unique promise ID.
   private promiseId_ :number = 1;
@@ -250,4 +250,3 @@ class CoreConnector implements uproxy_core_api.CoreApi {
   }
 }  // class CoreConnector
 
-export = CoreConnector;

--- a/src/generic_ui/scripts/dialogs.ts
+++ b/src/generic_ui/scripts/dialogs.ts
@@ -1,5 +1,5 @@
-import translator = require('./translator');
-import ui = require('../../interfaces/ui');
+import * as translator from './translator';
+import * as ui from '../../interfaces/ui';
 
 /**
  * This gets a description object for a dialog that will simply show the text

--- a/src/generic_ui/scripts/model.spec.ts
+++ b/src/generic_ui/scripts/model.spec.ts
@@ -1,6 +1,6 @@
-import model = require('./model');
+import * as model from './model';
 import Model = model.Model;
-import ui_constants = require('../../interfaces/ui');
+import * as ui_constants from '../../interfaces/ui';
 
 describe('model.Model', () => {
   var model :Model;

--- a/src/generic_ui/scripts/model.ts
+++ b/src/generic_ui/scripts/model.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import social = require('../../interfaces/social');
-import ui_constants = require('../../interfaces/ui');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import user_module = require('./user');
+import * as social from '../../interfaces/social';
+import * as ui_constants from '../../interfaces/ui';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as user_module from './user';
 import User = user_module.User;
-import _ = require('lodash');
+import * as _ from 'lodash';
 
 export interface ContactCategory {
   [type :string] :User[];

--- a/src/generic_ui/scripts/same_context_panel_connector.ts
+++ b/src/generic_ui/scripts/same_context_panel_connector.ts
@@ -4,7 +4,7 @@
  * its state will never be altered.  Given that all scripts are running in the
  * same environment, we have an insanely simple way of representing that here
  */
-import panel_connector = require('../../interfaces/panel_connector');
+import * as panel_connector from '../../interfaces/panel_connector';
 
 export class SameContextPanelConnector implements panel_connector.BrowserPanelConnector {
   private connectHandler: panel_connector.PanelConnectHandler;

--- a/src/generic_ui/scripts/translator.ts
+++ b/src/generic_ui/scripts/translator.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../../node_modules/i18next-client/typescript/i18next.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import i18next = require('i18next-client');
-import xregexp = require('xregexp');
+import * as i18next from 'i18next-client';
+import * as xregexp from 'xregexp';
 
 // Example usage of these tests:
 //   isRightToLeft('hi') -> false

--- a/src/generic_ui/scripts/ui.spec.ts
+++ b/src/generic_ui/scripts/ui.spec.ts
@@ -1,18 +1,18 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import user_interface = require('./ui');
-import ui_constants = require('../../interfaces/ui');
-import browser_api = require('../../interfaces/browser_api');
-import background_ui = require('./background_ui');
+import * as user_interface from './ui';
+import * as ui_constants from '../../interfaces/ui';
+import * as browser_api from '../../interfaces/browser_api';
+import * as background_ui from './background_ui';
 import BrowserAPI = browser_api.BrowserAPI;
-import browser_connector = require('../../interfaces/browser_connector');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import CoreConnector = require('./core_connector');
-import social = require('../../interfaces/social');
-import user = require('./user');
+import * as browser_connector from '../../interfaces/browser_connector';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import CoreConnector from './core_connector';
+import * as social from '../../interfaces/social';
+import * as user from './user';
 import User = user.User;
-import Constants = require('./constants');
-import _ = require('lodash');
+import * as Constants from './constants';
+import * as _ from 'lodash';
 
 describe('UI.UserInterface', () => {
   var ui :user_interface.UserInterface;

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -9,28 +9,28 @@
  * Common User Interface state holder and changer.
  */
 
-import _ = require('lodash');
-import ui_constants = require('../../interfaces/ui');
-import background_ui = require('./background_ui');
-import CoreConnector = require('./core_connector');
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
-import browser_api = require('../../interfaces/browser_api');
+import * as _ from 'lodash';
+import * as ui_constants from '../../interfaces/ui';
+import * as background_ui from './background_ui';
+import CoreConnector from './core_connector';
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
+import * as browser_api from '../../interfaces/browser_api';
 import ProxyAccessMode = browser_api.ProxyAccessMode;
 import BrowserAPI = browser_api.BrowserAPI;
 import ProxyDisconnectInfo = browser_api.ProxyDisconnectInfo;
-import net = require('../../lib/net/net.types');
-import user_module = require('./user');
+import * as net from '../../lib/net/net.types';
+import * as user_module from './user';
 import User = user_module.User;
-import social = require('../../interfaces/social');
-import Constants = require('./constants');
-import translator_module = require('./translator');
-import network_options = require('../../generic/network-options');
-import model = require('./model');
-import dialogs = require('./dialogs');
-import jsurl = require('jsurl');
-import uparams = require('uparams');
-import crypto = require('crypto');
-import jdenticon = require('jdenticon');
+import * as social from '../../interfaces/social';
+import * as Constants from './constants';
+import * as translator_module from './translator';
+import * as network_options from '../../generic/network-options';
+import * as model from './model';
+import * as dialogs from './dialogs';
+import * as jsurl from 'jsurl';
+import uparams from 'uparams';
+import * as crypto from 'crypto';
+import * as jdenticon from 'jdenticon';
 
 var NETWORK_OPTIONS = network_options.NETWORK_OPTIONS;
 

--- a/src/generic_ui/scripts/user.spec.ts
+++ b/src/generic_ui/scripts/user.spec.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import model = require('./model');
-import user_interface = require('./ui');
-import translator = require('./translator');
-import user = require('./user');
-import social = require('../../interfaces/social');
-import _ = require('lodash');
+import * as model from './model';
+import * as user_interface from './ui';
+import * as translator from './translator';
+import * as user from './user';
+import * as social from '../../interfaces/social';
+import * as _ from 'lodash';
 
 describe('UI.User', () => {
   var sampleUser :user.User;

--- a/src/generic_ui/scripts/user.ts
+++ b/src/generic_ui/scripts/user.ts
@@ -6,12 +6,12 @@
  * This is the UI-specific representation of a User.
  */
 
-import model = require('./model');
-import social = require('../../interfaces/social');
-import user_interface = require('./ui');
-import translator_module = require('./translator');
-import _ = require('lodash');
-import Constants = require('./constants');
+import * as model from './model';
+import * as social from '../../interfaces/social';
+import * as user_interface from './ui';
+import * as translator_module from './translator';
+import * as _ from 'lodash';
+import * as Constants from './constants';
 
 var i18n_t = translator_module.i18n_t;
 

--- a/src/integration/core.spec.ts
+++ b/src/integration/core.spec.ts
@@ -4,17 +4,17 @@
 /// <reference path='../../third_party/chrome/chrome.d.ts' />
 
 
-import _ = require('lodash');
-import arraybuffers = require('../../third_party/uproxy-lib/arraybuffers/arraybuffers');
-import CoreConnector = require('../generic_ui/scripts/core_connector');
-import credentials = require('./gtalk_credentials');
-import IntegrationTestConnector = require('./integration_test_connector');
-import loggingTypes = require('../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
-import mock_oauth = require('./mock_oauth');
-import net = require('../../third_party/uproxy-lib/net/net.types');
-import social = require('../interfaces/social');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
-import user_interface = require('../interfaces/ui');
+import * as _ from 'lodash';
+import * as arraybuffers from '../../third_party/uproxy-lib/arraybuffers/arraybuffers';
+import CoreConnector from '../generic_ui/scripts/core_connector';
+import * as credentials from './gtalk_credentials';
+import IntegrationTestConnector from './integration_test_connector';
+import * as loggingTypes from '../../third_party/uproxy-lib/loggingprovider/loggingprovider.types';
+import * as mock_oauth from './mock_oauth';
+import * as net from '../../third_party/uproxy-lib/net/net.types';
+import * as social from '../interfaces/social';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
+import * as user_interface from '../interfaces/ui';
 
 import ALICE = credentials.ALICE;
 import BOB = credentials.BOB;

--- a/src/integration/integration_test_connector.ts
+++ b/src/integration/integration_test_connector.ts
@@ -1,5 +1,5 @@
-import browser_connector = require('../interfaces/browser_connector');
-import uproxy_core_api = require('../interfaces/uproxy_core_api');
+import * as browser_connector from '../interfaces/browser_connector';
+import * as uproxy_core_api from '../interfaces/uproxy_core_api';
 
 /**
  * Integration test connector.  This class is modeled after FirefoxConnector.

--- a/src/integration/integration_test_connector.ts
+++ b/src/integration/integration_test_connector.ts
@@ -8,7 +8,7 @@ import * as uproxy_core_api from '../interfaces/uproxy_core_api';
  * This allows us to use a CoreConnector in our integration tests, rather than
  * just making .on and .emit calls.
  */
-class IntegrationTestConnector implements browser_connector.CoreBrowserConnector {
+export default class IntegrationTestConnector implements browser_connector.CoreBrowserConnector {
   public status :browser_connector.StatusObject;
   public onceConnected :Promise<void>;
 
@@ -46,5 +46,3 @@ class IntegrationTestConnector implements browser_connector.CoreBrowserConnector
     }
   }
 }  // class IntegrationTestConnector
-
-export = IntegrationTestConnector;

--- a/src/integration/test_connection.ts
+++ b/src/integration/test_connection.ts
@@ -1,6 +1,6 @@
-import tcp = require('../../third_party/uproxy-lib/net/tcp');
-import socks_common = require('../../third_party/uproxy-lib/socks-common/socks-headers');
-import net = require('../../third_party/uproxy-lib/net/net.types');
+import * as tcp from '../../third_party/uproxy-lib/net/tcp';
+import * as socks_common from '../../third_party/uproxy-lib/socks-common/socks-headers';
+import * as net from '../../third_party/uproxy-lib/net/net.types';
 
 class ProxyTester {
   private echoServer_ :tcp.Server;

--- a/src/interfaces/browser_api.ts
+++ b/src/interfaces/browser_api.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import net = require('../lib/net/net.types');
+import * as net from '../lib/net/net.types';
 
 // Describes the interface for functions that have different implications
 // for different browsers.

--- a/src/interfaces/browser_connector.ts
+++ b/src/interfaces/browser_connector.ts
@@ -1,4 +1,4 @@
-import uproxy_core_api = require('./uproxy_core_api');
+import * as uproxy_core_api from './uproxy_core_api';
 
 // Status object for connected. This is an object so it can be bound in
 // angular. connected = true iff connected to the app which is running

--- a/src/interfaces/persistent.ts
+++ b/src/interfaces/persistent.ts
@@ -49,4 +49,4 @@ interface Persistent {
 
 }  // interface Persistent
 
-export = Persistent;
+export default Persistent;

--- a/src/interfaces/social.ts
+++ b/src/interfaces/social.ts
@@ -3,8 +3,8 @@
  * interface to be extended as classes specific to particular components.
  */
 
-import net = require('../lib/net/net.types');
-import uproxy_core_api = require('./uproxy_core_api');
+import * as net from '../lib/net/net.types';
+import * as uproxy_core_api from './uproxy_core_api';
 
 export interface UserPath {
   network :SocialNetworkInfo;

--- a/src/interfaces/ui.ts
+++ b/src/interfaces/ui.ts
@@ -1,4 +1,4 @@
-import social = require('./social');
+import * as social from './social';
 
 /**
  * Enumeration of mutually-exclusive view states.

--- a/src/interfaces/uproxy_core_api.ts
+++ b/src/interfaces/uproxy_core_api.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../third_party/typings/index.d.ts' />
 
-import loggingTypes = require('../lib/loggingprovider/loggingprovider.types');
-import net = require('../lib/net/net.types');
-import social = require('./social');
-import ui = require('./ui');
+import * as loggingTypes from '../lib/loggingprovider/loggingprovider.types';
+import * as net from '../lib/net/net.types';
+import * as social from './social';
+import * as ui from './ui';
 
 // --- Core <--> UI Interfaces ---
 

--- a/src/lib/aqm/aqm.ts
+++ b/src/lib/aqm/aqm.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('../logging/logging');
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('aqm');
 

--- a/src/lib/arraybuffers/arraybuffers.spec.ts
+++ b/src/lib/arraybuffers/arraybuffers.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('./arraybuffers');
+import * as arraybuffers from './arraybuffers';
 
 const array1 = new Uint8Array([12, 118, 101, 114, 105, 115]).buffer;
 const array2 = new Uint8Array([0, 2, 129, 128, 0, 1, 0, 5, 0]).buffer;

--- a/src/lib/bridge/bridge.spec.ts
+++ b/src/lib/bridge/bridge.spec.ts
@@ -1,17 +1,17 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); }
 });
 
-import bridge = require('./bridge');
-import datachannel = require('../webrtc/datachannel');
-import handler = require('../handler/queue');
-import mockFreedomRtcPeerConnection = require('../freedom/mocks/mock-rtcpeerconnection');
-import peerconnection = require('../webrtc/peerconnection');
-import peerconnection_types = require('../webrtc/signals');
+import * as bridge from './bridge';
+import * as datachannel from '../webrtc/datachannel';
+import * as handler from '../handler/queue';
+import mockFreedomRtcPeerConnection from '../freedom/mocks/mock-rtcpeerconnection';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as peerconnection_types from '../webrtc/signals';
 
 ////////
 // For mocking async functions.

--- a/src/lib/bridge/bridge.ts
+++ b/src/lib/bridge/bridge.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import churn = require('../churn/churn');
-import churn_types = require('../churn/churn.types');
-import handler = require('../handler/queue');
-import logging = require('../logging/logging');
-import peerconnection = require('../webrtc/peerconnection');
-import peerconnection_types = require('../webrtc/signals');
-import xchurn = require('../churn/xwalk');
+import * as churn from '../churn/churn';
+import * as churn_types from '../churn/churn.types';
+import * as handler from '../handler/queue';
+import * as logging from '../logging/logging';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as peerconnection_types from '../webrtc/signals';
+import * as xchurn from '../churn/xwalk';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/bridge/onetime.spec.ts
+++ b/src/lib/bridge/onetime.spec.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import mockFreedomRtcPeerConnection = require('../freedom/mocks/mock-rtcpeerconnection');
-import onetime = require('./onetime');
+import * as mockFreedomRtcPeerConnection from '../freedom/mocks/mock-rtcpeerconnection';
+import * as onetime from './onetime';
 
 interface Clown {
   name:string;

--- a/src/lib/bridge/onetime.ts
+++ b/src/lib/bridge/onetime.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/browserify-zlib/browserify-zlib.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import bridge = require('./bridge');
-import churn_types = require('../churn/churn.types');
-import logging = require('../logging/logging');
-import signals = require('../webrtc/signals');
-import zlib = require('browserify-zlib');
+import * as bridge from './bridge';
+import * as churn_types from '../churn/churn.types';
+import * as logging from '../logging/logging';
+import * as signals from '../webrtc/signals';
+import * as zlib from 'browserify-zlib';
 
 var log :logging.Log = new logging.Log('signal batcher');
 

--- a/src/lib/build-tools/common-grunt-rules.ts
+++ b/src/lib/build-tools/common-grunt-rules.ts
@@ -1,7 +1,7 @@
 // common-grunt-rules
 
-import fs = require('fs');
-import path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
 export interface RuleConfig {
   // The path where code in this repository should be built in.

--- a/src/lib/churn-pipe/churn-pipe.ts
+++ b/src/lib/churn-pipe/churn-pipe.ts
@@ -1,19 +1,19 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import aqm = require('../aqm/aqm');
-import caesar = require('../transformers/caesar');
-import churn_types = require('../churn/churn.types');
-import decompression = require('../transformers/decompressionShaper');
-import fragmentation = require('../transformers/fragmentationShaper');
-import ipaddr = require('ipaddr.js');
-import logging = require('../logging/logging');
-import net = require('../net/net.types');
-import PassThrough = require('../transformers/passthrough');
-import promises = require('../promises/promises');
-import protean = require('../transformers/protean');
-import rc4 = require('../transformers/rc4');
-import sequence = require('../transformers/byteSequenceShaper');
-import transformer = require('../transformers/transformer');
+import * as aqm from '../aqm/aqm';
+import * as caesar from '../transformers/caesar';
+import * as churn_types from '../churn/churn.types';
+import * as decompression from '../transformers/decompressionShaper';
+import * as fragmentation from '../transformers/fragmentationShaper';
+import * as ipaddr from 'ipaddr.js';
+import * as logging from '../logging/logging';
+import * as net from '../net/net.types';
+import PassThrough from '../transformers/passthrough';
+import * as promises from '../promises/promises';
+import * as protean from '../transformers/protean';
+import * as rc4 from '../transformers/rc4';
+import * as sequence from '../transformers/byteSequenceShaper';
+import * as transformer from '../transformers/transformer';
 
 import Socket = freedom.UdpSocket.Socket;
 
@@ -56,7 +56,7 @@ interface MirrorSet {
  * us to achieve the same performance while allocating fewer ports, at the cost
  * of slightly more complex logic.
  */
-class Pipe {
+export default class Pipe {
   // Number of instances created, for logging purposes.
   private static id_ = 0;
 
@@ -523,4 +523,3 @@ class Pipe {
   }
 }
 
-export = Pipe;

--- a/src/lib/churn-pipe/freedom-module.interface.ts
+++ b/src/lib/churn-pipe/freedom-module.interface.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import churn_types = require('../churn/churn.types');
-import net = require('../net/net.types');
+import * as churn_types from '../churn/churn.types';
+import * as net from '../net/net.types';
 
 export interface MirrorMapping {
   local: net.Endpoint;

--- a/src/lib/churn-pipe/freedom-module.ts
+++ b/src/lib/churn-pipe/freedom-module.ts
@@ -8,4 +8,4 @@ if (typeof freedom !== 'undefined') {
   freedom['churnPipe']().providePromises(ChurnPipe);
 }
 
-export = ChurnPipe
+export default ChurnPipe

--- a/src/lib/churn-pipe/freedom-module.ts
+++ b/src/lib/churn-pipe/freedom-module.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import ChurnPipe = require('./churn-pipe');
+import ChurnPipe from './churn-pipe';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/churn/candidate.spec.ts
+++ b/src/lib/churn/candidate.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import candidate = require('./candidate');
+import * as candidate from './candidate';
 import Candidate = candidate.Candidate;
 
 describe('extractEndpointFromCandidateLine', function() {

--- a/src/lib/churn/candidate.ts
+++ b/src/lib/churn/candidate.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import net = require('../net/net.types');
+import * as net from '../net/net.types';
 
 // Throughout this file "RTCIceCandidate" refers to the JSON structure
 // produced and consumed by Freedom, not an actual browser

--- a/src/lib/churn/churn.spec.ts
+++ b/src/lib/churn/churn.spec.ts
@@ -1,13 +1,13 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import churn = require('./churn');
-import net = require('../net/net.types');
+import * as churn from './churn';
+import * as net from '../net/net.types';
 
-import candidate = require('./candidate');
+import * as candidate from './candidate';
 import Candidate = candidate.Candidate;
 
 describe('filterCandidatesFromSdp', function() {

--- a/src/lib/churn/churn.ts
+++ b/src/lib/churn/churn.ts
@@ -2,18 +2,18 @@
 /// <reference path='../../../third_party/random-lib/random-lib.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import caesar = require('../transformers/caesar');
-import candidate = require('./candidate');
-import churn_pipe_types = require('../churn-pipe/freedom-module.interface');
-import churn_types = require('./churn.types');
-import handler = require('../handler/queue');
-import ipaddr = require('ipaddr.js');
-import logging = require('../logging/logging');
-import net = require('../net/net.types');
-import peerconnection = require('../webrtc/peerconnection');
-import random = require('random-lib');
-import signals = require('../webrtc/signals');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as caesar from '../transformers/caesar';
+import * as candidate from './candidate';
+import * as churn_pipe_types from '../churn-pipe/freedom-module.interface';
+import * as churn_types from './churn.types';
+import * as handler from '../handler/queue';
+import * as ipaddr from 'ipaddr.js';
+import * as logging from '../logging/logging';
+import * as net from '../net/net.types';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as random from 'random-lib';
+import * as signals from '../webrtc/signals';
 
 import ChurnSignallingMessage = churn_types.ChurnSignallingMessage;
 import ChurnPipe = churn_pipe_types.freedom_ChurnPipe;

--- a/src/lib/churn/churn.types.ts
+++ b/src/lib/churn/churn.types.ts
@@ -1,5 +1,5 @@
-import signals = require('../webrtc/signals');
-import net = require('../net/net.types');
+import * as signals from '../webrtc/signals';
+import * as net from '../net/net.types';
 
 // This file holds the common signalling message type that may be referenced
 // from both module environment as well as the core environment.

--- a/src/lib/churn/xwalk.ts
+++ b/src/lib/churn/xwalk.ts
@@ -1,14 +1,14 @@
 /// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import caesar = require('../transformers/caesar');
-import candidate = require('../churn/candidate');
-import churn_types = require('../churn/churn.types');
-import handler = require('../handler/queue');
-import logging = require('../logging/logging');
-import peerconnection = require('../webrtc/peerconnection');
-import random = require('random-lib');
-import signals = require('../webrtc/signals');
+import * as caesar from '../transformers/caesar';
+import * as candidate from '../churn/candidate';
+import * as churn_types from '../churn/churn.types';
+import * as handler from '../handler/queue';
+import * as logging from '../logging/logging';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as random from 'random-lib';
+import * as signals from '../webrtc/signals';
 
 import Candidate = candidate.Candidate;
 

--- a/src/lib/cloud/deployer/freedom-module.ts
+++ b/src/lib/cloud/deployer/freedom-module.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import logging = require('../../logging/logging');
-import loggingTypes = require('../../loggingprovider/loggingprovider.types');
+import * as logging from '../../logging/logging';
+import * as loggingTypes from '../../loggingprovider/loggingprovider.types';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/cloud/digitalocean/freedom-module.ts
+++ b/src/lib/cloud/digitalocean/freedom-module.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import Provisioner = require('./provisioner');
+import Provisioner from './provisioner';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/cloud/digitalocean/freedom-module.ts
+++ b/src/lib/cloud/digitalocean/freedom-module.ts
@@ -6,4 +6,4 @@ declare const freedom: freedom.FreedomInModuleEnv;
 
 freedom().providePromises(Provisioner);
 
-export = Provisioner
+export default Provisioner;

--- a/src/lib/cloud/digitalocean/provisioner.ts
+++ b/src/lib/cloud/digitalocean/provisioner.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import logging = require('../../logging/logging');
-import Pinger = require('../../net/pinger');
+import * as logging from '../../logging/logging';
+import Pinger from '../../net/pinger';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 
@@ -44,7 +44,7 @@ interface KeyPair {
   public: string;
 }
 
-class Provisioner {
+export default class Provisioner {
   constructor(
     // This argument is passed implicitly to all freedomjs module constructors:
     private dispatch_ :Function,
@@ -576,5 +576,3 @@ class Provisioner {
     });
   }
 }
-
-export = Provisioner;

--- a/src/lib/cloud/install/freedom-module.ts
+++ b/src/lib/cloud/install/freedom-module.ts
@@ -6,4 +6,4 @@ declare const freedom: freedom.FreedomInModuleEnv;
 
 freedom().providePromises(CloudInstaller);
 
-export = CloudInstaller
+export default CloudInstaller;

--- a/src/lib/cloud/install/freedom-module.ts
+++ b/src/lib/cloud/install/freedom-module.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import CloudInstaller = require('./installer');
+import CloudInstaller from './installer';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/cloud/install/installer.ts
+++ b/src/lib/cloud/install/installer.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-require('../social/monkey/process');
+import '../social/monkey/process';
 
 import * as arraybuffers from '../../arraybuffers/arraybuffers';
 import * as linefeeder from '../../net/linefeeder';

--- a/src/lib/cloud/install/installer.ts
+++ b/src/lib/cloud/install/installer.ts
@@ -2,11 +2,11 @@
 
 require('../social/monkey/process');
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
-import linefeeder = require('../../net/linefeeder');
-import logging = require('../../logging/logging');
-import Pinger = require('../../net/pinger');
-import queue = require('../../handler/queue');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
+import * as linefeeder from '../../net/linefeeder';
+import * as logging from '../../logging/logging';
+import Pinger from '../../net/pinger';
+import * as queue from '../../handler/queue';
 
 // https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
 import * as ssh2 from 'ssh2';
@@ -40,7 +40,7 @@ const KEEPALIVE_MAX_FAILURES = 120;
 // Installs uProxy on a server, via SSH.
 // The process is as close as possible to a manual install
 // so that we have fewer paths to test.
-class CloudInstaller {
+export default class CloudInstaller {
   constructor(private dispatchEvent_: (name: string, args: Object) => void) {}
 
   // Runs the install command via SSH, resolving with the invitation URL.
@@ -153,5 +153,3 @@ class CloudInstaller {
     });
   }
 }
-
-export = CloudInstaller;

--- a/src/lib/cloud/social/freedom-module.ts
+++ b/src/lib/cloud/social/freedom-module.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import provider = require('./provider');
+import * as provider from './provider';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -2,11 +2,11 @@
 
 require('../social/monkey/process');
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
-import crypto = require('crypto');
-import linefeeder = require('../../net/linefeeder');
-import logging = require('../../logging/logging');
-import queue = require('../../handler/queue');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
+import * as crypto from 'crypto';
+import * as linefeeder from '../../net/linefeeder';
+import * as logging from '../../logging/logging';
+import * as queue from '../../handler/queue';
 
 // https://github.com/borisyankov/DefinitelyTyped/blob/master/ssh2/ssh2-tests.ts
 import * as ssh2 from 'ssh2';

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-require('../social/monkey/process');
+import '../social/monkey/process';
 
 import * as arraybuffers from '../../arraybuffers/arraybuffers';
 import * as crypto from 'crypto';

--- a/src/lib/copypaste-chat/freedom-module.ts
+++ b/src/lib/copypaste-chat/freedom-module.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import churn = require('../churn/churn');
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import peerconnection = require('../webrtc/peerconnection');
+import * as churn from '../churn/churn';
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as peerconnection from '../webrtc/peerconnection';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/copypaste-socks/freedom-module.ts
+++ b/src/lib/copypaste-socks/freedom-module.ts
@@ -1,14 +1,14 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import bridge = require('../bridge/bridge');
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import net = require('../net/net.types');
-import onetime = require('../bridge/onetime');
-import rtc_to_net = require('../rtc-to-net/rtc-to-net');
-import socks_to_rtc = require('../socks-to-rtc/socks-to-rtc');
-import tcp = require('../net/tcp');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as bridge from '../bridge/bridge';
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as net from '../net/net.types';
+import * as onetime from '../bridge/onetime';
+import * as rtc_to_net from '../rtc-to-net/rtc-to-net';
+import * as socks_to_rtc from '../socks-to-rtc/socks-to-rtc';
+import * as tcp from '../net/tcp';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/copypaste-socks/i18n-util.types.ts
+++ b/src/lib/copypaste-socks/i18n-util.types.ts
@@ -3,4 +3,4 @@ interface I18nUtil {
   changeLanguage(language:string) : void;
   getBrowserLanguage() : string;
 }
-export = I18nUtil;
+export default I18nUtil;

--- a/src/lib/copypaste-socks/main.core-env.ts
+++ b/src/lib/copypaste-socks/main.core-env.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../third_party/polymer/polymer.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import signals = require('../webrtc/signals');
-import net = require('../net/net.types');
-import copypaste_api = require('../copypaste-socks/copypaste-api');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as signals from '../webrtc/signals';
+import * as net from '../net/net.types';
+import * as copypaste_api from '../copypaste-socks/copypaste-api';
 
 // Platform-specific function to load the freedomjs module.
 declare var loadModule: () => Promise<freedom.OnAndEmit<any, any>>;

--- a/src/lib/copypaste-socks/polymer-components/connection-state.ts
+++ b/src/lib/copypaste-socks/polymer-components/connection-state.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }

--- a/src/lib/copypaste-socks/polymer-components/crypto.ts
+++ b/src/lib/copypaste-socks/polymer-components/crypto.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }

--- a/src/lib/copypaste-socks/polymer-components/getter.ts
+++ b/src/lib/copypaste-socks/polymer-components/getter.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }
 import copypaste = browserified_exports.copypaste;
 
-import I18nUtil = require('../i18n-util.types');
+import I18nUtil from '../i18n-util.types';
 declare var i18nUtil :I18nUtil;
 
 Polymer({

--- a/src/lib/copypaste-socks/polymer-components/giver.ts
+++ b/src/lib/copypaste-socks/polymer-components/giver.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }
 import copypaste = browserified_exports.copypaste;
 
-import I18nUtil = require('../i18n-util.types');
+import I18nUtil from '../i18n-util.types';
 declare var i18nUtil :I18nUtil;
 
 Polymer({

--- a/src/lib/copypaste-socks/polymer-components/root.ts
+++ b/src/lib/copypaste-socks/polymer-components/root.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }
 import copypaste = browserified_exports.copypaste;
 
-import I18nUtil = require('../i18n-util.types');
+import I18nUtil from '../i18n-util.types';
 declare var i18nUtil :I18nUtil;
 
 Polymer({

--- a/src/lib/copypaste-socks/polymer-components/start.ts
+++ b/src/lib/copypaste-socks/polymer-components/start.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../third_party/polymer/polymer.d.ts' />
 
-import copypaste_api = require('../copypaste-api');
+import * as copypaste_api from '../copypaste-api';
 declare module browserified_exports {
   var copypaste :copypaste_api.CopypasteApi;
 }

--- a/src/lib/echo/freedom-module.ts
+++ b/src/lib/echo/freedom-module.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import net = require('../net/net.types');
-import tcp = require('../net/tcp');
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as net from '../net/net.types';
+import * as tcp from '../net/tcp';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/freedom/mocks/mock-eventhandler.ts
+++ b/src/lib/freedom/mocks/mock-eventhandler.ts
@@ -3,7 +3,7 @@
 // A simple mock implementation of the freedom event handler that lets you cause
 // fake events. Useful for mocking out freedom freedom modules that will raise
 // events.
-class MockFreedomEventHandler implements freedom.EventHandler {
+export default class MockFreedomEventHandler implements freedom.EventHandler {
   private onHandlerTable_ : {[eventName:string] : Function[]} = {};
   private onceHandlerTable_ : {[eventName:string] : Function[]} = {};
 
@@ -45,5 +45,3 @@ class MockFreedomEventHandler implements freedom.EventHandler {
     this.onceHandlerTable_[eventName] = [];
   }
 }
-
-export = MockFreedomEventHandler;

--- a/src/lib/freedom/mocks/mock-rtcdatachannel.ts
+++ b/src/lib/freedom/mocks/mock-rtcdatachannel.ts
@@ -8,7 +8,7 @@ import RTCPeerConnection = freedom.RTCPeerConnection.RTCPeerConnection;
 import RTCSessionDescription = freedom.RTCPeerConnection.RTCSessionDescription;
 import RTCDataChannel = freedom.RTCDataChannel.RTCDataChannel;
 
-import MockEventHandler = require('./mock-eventhandler');
+import MockEventHandler from './mock-eventhandler';
 
 function makeMockSend<T>() : freedom.Method1<T,void> {
   var f : any = (x:T) => {
@@ -18,7 +18,7 @@ function makeMockSend<T>() : freedom.Method1<T,void> {
   return f;
 }
 
-class MockFreedomRtcDataChannel extends MockEventHandler
+export default class MockFreedomRtcDataChannel extends MockEventHandler
     implements RTCDataChannel {
   constructor() {
     super(['onopen', 'onerror', 'onclose', 'onmessage']);
@@ -56,5 +56,3 @@ class MockFreedomRtcDataChannel extends MockEventHandler
 
   public sendBuffer = makeMockSend<ArrayBuffer>()
 }
-
-export = MockFreedomRtcDataChannel;

--- a/src/lib/freedom/mocks/mock-rtcpeerconnection.ts
+++ b/src/lib/freedom/mocks/mock-rtcpeerconnection.ts
@@ -7,9 +7,9 @@ import RTCOfferOptions = freedom.RTCPeerConnection.RTCOfferOptions;
 import RTCPeerConnection = freedom.RTCPeerConnection.RTCPeerConnection;
 import RTCSessionDescription = freedom.RTCPeerConnection.RTCSessionDescription;
 
-import MockEventHandler = require('./mock-eventhandler');
+import MockEventHandler from './mock-eventhandler';
 
-class MockFreedomRtcPeerConnection extends MockEventHandler
+export default class MockFreedomRtcPeerConnection extends MockEventHandler
     implements RTCPeerConnection {
   constructor() {
     super(['ondatachannel', 'onnegotiationneeded', 'onicecandidate',
@@ -99,5 +99,3 @@ class MockFreedomRtcPeerConnection extends MockEventHandler
   }
 
 }
-
-export = MockFreedomRtcPeerConnection;

--- a/src/lib/handler/queue.spec.ts
+++ b/src/lib/handler/queue.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import HandlerQueue = require('./queue');
-import Aggregate = require('./aggregate');
+import * as HandlerQueue from './queue';
+import * as Aggregate from './aggregate';
 
 import Queue = HandlerQueue.Queue;
 

--- a/src/lib/handler/queue.ts
+++ b/src/lib/handler/queue.ts
@@ -23,7 +23,7 @@
 // CONSIDER: This is kind of similar to functional parsing. May be good to
 // formalize the relationship in comments here.
 
-import baseQueue = require('../queue/queue');
+import * as baseQueue from '../queue/queue';
 
 // The |QueueFeeder| is the abstraction for events to be handled.
 export interface QueueFeeder<Feed,Result> {

--- a/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
+++ b/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
-import socks_headers = require('../../socks/headers');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
+import * as socks_headers from '../../socks/headers';
 
-import proxyintegrationtesttypes = require('./proxy-integration-test.types');
+import * as proxyintegrationtesttypes from './proxy-integration-test.types';
 import ProxyIntegrationTester = proxyintegrationtesttypes.ProxyIntegrationTester;
 import ReceivedDataEvent = proxyintegrationtesttypes.ReceivedDataEvent;
 

--- a/src/lib/integration-tests/socks-echo/churn.core-env.spec.ts
+++ b/src/lib/integration-tests/socks-echo/churn.core-env.spec.ts
@@ -1,4 +1,4 @@
-import echotest = require('./base-spec.core-env');
+import * as echotest from './base-spec.core-env';
 
 describe('proxy integration tests using churn', function() {
   echotest.socksEchoTestDescription(true);

--- a/src/lib/integration-tests/socks-echo/freedom-module.ts
+++ b/src/lib/integration-tests/socks-echo/freedom-module.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import AbstractProxyIntegrationTest = require('./proxy-integration-test');
-import loggingTypes = require('../../loggingprovider/loggingprovider.types');
+import AbstractProxyIntegrationTest from './proxy-integration-test';
+import * as loggingTypes from '../../loggingprovider/loggingprovider.types';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/integration-tests/socks-echo/nochurn.core-env.spec.ts
+++ b/src/lib/integration-tests/socks-echo/nochurn.core-env.spec.ts
@@ -1,4 +1,4 @@
-import echotest = require('./base-spec.core-env');
+import * as echotest from './base-spec.core-env';
 
 describe('proxy integration tests', function() {
   echotest.socksEchoTestDescription(false);

--- a/src/lib/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/lib/integration-tests/socks-echo/proxy-integration-test.ts
@@ -1,17 +1,17 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
-import bridge = require('../../bridge/bridge');
-import logging = require('../../logging/logging');
-import net = require('../../net/net.types');
-import peerconnection = require('../../webrtc/peerconnection');
-import proxyintegrationtesttypes = require('./proxy-integration-test.types');
-import rtc_to_net = require('../../rtc-to-net/rtc-to-net');
-import socks_headers = require('../../socks/headers');
-import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
-import tcp = require('../../net/tcp');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
+import * as bridge from '../../bridge/bridge';
+import * as logging from '../../logging/logging';
+import * as net from '../../net/net.types';
+import * as peerconnection from '../../webrtc/peerconnection';
+import * as proxyintegrationtesttypes from './proxy-integration-test.types';
+import * as rtc_to_net from '../../rtc-to-net/rtc-to-net';
+import * as socks_headers from '../../socks/headers';
+import * as socks_to_rtc from '../../socks-to-rtc/socks-to-rtc';
+import * as tcp from '../../net/tcp';
 
-import ProxyConfig = require('../../rtc-to-net/proxyconfig');
+import ProxyConfig from '../../rtc-to-net/proxyconfig';
 import ProxyIntegrationTester = proxyintegrationtesttypes.ProxyIntegrationTester;
 import ReceivedDataEvent = proxyintegrationtesttypes.ReceivedDataEvent;
 
@@ -20,7 +20,7 @@ var log :logging.Log = new logging.Log('SocksClient');
 // This abstract class is converted into a real class by Freedom, which
 // fills in the unimplemented on(...) method in the process of
 // constructing a module.
-class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
+export default class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
   private socksToRtc_ :socks_to_rtc.SocksToRtc;
   private rtcToNet_ :rtc_to_net.RtcToNet;
   private socksEndpoint_ : Promise<net.Endpoint>;
@@ -362,5 +362,3 @@ class AbstractProxyIntegrationTest implements ProxyIntegrationTester {
     throw new Error('Placeholder function to keep Typescript happy');
   }
 }
-
-export = AbstractProxyIntegrationTest;

--- a/src/lib/integration-tests/socks-echo/slow.core-env.spec.ts
+++ b/src/lib/integration-tests/socks-echo/slow.core-env.spec.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import socks_headers = require('../../socks/headers');
+import * as socks_headers from '../../socks/headers';
 
-import proxyintegrationtesttypes = require('./proxy-integration-test.types');
+import * as proxyintegrationtesttypes from './proxy-integration-test.types';
 import ProxyIntegrationTester = proxyintegrationtesttypes.ProxyIntegrationTester;
 import ReceivedDataEvent = proxyintegrationtesttypes.ReceivedDataEvent;
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
 
 declare const freedom: freedom.FreedomInCoreEnv;
 

--- a/src/lib/integration-tests/tcp/freedom-module.ts
+++ b/src/lib/integration-tests/tcp/freedom-module.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../../arraybuffers/arraybuffers');
-import tcp = require('../../net/tcp');
-import net = require('../../net/net.types');
+import * as arraybuffers from '../../arraybuffers/arraybuffers';
+import * as tcp from '../../net/tcp';
+import * as net from '../../net/net.types';
 
-import logging = require('../../logging/logging');
-import loggingTypes = require('../../loggingprovider/loggingprovider.types');
+import * as logging from '../../logging/logging';
+import * as loggingTypes from '../../loggingprovider/loggingprovider.types';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/logging/logging.spec.ts
+++ b/src/lib/logging/logging.spec.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
-import MockFreedomEventHandler = require('../freedom/mocks/mock-eventhandler');
-import loggingProviderTypes = require('../loggingprovider/loggingprovider.types');
-import Logging = require('./logging');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
+import MockFreedomEventHandler from '../freedom/mocks/mock-eventhandler';
+import * as loggingProviderTypes from '../loggingprovider/loggingprovider.types';
+import * as Logging from './logging';
 
 declare var freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/logging/logging.ts
+++ b/src/lib/logging/logging.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import loggingProviderTypes = require('../loggingprovider/loggingprovider.types');
-import CircularJSON = require('circular-json');
+import * as loggingProviderTypes from '../loggingprovider/loggingprovider.types';
+import * as CircularJSON from 'circular-json';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/loggingprovider/freedom-module.ts
+++ b/src/lib/loggingprovider/freedom-module.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-export import logging_provider = require('./loggingprovider');
+import * as logging_provider from './loggingprovider';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/loggingprovider/loggingprovider.spec.ts
+++ b/src/lib/loggingprovider/loggingprovider.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
 // Setup freedom mock environment.
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 
 declare var freedom: freedom.FreedomInModuleEnv;
 
@@ -26,8 +26,8 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   }
 });
 
-import logging = require('./loggingprovider.types');
-import LoggingProvider = require('./loggingprovider');
+import * as logging from './loggingprovider.types';
+import * as LoggingProvider from './loggingprovider';
 
 describe('Logging Provider', () => {
   var logger :logging.Log;

--- a/src/lib/loggingprovider/loggingprovider.ts
+++ b/src/lib/loggingprovider/loggingprovider.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('./loggingprovider.types');
+import * as logging from './loggingprovider.types';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/nat/probe.ts
+++ b/src/lib/nat/probe.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import logging = require('../logging/logging');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as logging from '../logging/logging';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/net/counter.spec.ts
+++ b/src/lib/net/counter.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import counter = require('./counter');
+import * as counter from './counter';
 
 describe('socket call counter', function() {
   // One wrapped call, then destroy.

--- a/src/lib/net/linefeeder.spec.ts
+++ b/src/lib/net/linefeeder.spec.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import linefeeder = require('./linefeeder');
-import queue = require('../handler/queue');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as linefeeder from './linefeeder';
+import * as queue from '../handler/queue';
 
 describe('LineFeeder', function() {
   let bufferQueue: queue.Queue<ArrayBuffer, void>;

--- a/src/lib/net/linefeeder.ts
+++ b/src/lib/net/linefeeder.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import queue = require('../handler/queue');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as queue from '../handler/queue';
 
 // Transforms a raw network-like ArrayBuffer-based queue into
 // a telnet-style string-based queue.

--- a/src/lib/net/pinger.ts
+++ b/src/lib/net/pinger.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('../logging/logging');
-import promises = require('../promises/promises');
+import * as logging from '../logging/logging';
+import * as promises from '../promises/promises';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 
@@ -11,7 +11,7 @@ const DEFAULT_TIMEOUT_SECS = 60;
 const DEFAULT_INTERVAL_MS = 1000;
 
 // "Pings" - in an nmap sense - a port until a TCP connection can be established.
-class Pinger {
+export default class Pinger {
   constructor(
     private host_: string,
     private port_: number,
@@ -47,5 +47,3 @@ class Pinger {
     }, this.timeout_, DEFAULT_INTERVAL_MS);
   }
 }
-
-export = Pinger;

--- a/src/lib/net/tcp.spec.ts
+++ b/src/lib/net/tcp.spec.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import tcp = require('./tcp');
+import * as tcp from './tcp';
 
 describe('Tcp', function() {
   it('conversion of a connected endpoint info', () => {

--- a/src/lib/net/tcp.ts
+++ b/src/lib/net/tcp.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('../logging/logging');
-import handler = require('../handler/queue');
-import net = require('./net.types');
-import counter = require('./counter');
+import * as logging from '../logging/logging';
+import * as handler from '../handler/queue';
+import * as net from './net.types';
+import * as counter from './counter';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/pool/pool.spec.ts
+++ b/src/lib/pool/pool.spec.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import peerconnection = require('../webrtc/peerconnection');
-import handler = require('../handler/queue');
-import Pool = require('./pool');
+import * as peerconnection from '../webrtc/peerconnection';
+import * as handler from '../handler/queue';
+import Pool from './pool';
 
 describe('pool', function() {
   var mockPeerConnection :peerconnection.PeerConnection<Object>;

--- a/src/lib/pool/pool.ts
+++ b/src/lib/pool/pool.ts
@@ -15,12 +15,12 @@
 // It may therefore be worth preserving even after any platform bugs are
 // resolved.
 
-import peerconnection = require('../webrtc/peerconnection');
-import datachannel = require('../webrtc/datachannel');
-import handler = require('../handler/queue');
-import queue = require('../queue/queue');
+import * as peerconnection from '../webrtc/peerconnection';
+import * as datachannel from '../webrtc/datachannel';
+import * as handler from '../handler/queue';
+import * as queue from '../queue/queue';
 
-import logging = require('../logging/logging');
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('pool');
 
@@ -31,7 +31,7 @@ var log :logging.Log = new logging.Log('pool');
 // and remote pools do not interfere with each other, even if they use the
 // same labels, because the browser ensures that data channels created by each
 // peer are drawn from separate ID spaces (odd vs. even).
-class Pool {
+export default class Pool {
   public peerOpenedChannelQueue
       :handler.QueueHandler<datachannel.DataChannel, void>;
 
@@ -383,5 +383,3 @@ class PoolChannel implements datachannel.DataChannel {
     return 'PoolChannel(' + this.dc_.toString() + ')';
   }
 }
-
-export = Pool;

--- a/src/lib/promises/promises.spec.ts
+++ b/src/lib/promises/promises.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import promises = require('./promises');
+import * as promises from './promises';
 
 describe('retry', () => {
   const MAX_ATTEMPTS = 5;

--- a/src/lib/queue/queue.spec.ts
+++ b/src/lib/queue/queue.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import queue = require('./queue');
+import * as queue from './queue';
 import Queue = queue.Queue;
 
 describe('Base Queue', function() {

--- a/src/lib/rtc-to-net/proxyconfig.ts
+++ b/src/lib/rtc-to-net/proxyconfig.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import uproxy_core_api = require('../../interfaces/uproxy_core_api');
+import * as uproxy_core_api from '../../interfaces/uproxy_core_api';
 
 interface ProxyConfig {
   // If |allowNonUnicast === false| then any proxy attempt that results
@@ -9,4 +9,4 @@ interface ProxyConfig {
   reproxy        ?:uproxy_core_api.reproxySettings;
 }
 
-export = ProxyConfig;
+export default ProxyConfig;

--- a/src/lib/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.spec.ts
@@ -1,22 +1,22 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 (<any>window).freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import peerconnection = require('../webrtc/peerconnection');
-import signals = require('../webrtc/signals');
-import handler = require('../handler/queue');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as signals from '../webrtc/signals';
+import * as handler from '../handler/queue';
 
-import rtc_to_net = require('./rtc-to-net');
-import net = require('../net/net.types');
-import tcp = require('../net/tcp');
-import socks_headers = require('../socks/headers');
+import * as rtc_to_net from './rtc-to-net';
+import * as net from '../net/net.types';
+import * as tcp from '../net/tcp';
+import * as socks_headers from '../socks/headers';
 
-import logging = require('../logging/logging');
+import * as logging from '../logging/logging';
 
-import ProxyConfig = require('./proxyconfig');
+import ProxyConfig from './proxyconfig';
 
 var log :logging.Log = new logging.Log('socks-to-rtc spec');
 

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -3,17 +3,17 @@
 
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import handler = require('../handler/queue');
-import ipaddr = require('ipaddr.js');
-import logging = require('../logging/logging');
-import net = require('../net/net.types');
-import peerconnection = require('../webrtc/peerconnection');
-import socks_headers = require('../socks/headers');
-import tcp = require('../net/tcp');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as handler from '../handler/queue';
+import * as ipaddr from 'ipaddr.js';
+import * as logging from '../logging/logging';
+import * as net from '../net/net.types';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as socks_headers from '../socks/headers';
+import * as tcp from '../net/tcp';
 
-import Pool = require('../pool/pool');
-import ProxyConfig = require('./proxyconfig');
+import Pool from '../pool/pool';
+import ProxyConfig from './proxyconfig';
 
 // module RtcToNet {
 

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -838,4 +838,3 @@ import ProxyConfig from './proxyconfig';
   }  // Session
 
 //}  // module RtcToNet
-//export = RtcToNet;

--- a/src/lib/simple-chat/freedom-module.ts
+++ b/src/lib/simple-chat/freedom-module.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import churn = require('../churn/churn');
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import peerconnection = require('../webrtc/peerconnection');
-import signals = require('../webrtc/signals');
+import * as churn from '../churn/churn';
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as signals from '../webrtc/signals';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/simple-socks/freedom-module.ts
+++ b/src/lib/simple-socks/freedom-module.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import bridge = require('../bridge/bridge');
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import net = require('../net/net.types');
-import rtc_to_net = require('../rtc-to-net/rtc-to-net');
-import socks_to_rtc = require('../socks-to-rtc/socks-to-rtc');
-import tcp = require('../net/tcp');
+import * as bridge from '../bridge/bridge';
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as net from '../net/net.types';
+import * as rtc_to_net from '../rtc-to-net/rtc-to-net';
+import * as socks_to_rtc from '../socks-to-rtc/socks-to-rtc';
+import * as tcp from '../net/tcp';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/lib/socks-to-rtc/socks-to-rtc.spec.ts
@@ -1,20 +1,20 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import peerconnection = require('../webrtc/peerconnection');
-import signals = require('../webrtc/signals');
-import handler = require('../handler/queue');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as peerconnection from '../webrtc/peerconnection';
+import * as signals from '../webrtc/signals';
+import * as handler from '../handler/queue';
 
-import socks_to_rtc = require('./socks-to-rtc');
-import net = require('../net/net.types');
-import tcp = require('../net/tcp');
-import socks_headers = require('../socks/headers');
+import * as socks_to_rtc from './socks-to-rtc';
+import * as net from '../net/net.types';
+import * as tcp from '../net/tcp';
+import * as socks_headers from '../socks/headers';
 
-import logging = require('../logging/logging');
+import * as logging from '../logging/logging';
 
 var log: logging.Log = new logging.Log('socks-to-rtc spec');
 

--- a/src/lib/socks-to-rtc/socks-to-rtc.ts
+++ b/src/lib/socks-to-rtc/socks-to-rtc.ts
@@ -1,13 +1,13 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import handler = require('../handler/queue');
-import net = require('../net/net.types');
-import logging = require('../logging/logging');
-import peerconnection = require('../webrtc/peerconnection');
-import Pool = require('../pool/pool');
-import socks_headers = require('../socks/headers');
-import tcp = require('../net/tcp');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as handler from '../handler/queue';
+import * as net from '../net/net.types';
+import * as logging from '../logging/logging';
+import * as peerconnection from '../webrtc/peerconnection';
+import Pool from '../pool/pool';
+import * as socks_headers from '../socks/headers';
+import * as tcp from '../net/tcp';
 
 const log = new logging.Log('SocksToRtc');
 

--- a/src/lib/socks/headers.spec.ts
+++ b/src/lib/socks/headers.spec.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import Socks = require('./headers');
+import * as Socks from './headers';
 
 // TODO: add tests for IPv6 address parsing
 describe('socks', function() {

--- a/src/lib/socks/headers.ts
+++ b/src/lib/socks/headers.ts
@@ -4,9 +4,9 @@
 */
 /// <reference path='../../../third_party/ipaddrjs/ipaddrjs.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import ipaddr = require('ipaddr.js');
-import net = require('../net/net.types');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as ipaddr from 'ipaddr.js';
+import * as net from '../net/net.types';
 
 // VERSION - Socks protocol and subprotocol version headers
 export enum Version {

--- a/src/lib/transformers/arithmetic.spec.ts
+++ b/src/lib/transformers/arithmetic.spec.ts
@@ -1,12 +1,12 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import arithmetic = require('./arithmetic');
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import decompression = require('./decompressionShaper');
+import * as arithmetic from './arithmetic';
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as decompression from './decompressionShaper';
 
 const frequencies :number[] = decompression.sampleConfig().frequencies;
 let encoder :arithmetic.Encoder;

--- a/src/lib/transformers/arithmetic.ts
+++ b/src/lib/transformers/arithmetic.ts
@@ -1,5 +1,5 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import logging = require('../logging/logging');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('arithmetic shaper');
 

--- a/src/lib/transformers/byteSequenceShaper.ts
+++ b/src/lib/transformers/byteSequenceShaper.ts
@@ -1,7 +1,7 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import crypto = require('crypto');
-import logging = require('../logging/logging');
-import transformer = require('./transformer');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as crypto from 'crypto';
+import * as logging from '../logging/logging';
+import * as transformer from './transformer';
 
 const log :logging.Log = new logging.Log('byte sequence shaper');
 

--- a/src/lib/transformers/caesar.spec.ts
+++ b/src/lib/transformers/caesar.spec.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import caesar = require('./caesar');
+import * as caesar from './caesar';
 
 describe('caesar cipher', function() {
   var transformer :caesar.CaesarCipher;

--- a/src/lib/transformers/caesar.ts
+++ b/src/lib/transformers/caesar.ts
@@ -1,5 +1,5 @@
-import logging = require('../logging/logging');
-import transformer = require('./transformer');
+import * as logging from '../logging/logging';
+import * as transformer from './transformer';
 
 var log :logging.Log = new logging.Log('caesar');
 

--- a/src/lib/transformers/decompressionShaper.ts
+++ b/src/lib/transformers/decompressionShaper.ts
@@ -1,8 +1,8 @@
-import arithmetic = require('./arithmetic');
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import decompression = require('./decompressionShaper');
-import logging = require('../logging/logging');
-import transformer = require('./transformer');
+import * as arithmetic from './arithmetic';
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as decompression from './decompressionShaper';
+import * as logging from '../logging/logging';
+import * as transformer from './transformer';
 
 const log :logging.Log = new logging.Log('decompression shaper');
 

--- a/src/lib/transformers/defragmenter.ts
+++ b/src/lib/transformers/defragmenter.ts
@@ -1,6 +1,6 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import fragments = require('./fragment');
-import logging = require('../logging/logging');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as fragments from './fragment';
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('defragmenter');
 

--- a/src/lib/transformers/fragment.ts
+++ b/src/lib/transformers/fragment.ts
@@ -1,6 +1,6 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import crypto = require('crypto');
-import logging = require('../logging/logging');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as crypto from 'crypto';
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('fragment');
 

--- a/src/lib/transformers/fragmentationShaper.ts
+++ b/src/lib/transformers/fragmentationShaper.ts
@@ -1,8 +1,8 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import crypto = require('crypto');
-import defragmenter = require('./defragmenter');
-import fragments = require('./fragment');
-import logging = require('../logging/logging');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as crypto from 'crypto';
+import * as defragmenter from './defragmenter';
+import * as fragments from './fragment';
+import * as logging from '../logging/logging';
 
 var log :logging.Log = new logging.Log('fragmentation shaper');
 

--- a/src/lib/transformers/passthrough.ts
+++ b/src/lib/transformers/passthrough.ts
@@ -1,7 +1,7 @@
-import transformer = require('./transformer');
+import * as transformer from './transformer';
 
 /** An obfuscator which does nothing. */
-class PassThrough implements transformer.Transformer {
+export default class PassThrough implements transformer.Transformer {
 
   public constructor() {}
 
@@ -15,5 +15,3 @@ class PassThrough implements transformer.Transformer {
     return [buffer];
   }
 }
-
-export = PassThrough;

--- a/src/lib/transformers/protean.ts
+++ b/src/lib/transformers/protean.ts
@@ -1,10 +1,10 @@
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import decompression = require('./decompressionShaper');
-import fragmentation = require('./fragmentationShaper');
-import logging = require('../logging/logging');
-import rc4 = require('./rc4');
-import sequence = require('./byteSequenceShaper');
-import transformer = require('./transformer');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as decompression from './decompressionShaper';
+import * as fragmentation from './fragmentationShaper';
+import * as logging from '../logging/logging';
+import * as rc4 from './rc4';
+import * as sequence from './byteSequenceShaper';
+import * as transformer from './transformer';
 
 const log :logging.Log = new logging.Log('protean');
 

--- a/src/lib/transformers/rc4.spec.ts
+++ b/src/lib/transformers/rc4.spec.ts
@@ -1,11 +1,11 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare let freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import rc4 = require('./rc4');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as rc4 from './rc4';
 
 describe('rc4 transformer', function() {
   let transformer: rc4.Rc4Transformer;

--- a/src/lib/transformers/rc4.ts
+++ b/src/lib/transformers/rc4.ts
@@ -1,10 +1,10 @@
 /// <reference path='../../../third_party/simple-rc4/simple-rc4.d.ts' />
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import crypto = require('crypto');
-import logging = require('../logging/logging');
-import rc4 = require('simple-rc4');
-import transformer = require('./transformer');
+import * as crypto from 'crypto';
+import * as logging from '../logging/logging';
+import rc4 from 'simple-rc4';
+import * as transformer from './transformer';
 
 const log = new logging.Log('rc4 transformer');
 

--- a/src/lib/transformers/rc4.ts
+++ b/src/lib/transformers/rc4.ts
@@ -3,7 +3,7 @@
 
 import * as crypto from 'crypto';
 import * as logging from '../logging/logging';
-import rc4 from 'simple-rc4';
+var RC4 = require('simple-rc4');
 import * as transformer from './transformer';
 
 const log = new logging.Log('rc4 transformer');
@@ -78,7 +78,7 @@ export class Rc4Transformer implements transformer.Transformer {
     const hasher = crypto.createHash('sha1');
     const iv = hasher.update(Buffer.concat([this.key_, r]));
     const truncatedIv = iv.digest().slice(0, TRUNCATED_IV_LENGTH_BYTES);
-    new rc4(truncatedIv).update(bytes);
+    new RC4(truncatedIv).update(bytes);
   }
 
   public transform = (ab: ArrayBuffer): ArrayBuffer[] => {

--- a/src/lib/uprobe/freedom-module.ts
+++ b/src/lib/uprobe/freedom-module.ts
@@ -1,8 +1,8 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import nat_probe = require('../nat/probe');
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as nat_probe from '../nat/probe';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/webrtc/datachannel.spec.ts
+++ b/src/lib/webrtc/datachannel.spec.ts
@@ -1,14 +1,14 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import MockFreedomRtcDataChannel = require('../freedom/mocks/mock-rtcdatachannel');
+import MockFreedomRtcDataChannel from '../freedom/mocks/mock-rtcdatachannel';
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'rtcdatachannel': () => { return new MockFreedomRtcDataChannel(); }
 });
 
-import datachannel = require('./datachannel');
+import * as datachannel from './datachannel';
 
 describe('DataChannel', function() {
   var mockRtcDataChannel :MockFreedomRtcDataChannel;

--- a/src/lib/webrtc/datachannel.ts
+++ b/src/lib/webrtc/datachannel.ts
@@ -6,9 +6,9 @@
 // platform compatibility library webrtc-adaptor.js (from:
 // https://code.google.com/p/webrtc/source/browse/stable/samples/js/base/adapter.js)
 
-import handler = require('../handler/queue');
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import logging = require('../logging/logging');
+import * as handler from '../handler/queue';
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as logging from '../logging/logging';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/lib/webrtc/peerconnection.spec.ts
+++ b/src/lib/webrtc/peerconnection.spec.ts
@@ -1,19 +1,17 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import MockFreedomRtcDataChannel =
-  require('../freedom/mocks/mock-rtcdatachannel');
-import MockFreedomRtcPeerConnection =
-  require('../freedom/mocks/mock-rtcpeerconnection');
+import MockFreedomRtcDataChannel from '../freedom/mocks/mock-rtcdatachannel';
+import MockFreedomRtcPeerConnection from '../freedom/mocks/mock-rtcpeerconnection';
 import RTCPeerConnection = freedom.RTCPeerConnection.RTCPeerConnection;
 import RTCDataChannelInit = freedom.RTCPeerConnection.RTCDataChannelInit;
 
-import freedomMocker = require('../freedom/mocks/mock-freedom-in-module-env');
+import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
-import signals = require('./signals');
-import peerconnection = require('./peerconnection');
-import datachannel = require('./datachannel');
+import * as signals from './signals';
+import * as peerconnection from './peerconnection';
+import * as datachannel from './datachannel';
 
 describe('PeerConnection', function() {
   var mockRtcPeerConnection :MockFreedomRtcPeerConnection;

--- a/src/lib/webrtc/peerconnection.ts
+++ b/src/lib/webrtc/peerconnection.ts
@@ -1,9 +1,9 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import datachannel = require('./datachannel');
-import handler = require('../handler/queue');
-import logging = require('../logging/logging');
-import signals = require('./signals');
+import * as datachannel from './datachannel';
+import * as handler from '../handler/queue';
+import * as logging from '../logging/logging';
+import * as signals from './signals';
 
 import RTCSessionDescription = freedom.RTCPeerConnection.RTCSessionDescription;
 

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -1,17 +1,17 @@
 /// <reference path='../../../third_party/typings/index.d.ts' />
 
-import arraybuffers = require('../arraybuffers/arraybuffers');
-import bridge = require('../bridge/bridge');
-import churn_types = require('../churn/churn.types');
-import constants = require('../../generic_core/constants');
-import logging = require('../logging/logging');
-import loggingTypes = require('../loggingprovider/loggingprovider.types');
-import net = require('../net/net.types');
-import linefeeder = require('../net/linefeeder');
-import queue = require('../handler/queue');
-import rtc_to_net = require('../rtc-to-net/rtc-to-net');
-import socks_to_rtc = require('../socks-to-rtc/socks-to-rtc');
-import tcp = require('../net/tcp');
+import * as arraybuffers from '../arraybuffers/arraybuffers';
+import * as bridge from '../bridge/bridge';
+import * as churn_types from '../churn/churn.types';
+import * as constants from '../../generic_core/constants';
+import * as logging from '../logging/logging';
+import * as loggingTypes from '../loggingprovider/loggingprovider.types';
+import * as net from '../net/net.types';
+import * as linefeeder from '../net/linefeeder';
+import * as queue from '../handler/queue';
+import * as rtc_to_net from '../rtc-to-net/rtc-to-net';
+import * as socks_to_rtc from '../socks-to-rtc/socks-to-rtc';
+import * as tcp from '../net/tcp';
 
 declare const freedom: freedom.FreedomInModuleEnv;
 

--- a/src/mocks/freedom-mocks.ts
+++ b/src/mocks/freedom-mocks.ts
@@ -8,8 +8,8 @@
  * This file must be compiled independently of all other typescript in uProxy.
  */
 
-import MockEventHandler = require('../lib/freedom/mocks/mock-eventhandler');
-import arraybuffers = require('../lib/arraybuffers/arraybuffers');
+import MockEventHandler from '../lib/freedom/mocks/mock-eventhandler';
+import * as arraybuffers from '../lib/arraybuffers/arraybuffers';
 
 export class MockFreedomStorage implements freedom.Storage.Storage {
 

--- a/src/mocks/mock-storage.ts
+++ b/src/mocks/mock-storage.ts
@@ -1,4 +1,4 @@
-import storage_interface = require('../interfaces/storage');
+import * as storage_interface from '../interfaces/storage';
 
 export class MockStorage implements storage_interface.Storage {
   constructor(private data_ ?:any) {

--- a/src/mocks/rtc-to-net.ts
+++ b/src/mocks/rtc-to-net.ts
@@ -1,5 +1,5 @@
-import rtc_to_net = require('../lib/rtc-to-net/rtc-to-net');
-import handler_queue = require('../lib/handler/queue');
+import * as rtc_to_net from '../lib/rtc-to-net/rtc-to-net';
+import * as handler_queue from '../lib/handler/queue';
 
 export class RtcToNetMock { // TODO implements rtc_to_net.RtcToNet {
   public signalsForPeer = new handler_queue.Queue<Object, void>();

--- a/src/mocks/socks-to-rtc.ts
+++ b/src/mocks/socks-to-rtc.ts
@@ -1,5 +1,5 @@
-import handler = require('../lib/handler/queue');
-import net = require('../lib/net/net.types');
+import * as handler from '../lib/handler/queue';
+import * as net from '../lib/net/net.types';
 
 export class SocksToRtcMock { // TODO implements SocksToRtc.SocksToRtc {
   public resolveStart :(v :Object) => void;

--- a/third_party/generic/uparams.d.ts
+++ b/third_party/generic/uparams.d.ts
@@ -4,5 +4,5 @@ declare module 'uparams' {
   // The uparams module is itself a function, rather than an object with
   // member functions.
   function uparams(s:string) : any;
-  export = uparams;
+  export default uparams;
 }

--- a/third_party/simple-rc4/simple-rc4.d.ts
+++ b/third_party/simple-rc4/simple-rc4.d.ts
@@ -8,5 +8,5 @@ declare module 'simple-rc4' {
     // Returns the supplied Buffer, encoded.
     update(msg: Buffer): Buffer;
   }
-  export default RC4
+  export = RC4;
 }

--- a/third_party/simple-rc4/simple-rc4.d.ts
+++ b/third_party/simple-rc4/simple-rc4.d.ts
@@ -8,6 +8,5 @@ declare module 'simple-rc4' {
     // Returns the supplied Buffer, encoded.
     update(msg: Buffer): Buffer;
   }
-
-  export = RC4;
+  export default RC4
 }


### PR DESCRIPTION
We use `require` everywhere, but that's not valid ES6 code. The Typescript team recommended using the ES6 import format to reduce divergence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2777)
<!-- Reviewable:end -->
