### PR TITLE
Fix tun2socks_vpn_device

### DIFF
--- a/src/cca/scripts/tun2socks_vpn_device.ts
+++ b/src/cca/scripts/tun2socks_vpn_device.ts
@@ -27,19 +27,18 @@ class Tun2SocksVpnDevice implements VpnDevice {
 }
 
 const globalTun2SocksVpnDevice = new Promise((resolve, reject) => {
-  // Wait for Cordova plugins to be loaded.
-  window.top.document.addEventListener('deviceready', () => {
-    if (!window.tun2socks) {
-      reject('Device does not support VPN');
+  if (!window.tun2socks) {
+    reject('Device does not support VPN');
+    return;
+  }
+  window.tun2socks.deviceSupportsPlugin().then((supportsVpn) => {
+    if (!supportsVpn) {
+      reject(`Device does not support VPN`);
       return;
     }
-    window.tun2socks.deviceSupportsPlugin().then((supportsVpn) => {
-      if (!supportsVpn) {
-        reject(`Device does not support VPN`);
-        return;
-      }
-      resolve(new Tun2SocksVpnDevice(window.tun2socks));
-    });
+    resolve(new Tun2SocksVpnDevice(window.tun2socks));
+  }).catch((reason) => {
+    reject(`Error calling window.tun2socks.deviceSupportsPlugin(): ${reason}`);
   });
 });
 


### PR DESCRIPTION
For some reason I'm not getting that event on the browser. I think the CCA app already waits for the Cordova plugins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2809)
<!-- Reviewable:end -->
