### PR TITLE
fix numGetters logic, support getting from multiple peers simultaneously

### DIFF
--- a/src/lib/socks/node/server.ts
+++ b/src/lib/socks/node/server.ts
@@ -3,6 +3,7 @@ import * as piece from '../piece';
 import * as socks_server from '../server';
 
 export class NodeSocksServer implements socks_server.SocksServer {
+  private tcpServer: net.Server;
   private getSocksSession: (clientId: string) => piece.SocksPiece;
   private numSessions = 0;
 
@@ -14,12 +15,16 @@ export class NodeSocksServer implements socks_server.SocksServer {
   public onConnection = (callback: (clientId: string) => piece.SocksPiece) => {
     this.getSocksSession = callback;
     return this;
-  }
+  };
+
+  public address = () => {
+    return this.tcpServer.address();
+  };
 
   public listen = () => {
     // complete list of events:
     //   https://nodejs.org/dist/latest-v4.x/docs/api/net.html#net_class_net_server
-    const server = net.createServer((client) => {
+    const server = this.tcpServer = net.createServer((client) => {
       const clientId = 'p' + (this.numSessions++) + 'p';
 
       console.info(clientId + ': new client from ' +


### PR DESCRIPTION
Hey @trevj, I realized I could listen for ice connection state changes to track the current number of getters with active peer connections, so I implemented that here. I think this now correctly matches the intended behavior.

I also added support for getting access from multiple peers at the same time, which required a small change to NodeSocksServer. (Just needed to expose the underlying net.Server.address() method, so that when we currently have a giver and therefore are already running a socks server on the base port, we can pass 0 for the port, and then query for what it turned out to be once we're listening.)

Also added some explanatory comments and a few more small corrections and code improvements.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2848)
<!-- Reviewable:end -->
