### PR TITLE
fix android build by specifying cordova-custom-config version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,7 +219,7 @@ module.exports = function(grunt) {
 
     // Create commands to run in different directories.
     ccaPlatformAndroidCmd: '<%= ccaJsPath %> platform add android',
-    ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config https://github.com/Initsogar/cordova-webintent.git https://github.com/uProxy/cordova-plugin-tun2socks.git cordova-plugin-backbutton',
+    ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config@3.0.14 https://github.com/Initsogar/cordova-webintent.git https://github.com/uProxy/cordova-plugin-tun2socks.git cordova-plugin-backbutton',
     
     exec: {
       makeChromeWebStoreZips: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,6 +219,8 @@ module.exports = function(grunt) {
 
     // Create commands to run in different directories.
     ccaPlatformAndroidCmd: '<%= ccaJsPath %> platform add android',
+    // Here's why we pin the cordova-custom-config version:
+    //   https://github.com/uProxy/uproxy/issues/2835
     ccaAddPluginsCmd: '<%= ccaJsPath %> plugin add https://github.com/bemasc/cordova-plugin-themeablebrowser.git https://github.com/bemasc/cordova-plugin-splashscreen cordova-custom-config@3.0.14 https://github.com/Initsogar/cordova-webintent.git https://github.com/uProxy/cordova-plugin-tun2socks.git cordova-plugin-backbutton',
     
     exec: {


### PR DESCRIPTION
Something changed recently:
https://github.com/dpa99c/cordova-custom-config/commit/2e1d5d686ac31d3a01d17efbe625de4ff0cd86ce#diff-04c6e90faac2675aa89e2176d2eec7d8

`cca` doesn't seem to support this method...next-to-most recent NPM still works fine - this unbreaks the Android build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2834)
<!-- Reviewable:end -->
