### PR TITLE
Change uparams to no longer use ES6 imports

### DIFF
--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -28,7 +28,9 @@ import * as network_options from '../../generic/network-options';
 import * as model from './model';
 import * as dialogs from './dialogs';
 import * as jsurl from 'jsurl';
-import uparams from 'uparams';
+// TODO: remove uparams as it doesn't work with ES6 imports and TypeScript,
+// see https://github.com/uProxy/uproxy/issues/2782
+import uparams = require('uparams');
 import * as crypto from 'crypto';
 import * as jdenticon from 'jdenticon';
 

--- a/third_party/generic/uparams.d.ts
+++ b/third_party/generic/uparams.d.ts
@@ -1,8 +1,10 @@
 // Type definitions for the uparams module
+// TODO: remove uparams as it doesn't work with ES6 imports and TypeScript,
+// see https://github.com/uProxy/uproxy/issues/2782
 
 declare module 'uparams' {
   // The uparams module is itself a function, rather than an object with
   // member functions.
   function uparams(s:string) : any;
-  export default uparams;
+  export = uparams;
 }


### PR DESCRIPTION
See https://github.com/uProxy/uproxy/issues/2782 for details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2783)
<!-- Reviewable:end -->
