### PR TITLE
remove a bunch of old stuff from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,17 +17,10 @@
 *~
 .DS_Store
 .grunt
-.mozilla_addon_sdk
 .sass-cache
 .tscache
 build
-.build
-editor_support/*/*.sublime-workspace
 node_modules
 npm-debug.log
-test_output
-tmp
 keys
 third_party/bower
-third_party/typings
-src/.baseDir.ts


### PR DESCRIPTION
Notably, `build/typings`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2791)
<!-- Reviewable:end -->
