### PR TITLE
Check if cloud server is online

### DIFF
--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -574,6 +574,9 @@ var log :logging.Log = new logging.Log('remote-user');
         // handshake is sent to the peer.
         log.error('Attempting to send instance handshake before ready');
         return;
+      } else if (this.network.name === 'Cloud') {
+        // Don't send instance handshake to cloud servers.
+        return;
       }
       // Ensure that the user is loaded so that we have correct consent bits.
       return this.onceLoaded.then(() => {

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -440,7 +440,6 @@ export function notifyUI(networkName :string, userId :string) {
         log.error('Firewall: invalid client state:', freedomClient);
         return;
       }
-      console.log('got clientState: ', freedomClient)
       var client :social.ClientState =
         freedomClientToUproxyClient(freedomClient);
       if (client.userId == this.myInstance.userId &&

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -440,6 +440,7 @@ export function notifyUI(networkName :string, userId :string) {
         log.error('Firewall: invalid client state:', freedomClient);
         return;
       }
+      console.log('got clientState: ', freedomClient)
       var client :social.ClientState =
         freedomClientToUproxyClient(freedomClient);
       if (client.userId == this.myInstance.userId &&

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -862,22 +862,6 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
         networkName: args.networkName,
         userId: args.userId
       });
-    }).then(() => {
-      // If we removed the only cloud friend, logout of the cloud network
-      if (args.networkName === 'Cloud') {
-        return this.logoutIfRosterEmpty_(network);
-      }
     });
-  }
-
-  private logoutIfRosterEmpty_ = (network :social.Network) : Promise<void> => {
-    if (Object.keys(network.roster).length === 0) {
-      return this.logout({
-       name: network.name
-      }).then(() => {
-        log.info('Successfully logged out of %1 network because roster is empty', network.name);
-      });
-    }
-    return Promise.resolve();
   }
 }  // class uProxyCore

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -416,13 +416,6 @@ export class CloudSocialProvider {
       this.startMonitoringPresence_(invite.host);
       this.notifyOfUser_(this.savedContacts_[invite.host]);
       this.saveContacts_();
-
-      // Connect in the background in order to fetch metadata such as
-      // the banner (description).
-      this.reconnect_(invite).catch((e: Error) => {
-        log.warn('failed to log into cloud server during invite accept: %1', e.message);
-      });
-
       return Promise.resolve();
     } catch (e) {
       return Promise.reject(new Error('could not parse invite code: ' + e.message));

--- a/src/lib/net/pinger.ts
+++ b/src/lib/net/pinger.ts
@@ -20,8 +20,7 @@ export default class Pinger {
   public ping = (): Promise<void> => {
     log.debug('pinging %1:%2...', this.host_ , this.port_);
 
-    return promises.retry(this.pingOnce.bind(this),
-        this.timeout_, DEFAULT_INTERVAL_MS);
+    return promises.retry(this.pingOnce, this.timeout_, DEFAULT_INTERVAL_MS);
   }
 
   // Resolves if a connection has been established, or rejects if the connection

--- a/src/lib/net/pinger.ts
+++ b/src/lib/net/pinger.ts
@@ -24,6 +24,8 @@ export default class Pinger {
         this.timeout_, DEFAULT_INTERVAL_MS);
   }
 
+  // Resolves if a connection has been established, or rejects if the connection
+  // fails.  Does not retry.
   public pingOnce = () : Promise<void> => {
     const socket = freedom['core.tcpsocket']();
 


### PR DESCRIPTION
Check if a cloud server is online.  This is needed now that we will be deploying cloud servers from the uProxy website, invites will be generated ASAP even though the server will not be ready for 2+ minutes.

With this change:
* We ping each cloud server once per minute to see if it's online or offline.
* We stop pinging a cloud server if it's removed from the buddylist
* We no longer log out of cloud when the last server (contact) is removed from the buddylist (this was causing error messages to appear because social.logout rejects for Cloud)
* uProxy no longer attempts to send an instance message to Cloud servers (this was resulting in error trace and is not needed by the server)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2798)
<!-- Reviewable:end -->
