### PR TITLE
add some more anti-undeclared variable-type lint warnings

### DIFF
--- a/src/chrome/app/scripts/main.core-env.ts
+++ b/src/chrome/app/scripts/main.core-env.ts
@@ -16,6 +16,8 @@ export interface OnEmitModule extends freedom.OnAndEmit<any,any> {};
 export interface OnEmitModuleFactory extends
   freedom.FreedomModuleFactoryManager<OnEmitModule> {};
 
+let chromeUIConnector :ChromeUIConnector;
+
 function getPolicyFromManagedStorage() :Promise<Object> {
   return new Promise((fulfill, reject) => {
     chrome.storage.managed.get(null, (contents) => {
@@ -40,8 +42,6 @@ var oauthOptions :{connector:ChromeUIConnector;} = {
 };
 export var uProxyAppChannel :freedom.OnAndEmit<any,any>;
 export var moduleName = 'uProxy App Top Level';
-
-var chromeUIConnector :ChromeUIConnector;
 
 freedom('generic_core/freedom-module.json', <freedom.FreedomInCoreEnvOptions>{
   'logger': 'lib/loggingprovider/freedom-module.json',

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -73,19 +73,19 @@ chrome.runtime.onMessageExternal.addListener((request :any, sender :chrome.runti
   return true;
 });
 
-chrome.runtime.onUpdateAvailable.addListener((details) => {
+chrome.runtime.onUpdateAvailable.addListener((updateInfo) => {
   console.log('Update available');
 
   core.getVersion().then(function(versions) {
-    if (compareVersion(details.version, versions.version) > 0) {
+    if (compareVersion(updateInfo.version, versions.version) > 0) {
       // Only update if the new version is the same as or older than the app
       // version.  If we are not able to update now, this will be taken care of
       // by restarting at the same time as the core update.
       return;
     }
 
-    chrome.proxy.settings.get({}, (details) => {
-      if (details.levelOfControl === 'controlled_by_this_extension') {
+    chrome.proxy.settings.get({}, (proxyInfo) => {
+      if (proxyInfo.levelOfControl === 'controlled_by_this_extension') {
         return;
       }
 

--- a/src/chrome/extension/scripts/background.ts
+++ b/src/chrome/extension/scripts/background.ts
@@ -27,6 +27,17 @@ export var browserConnector :ChromeCoreConnector;  // way for ui to speak to a u
 export var core :CoreConnector;  // way for ui to speak to a uProxy.CoreApi
 export var backgroundUi: background_ui.BackgroundUi;
 export var browserApi :ChromeBrowserApi;
+
+/*
+ * TODO: this is a separate user_interface object from the one we refer to
+ * elsewhere in the code.  It will register listeners for all events and
+ * commands, however, these listeners will immediately be unbound after the
+ * panel is opened for the first time.  Its version of any data should not be
+ * relied upon as canonical and no updates made to data here should be expected
+ * to persist within the general UI.
+ */
+const ui = new user_interface.UserInterface(core, browserApi, backgroundUi);
+
 // Chrome Window ID of the window used to launch uProxy,
 // i.e. the window where the extension icon was clicked
 // or the window where the user is completing the install flow.
@@ -144,16 +155,6 @@ browserConnector.onUpdate(uproxy_core_api.Update.GET_CREDENTIALS,
 backgroundUi = new background_ui.BackgroundUi(
     new chrome_panel_connector.ChromePanelConnector(),
     core);
-
-/*
- * TODO: this is a separate user_interface object from the one we refer to
- * elsewhere in the code.  It will register listeners for all events and
- * commands, however, these listeners will immediately be unbound after the
- * panel is opened for the first time.  Its version of any data should not be
- * relied upon as canonical and no updates made to data here should be expected
- * to persist within the general UI.
- */
-var ui = new user_interface.UserInterface(core, browserApi, backgroundUi);
 
 chrome.webRequest.onBeforeRequest.addListener(
     function(details) {

--- a/src/chrome/extension/scripts/chrome_core_connector.spec.ts
+++ b/src/chrome/extension/scripts/chrome_core_connector.spec.ts
@@ -221,7 +221,6 @@ describe('core-connector', () => {
   // ChromeAppConnector into a consistent state for testing the communications
   // specs.
   it('reconnects to App when it returns.', (done) => {
-    var port = mockAppPort();
     var acker :Function = null;
     spyOn(chrome.runtime, 'connect').and.returnValue(port);
     spyOn(port.onMessage, 'addListener').and.callFake((handler :Function) => {
@@ -247,13 +246,13 @@ describe('core-connector', () => {
   });
 
   it('flushes the queue correctly.', () => {
-    var flushed :browser_connector.Payload[] = [];
+    var flushQueue :browser_connector.Payload[] = [];
     spyOn(chromeCoreConnector, 'send').and.callFake((payload :browser_connector.Payload) => {
-      flushed.push(payload);
+      flushQueue.push(payload);
     });
     chromeCoreConnector.flushQueue();
     expect(chromeCoreConnector['queue_']).toEqual([]);
-    expect(flushed).toEqual([
+    expect(flushQueue).toEqual([
         jasmine.objectContaining({ cmd: 'emit', type: 1019, data: undefined }),
         { cmd: 'test1', type: 1 },
         jasmine.objectContaining({ cmd: 'emit', type: 1019, data: undefined }),

--- a/src/generic_core/firewall.spec.ts
+++ b/src/generic_core/firewall.spec.ts
@@ -1,5 +1,7 @@
 import * as freedomMocker from '../lib/freedom/mocks/mock-freedom-in-module-env';
 import mockFreedomRtcPeerConnection from '../lib/freedom/mocks/mock-rtcpeerconnection';
+import * as freedom_mocks from '../mocks/freedom-mocks';
+
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.storage': () => { return new freedom_mocks.MockFreedomStorage(); },
@@ -11,7 +13,6 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'portControl': () => { return new Object },
 });
 
-import * as freedom_mocks from '../mocks/freedom-mocks';
 import * as firewall from './firewall';
 
 class MockPolicy implements firewall.ResponsePolicy {

--- a/src/generic_core/remote-instance.spec.ts
+++ b/src/generic_core/remote-instance.spec.ts
@@ -59,10 +59,6 @@ describe('remote_instance.RemoteInstance', () => {
   };
   user.onceNameReceived = Promise.resolve<string>('name');
 
-  var socksToRtc =
-      <socks_to_rtc.SocksToRtc><any>jasmine.createSpyObj('socksToRtc', [
-          'onceReady'
-      ]);
   var instance :remote_instance.RemoteInstance;
   var localPeerId = {
     clientInstancePath: 'clientInstancePath',
@@ -106,7 +102,6 @@ describe('remote_instance.RemoteInstance', () => {
   });
 
   describe('updating consent from instance handshake', () => {
-    var instance :remote_instance.RemoteInstance;
     var INSTANCE_ID = 'instance1';
 
     beforeEach((done) => {
@@ -119,7 +114,7 @@ describe('remote_instance.RemoteInstance', () => {
         network['getLocalInstanceId'] = function() { return 'myInstanceId'; };
         network['myInstance'] =
             new local_instance.LocalInstance(network, 'localUserId');
-        var user = new remote_user.User(network, 'testUser');
+        user = new remote_user.User(network, 'testUser');
         user.update({userId: 'testUser', name: 'Alice'});
         instance = new remote_instance.RemoteInstance(user, INSTANCE_ID);
         user['instances_'][INSTANCE_ID] = instance;

--- a/src/generic_core/remote-user.spec.ts
+++ b/src/generic_core/remote-user.spec.ts
@@ -36,7 +36,6 @@ describe('remote_user.User', () => {
       new local_instance.LocalInstance(network, 'localUserId');
 
   var user :remote_user.User;
-  var instance :remote_instance.RemoteInstance;
 
   it('creates with the correct userId', (done) => {
     user = new remote_user.User(network, 'fakeuser');
@@ -191,6 +190,7 @@ describe('remote_user.User', () => {
 
   describe('client <---> instance', () => {
     it('syncs clientId <--> instanceId mapping', (done) => {
+      var instance :remote_instance.RemoteInstance;
       var realStorage = new local_storage.Storage;
       storage.save = function(key :string, value :Object) {
         return realStorage.save(key, value);
@@ -234,7 +234,7 @@ describe('remote_user.User', () => {
   });  // describe client <---> instance
 
   describe('local consent towards remote proxy', () => {
-    var user = new remote_user.User(network, 'fakeuser2');
+    user = new remote_user.User(network, 'fakeuser2');
 
     it('can request access, and cancel that request', (done) => {
       user.modifyConsent(uproxy_core_api.ConsentUserAction.REQUEST).then(() => {

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -633,7 +633,7 @@ var log :logging.Log = new logging.Log('remote-user');
         // If remote is currently an active client, but user revokes access, also
         // stop the proxy session.
         if (uproxy_core_api.ConsentUserAction.CANCEL_OFFER === action) {
-          for (var instanceId in this.instances_) {
+          for (const instanceId in this.instances_) {
             var instanceData = this.instances_[instanceId].currentStateForUi();
             if (instanceData.localSharingWithRemote == social.SharingState.SHARING_ACCESS) {
               this.instances_[instanceId].stopShare();
@@ -642,7 +642,7 @@ var log :logging.Log = new logging.Log('remote-user');
         }
 
         // Send new consent bits to all remote clients, and save to storage.
-        for (var instanceId in this.instances_) {
+        for (const instanceId in this.instances_) {
           if (this.isInstanceOnline(instanceId)) {
             this.sendInstanceHandshake(this.instanceToClient(instanceId));
           }

--- a/src/generic_core/remote-user.ts
+++ b/src/generic_core/remote-user.ts
@@ -219,8 +219,8 @@ var log :logging.Log = new logging.Log('remote-user');
 
         case social.PeerMessageType.SIGNAL_FROM_CLIENT_PEER:
         case social.PeerMessageType.SIGNAL_FROM_SERVER_PEER:
-          var instance = this.getInstance(this.clientToInstance(clientId));
-          if (!instance) {
+          const recipientInstance = this.getInstance(this.clientToInstance(clientId));
+          if (!recipientInstance) {
             // TODO: this may occur due to a race condition where uProxy has
             // received an onUserProfile and onClientState event, but not yet
             // recieved and instance message, and the peer tries to start
@@ -229,7 +229,7 @@ var log :logging.Log = new logging.Log('remote-user');
             log.error('failed to get instance', clientId);
             return;
           }
-          instance.handleSignal(msg);
+          recipientInstance.handleSignal(msg);
           return;
 
         case social.PeerMessageType.INSTANCE_REQUEST:
@@ -260,13 +260,13 @@ var log :logging.Log = new logging.Log('remote-user');
           log.debug('got instance key-verify mssage', msg);
           // Find the RemoteInstance representing the peer, and relay
           // the message there.
-          var instance = this.getInstance(this.clientToInstance(clientId));
-          if (!instance) {
+          let peerInstance = this.getInstance(this.clientToInstance(clientId));
+          if (!peerInstance) {
             // issues: https://github.com/uProxy/uproxy/pull/732
             log.error('failed to get instance', clientId);
             return;
           }
-         instance.handleKeyVerifyMessage(msg.data);
+         peerInstance.handleKeyVerifyMessage(msg.data);
         return;
 
         default:

--- a/src/generic_core/social.spec.ts
+++ b/src/generic_core/social.spec.ts
@@ -135,7 +135,7 @@ describe('social_network.FreedomNetwork', () => {
           'dummy-instance-id/roster/somefriend', ''));
 
       Promise.all(savedToStorage).then(() => {
-        var loginPromise = network.login(uproxy_core_api.LoginType.INITIAL);
+        loginPromise = network.login(uproxy_core_api.LoginType.INITIAL);
         return loginPromise;
       }).then(() => {
         expect(network.myInstance).toBeDefined();

--- a/src/generic_core/ui_connector.ts
+++ b/src/generic_core/ui_connector.ts
@@ -68,8 +68,8 @@ export class UIConnector {
         return Promise.resolve();
       }
 
-      return (<Promise<any>>result).then((result?:any) => {
-        this.fulfillPromise_(args.promiseId, cmd, result);
+      return (<Promise<any>>result).then((result2?:any) => {
+        this.fulfillPromise_(args.promiseId, cmd, result2);
       }, (error :Error) => {
         this.rejectPromise_(args.promiseId, error);
       });

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -619,7 +619,8 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
     }
 
     return new Promise<void>((fulfill, reject) => {
-      var checkIfOnline = () => {
+      let intervalId: NodeJS.Timer;
+      const checkIfOnline = () => {
         ping().then(() => {
           clearInterval(intervalId);
           fulfill();
@@ -628,7 +629,7 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
           // we will try again on the next interval.
         });
       };
-      var intervalId = setInterval(checkIfOnline, 5000);
+      intervalId = setInterval(checkIfOnline, 5000);
       checkIfOnline();
     });
   }

--- a/src/generic_core/uproxy_core.ts
+++ b/src/generic_core/uproxy_core.ts
@@ -168,11 +168,12 @@ export class uProxyCore implements uproxy_core_api.CoreApi {
    */
   public logout = (networkInfo :social.SocialNetworkInfo) : Promise<void> => {
     var networkName = networkInfo.name;
+    let network :social.Network;
     if (networkInfo.userId) {
       const userId = networkInfo.userId;
-      var network = social_network.getNetwork(networkName, userId);
+      network = social_network.getNetwork(networkName, userId);
     } else {
-      var network = this.getNetworkByName_(networkName);
+      network = this.getNetworkByName_(networkName);
     }
 
     if (null === network) {

--- a/src/generic_ui/polymer/advanced-settings.ts
+++ b/src/generic_ui/polymer/advanced-settings.ts
@@ -46,12 +46,12 @@ Polymer({
   // We will only check that the number and names of keys are identical.
   // This will fail if the user tries to change key order.
   checkSettings_: function(oldSettings :any, newSettings :any) {
-    for (var key in oldSettings){
+    for (const key in oldSettings){
       if (!(key in newSettings)) {
         return false;
       }
     }
-    for (var key in newSettings){
+    for (const key in newSettings){
       if (!(key in oldSettings)) {
         return false;
       }

--- a/src/generic_ui/polymer/settings.ts
+++ b/src/generic_ui/polymer/settings.ts
@@ -30,11 +30,10 @@ Polymer({
 
     var isGetting = ui.isGettingAccess();
     var isSharing = ui.isGivingAccess();
-    var confirmationMessage: string = null;
     var confirmLogout = Promise.resolve();
 
     if (isGetting || isSharing) {
-      var confirmationMessage = dialogs.getLogoutConfirmationMessage(ui.isGettingAccess(), ui.isGivingAccess());
+      const confirmationMessage = dialogs.getLogoutConfirmationMessage(ui.isGettingAccess(), ui.isGivingAccess());
       confirmLogout = this.$.state.openDialog(dialogs.getConfirmationDialogDescription('', confirmationMessage));
     }
 

--- a/src/generic_ui/polymer/state.ts
+++ b/src/generic_ui/polymer/state.ts
@@ -37,7 +37,7 @@ Polymer({
     dialogClickFn(fulfill, data);
     dialogClickFn = null;
   },
-  openDialog: function(data: ui.DialogDescription) {
+  openDialog: function(dialogDescription: ui.DialogDescription) {
     return new Promise<Object>((F, R) => {
       if (dialogClickFn) {
         console.error('Previous dialog was not cleaned up');
@@ -53,7 +53,7 @@ Polymer({
 
       this.fire('core-signal', {
         name: 'open-dialog',
-        data: data
+        data: dialogDescription
       });
     });
   }

--- a/src/generic_ui/scripts/ui.ts
+++ b/src/generic_ui/scripts/ui.ts
@@ -500,7 +500,7 @@ export class UserInterface implements ui_constants.UiApi {
 
     if (networkName == 'Cloud') {
       // Log into cloud if needed.
-      var loginPromise = Promise.resolve();
+      let loginPromise = Promise.resolve();
       if (!this.model.getNetwork('Cloud')) {
         loginPromise = this.login('Cloud');
       }
@@ -518,7 +518,7 @@ export class UserInterface implements ui_constants.UiApi {
     }
 
     // loginPromise should resolve when the use is logged into networkName.
-    var loginPromise :Promise<void>;
+    let loginPromise :Promise<void>;
     if (networkName == 'Quiver') {
       // Show user confirmation for Quiver login, where they can enter their
       // Quiver user name.
@@ -880,11 +880,11 @@ export class UserInterface implements ui_constants.UiApi {
 
     user.update(payload);
 
-    for (var i = 0; i < payload.allInstanceIds.length; ++i) {
+    for (let i = 0; i < payload.allInstanceIds.length; ++i) {
       this.mapInstanceIdToUser_[payload.allInstanceIds[i]] = user;
     }
 
-    for (var i = 0; i < payload.offeringInstances.length; i++) {
+    for (let i = 0; i < payload.offeringInstances.length; i++) {
       let instance = payload.offeringInstances[i];
       this.syncGettingState_(instance);
       this.syncTryingToGetState_(instance);
@@ -892,7 +892,7 @@ export class UserInterface implements ui_constants.UiApi {
     }
     this.updateGettingStatusBar_();
 
-    for (var i = 0; i < payload.instancesSharingWithLocal.length; i++) {
+    for (let i = 0; i < payload.instancesSharingWithLocal.length; i++) {
       this.instancesGivingAccessTo[payload.instancesSharingWithLocal[i]] = true;
       user.isGettingFromMe = true;
     }

--- a/src/lib/bridge/bridge.spec.ts
+++ b/src/lib/bridge/bridge.spec.ts
@@ -1,13 +1,12 @@
 import * as freedomMocker from '../freedom/mocks/mock-freedom-in-module-env';
+import mockFreedomRtcPeerConnection from '../freedom/mocks/mock-rtcpeerconnection';
 declare var freedom: freedom.FreedomInModuleEnv;
 freedom = freedomMocker.makeMockFreedomInModuleEnv({
   'core.rtcpeerconnection': () => { return new mockFreedomRtcPeerConnection(); }
 });
-
 import * as bridge from './bridge';
 import * as datachannel from '../webrtc/datachannel';
 import * as handler from '../handler/queue';
-import mockFreedomRtcPeerConnection from '../freedom/mocks/mock-rtcpeerconnection';
 import * as peerconnection from '../webrtc/peerconnection';
 import * as peerconnection_types from '../webrtc/signals';
 

--- a/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
+++ b/src/lib/integration-tests/socks-echo/base-spec.core-env.ts
@@ -20,7 +20,6 @@ export function socksEchoTestDescription(useChurn:boolean) {
 
   var testerFactoryManager
         :freedom.FreedomModuleFactoryManager<ProxyIntegrationTester>;
-  var testModule :ProxyIntegrationTester;
   var createTestModule = function(denyLocalhost?:boolean, sessionLimit?:number,
                                   ipv6Only?:boolean, reproxy?:boolean)
                                   : ProxyIntegrationTester {

--- a/src/lib/loggingprovider/loggingprovider.ts
+++ b/src/lib/loggingprovider/loggingprovider.ts
@@ -57,13 +57,13 @@ export class AbstractLoggingDestination {
   private doFilterChanges_ = (doChange :Function) => {
     var oldLevels :{[tag :string] :logging.Level} = {};
 
-    for (var tag in listeners) {
+    for (const tag in listeners) {
       oldLevels[tag] = getMinLevel(tag);
     }
 
     doChange();
 
-    for (var tag in oldLevels) {
+    for (const tag in oldLevels) {
       if (oldLevels[tag] !== getMinLevel(tag)) {
         updateTag(tag);
       }

--- a/src/lib/loggingprovider/loggingprovider.ts
+++ b/src/lib/loggingprovider/loggingprovider.ts
@@ -17,6 +17,8 @@ export var logBuffer: logging.Message[] = [];
 
 export var enabled = true;
 
+const listeners :{[tag :string] :LoggingListener[]} = {};
+
 // This represents a possible destination for log messages.  To make use of
 // this, the class should be inherited from and the log_ method reimplemented
 // to record the message in whichever way is best for that transport.
@@ -192,8 +194,6 @@ export class Log implements logging.Log {
     this.log_(logging.Level.error, source, msg);
   }
 }
-
-var listeners :{[tag :string] :LoggingListener[]} = {};
 
 function getMinLevel(tag :string) {
   var min = logging.Level.error;

--- a/src/lib/nat/probe.ts
+++ b/src/lib/nat/probe.ts
@@ -13,7 +13,7 @@ var TEST_PORT = 6666;
 var log :logging.Log = new logging.Log('probe');
 
 export function probe() : Promise<string> {
-  return new Promise((F, R) => {
+  return new Promise((resolve, reject) => {
     var socket :freedom.UdpSocket.Socket = freedom['core.udpsocket']();
     // The weird-looking type is due to a DefinitelyTyped weirdness
     // mentioned here:
@@ -29,31 +29,31 @@ export function probe() : Promise<string> {
       var rsp = JSON.parse(rspStr);
 
       if (rsp['answer'] === 'FullCone') {
-        F('FullCone');
+        resolve('FullCone');
       } else if (rsp['answer'] === 'RestrictedConePrepare') {
-        var peer_addr: string[] = rsp['prepare_peer'].split(':');
-        var req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
+        const peer_addr: string[] = rsp['prepare_peer'].split(':');
+        const req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
         log.debug('reply to RestrictedConePrepare');
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] === 'RestrictedCone') {
-        F('RestrictedCone');
+        resolve('RestrictedCone');
       } else if (rsp['answer'] === 'PortRestrictedConePrepare') {
-        var peer_addr: string[] = rsp['prepare_peer'].split(':');
-        var req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
+        const peer_addr: string[] = rsp['prepare_peer'].split(':');
+        const req: ArrayBuffer = arraybuffers.stringToArrayBuffer('{"ask":""}');
         log.debug('reply to PortRestrictedConePrepare');
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] === 'PortRestrictedCone') {
-        F('PortRestrictedCone');
+        resolve('PortRestrictedCone');
       } else if (rsp['answer'] === 'SymmetricNATPrepare') {
-        var peer_addr: string[] = rsp['prepare_peer'].split(':');
-        var reqStr: string = JSON.stringify({ 'ask': 'AmISymmetricNAT' });
-        var req: ArrayBuffer = arraybuffers.stringToArrayBuffer(reqStr);
+        const peer_addr: string[] = rsp['prepare_peer'].split(':');
+        const reqStr: string = JSON.stringify({ 'ask': 'AmISymmetricNAT' });
+        const req: ArrayBuffer = arraybuffers.stringToArrayBuffer(reqStr);
         socket.sendTo(req, peer_addr[0], parseInt(peer_addr[1]));
         return;
       } else if (rsp['answer'] === 'SymmetricNAT') {
-        F('SymmetricNAT');
+        resolve('SymmetricNAT');
       } else {
         return;
       }
@@ -133,7 +133,7 @@ export function probe() : Promise<string> {
     }).catch((e: Error) => {
       if (e.message !== 'shortCircuit') {
         log.error('something wrong: ' + e.message);
-        R(e);
+        reject(e);
       } else {
         log.debug('shortCircuit');
       }

--- a/src/lib/net/linefeeder.spec.ts
+++ b/src/lib/net/linefeeder.spec.ts
@@ -38,10 +38,10 @@ describe('LineFeeder', function() {
     bufferQueue.handle(arraybuffers.stringToArrayBuffer('a\nb\n'));
     lines.flush();
 
-    lines.setSyncNextHandler((result: string) => {
-      expect(result).toEqual('a');
-      lines.setSyncNextHandler((result: string) => {
-        expect(result).toEqual('b');
+    lines.setSyncNextHandler((result1: string) => {
+      expect(result1).toEqual('a');
+      lines.setSyncNextHandler((result2: string) => {
+        expect(result2).toEqual('b');
         done();
       });
     });

--- a/src/lib/rtc-to-net/rtc-to-net.ts
+++ b/src/lib/rtc-to-net/rtc-to-net.ts
@@ -588,8 +588,8 @@ import ProxyConfig from './proxyconfig';
                       [this.longId(), userpass]);
             this.tcpConnection_.send(userpassRequest);
             return this.tcpConnection_.receiveNext()
-              .then((buffer:ArrayBuffer) :void => {
-                var success :boolean = socks_headers.interpretUserPassResponse(buffer);
+              .then((userPassResponseBuffer:ArrayBuffer) :void => {
+                var success :boolean = socks_headers.interpretUserPassResponse(userPassResponseBuffer);
                 log.debug('%1: Received userpass subnegotiation reply: %2',
                           [this.longId(), success]);
                 if (!success) {

--- a/src/lib/socks/headers.ts
+++ b/src/lib/socks/headers.ts
@@ -326,7 +326,7 @@ export function interpretRequest(byteArray:Uint8Array) : Request {
   }
 
   // Fail if client is not talking Socks version 5.
-  var version = byteArray[0];
+  version = byteArray[0];
   if (version !== Version.VERSION5) {
     throw new Error('must be SOCKS5');
   }

--- a/src/lib/transformers/defragmenter.ts
+++ b/src/lib/transformers/defragmenter.ts
@@ -50,7 +50,7 @@ export class Defragmenter {
       // A fragment for an existing packet
 
       // Get list of fragment contents for this packet identifier
-      var fragmentList :ArrayBuffer[] = this.tracker_[hexid].pieces;
+      const fragmentList :ArrayBuffer[] = this.tracker_[hexid].pieces;
       if (fragmentList[fragment.index] !== null) {
         // Duplicate fragment
 
@@ -86,7 +86,7 @@ export class Defragmenter {
       // A new fragment for a new packet
 
       // Make an empty list of fragments.
-      var fragmentList :ArrayBuffer[] = [];
+      const fragmentList :ArrayBuffer[] = [];
       for(var i = 0; i < fragment.count; i++) {
         fragmentList.push(null);
       }

--- a/src/lib/webrtc/peerconnection.spec.ts
+++ b/src/lib/webrtc/peerconnection.spec.ts
@@ -104,6 +104,8 @@ describe('PeerConnection', function() {
     spyOn(mockRtcPeerConnection, 'addIceCandidate').and.returnValue(
         Promise.resolve());
 
+    const pc = new peerconnection.PeerConnectionClass(mockRtcPeerConnection);
+
     var setRemoteDescriptionSpy = spyOn(mockRtcPeerConnection,
         'setRemoteDescription').and.callFake(
         (desc:freedom.RTCPeerConnection.RTCSessionDescription) => {
@@ -118,7 +120,6 @@ describe('PeerConnection', function() {
       return Promise.resolve();
     });
 
-    var pc = new peerconnection.PeerConnectionClass(mockRtcPeerConnection);
     pc.negotiateConnection();
     pc.handleSignalMessage({
       type: signals.Type.ANSWER,
@@ -130,6 +131,7 @@ describe('PeerConnection', function() {
       expect(mockRtcPeerConnection.addIceCandidate).toHaveBeenCalled();
       done();
     });
+
   });
 });
 

--- a/src/lib/webrtc/peerconnection.ts
+++ b/src/lib/webrtc/peerconnection.ts
@@ -293,7 +293,7 @@ export class PeerConnectionClass implements PeerConnection<signals.Message> {
   // response, and goes to 'disconnected' or 'failed' if pings consistently
   // fail.
   private onIceConnectionStateChange_ = () : void => {
-    var state = this.pc_.getIceConnectionState().then((state:string) => {
+    this.pc_.getIceConnectionState().then((state:string) => {
       log.debug('%1: ice connection state: %2', this.peerName_, state);
 
       if (state === 'disconnected') {

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -10,6 +10,7 @@
       "spaces"
     ],
     "no-trailing-whitespace": true,
-    "no-shadowed-variable": true
+    "no-shadowed-variable": true,
+    "no-duplicate-variable": true
   }
 }

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -9,6 +9,7 @@
       true,
       "spaces"
     ],
-    "no-trailing-whitespace": true
+    "no-trailing-whitespace": true,
+    "no-shadowed-variable": true
   }
 }

--- a/src/tslint.json
+++ b/src/tslint.json
@@ -11,6 +11,7 @@
     ],
     "no-trailing-whitespace": true,
     "no-shadowed-variable": true,
-    "no-duplicate-variable": true
+    "no-duplicate-variable": true,
+    "no-use-before-declare": true
   }
 }


### PR DESCRIPTION
I was working on some code this morning and spent ages debugging an issue only to eventually realise I had redeclared (shadowed) a variable. Argh, can't tslint help with that? Yes it can.

This adds three more tslint rules:
* https://palantir.github.io/tslint/rules/no-shadowed-variable/
* https://palantir.github.io/tslint/rules/no-duplicate-variable/
* https://palantir.github.io/tslint/rules/no-use-before-declare/

The last two would actually be superceded by https://palantir.github.io/tslint/rules/no-var-keyword/ but I figure we're some way from that :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2847)
<!-- Reviewable:end -->
