### PR TITLE
Setting isMetricsEnabled flag in Zork Firefox app based on options file

### DIFF
--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -15,7 +15,7 @@ function checkIfMetricsEnabled() {
         let decoder = new TextDecoder();
         let text = decoder.decode(array);
         let options = JSON.parse(text);
-        return options['areMetricsEnabled'] === true;
+        return options['isMetricsEnabled'] === true;
       } catch (e) {
         console.error('Could not parse options file');
         return false;

--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -1,16 +1,43 @@
 const {Cu} = require("chrome");
 var self = require("sdk/self");
 var {setTimeout} = require("sdk/timers");
+const {TextDecoder, OS} = Cu.import("resource://gre/modules/osfile.jsm", {});
 
 Cu.import(self.data.url("freedom-for-firefox/freedom-for-firefox.jsm"));
 
+const OPTIONS_FILE_PATH = '/zork-options';
+
+// Returns Promise<boolean>
+function checkIfMetricsEnabled() {
+  return OS.File.read(OPTIONS_FILE_PATH).then(
+    function onSuccess(array) {
+      try {
+        let decoder = new TextDecoder();
+        let text = decoder.decode(array);
+        let options = JSON.parse(text);
+        return options['areMetricsEnabled'] === true;
+      } catch (e) {
+        console.error('Could not parse options file');
+        return false;
+      }
+    }
+  ).catch(function(e) {
+    console.warn('Could not find options file');
+    return false;  // Options file not found, not an error.
+  });
+}
+
 var manifest = self.data.url("lib/zork/freedom-module.json");
 var loggingProviderManifest = self.data.url("lib/loggingprovider/freedom-module.json");
+var provider;
 freedom(manifest, {
   'logger': loggingProviderManifest,
   'debug': 'debug'
 }).then(function(moduleFactory) {
-  moduleFactory();
+  let provider = moduleFactory();
+  checkIfMetricsEnabled().then(function(isEnabled) {
+    provider.emit('setMetricsEnablement', isEnabled);
+  });
 }, function() {
   console.error('could not load freedomjs module');
 });

--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -9,19 +9,17 @@ const OPTIONS_FILE_PATH = '/zork-options';
 
 // Returns Promise<boolean>
 function checkIfMetricsEnabled() {
-  return OS.File.read(OPTIONS_FILE_PATH).then(
-    function onSuccess(array) {
-      try {
-        let decoder = new TextDecoder();
-        let text = decoder.decode(array);
-        let options = JSON.parse(text);
-        return options['isMetricsEnabled'] === true;
-      } catch (e) {
-        console.error('Could not parse options file');
-        return false;
-      }
+  return OS.File.read(OPTIONS_FILE_PATH).then((array) => {
+    try {
+      let decoder = new TextDecoder();
+      let text = decoder.decode(array);
+      let options = JSON.parse(text);
+      return options['isMetricsEnabled'] === true;
+    } catch (e) {
+      console.error('Could not parse options file');
+      return false;
     }
-  ).catch(function(e) {
+  }).catch((e) => {
     console.warn('Could not find options file');
     return false;  // Options file not found, not an error.
   });
@@ -29,12 +27,11 @@ function checkIfMetricsEnabled() {
 
 var manifest = self.data.url("lib/zork/freedom-module.json");
 var loggingProviderManifest = self.data.url("lib/loggingprovider/freedom-module.json");
-var provider;
 freedom(manifest, {
   'logger': loggingProviderManifest,
   'debug': 'debug'
 }).then(function(moduleFactory) {
-  let provider = moduleFactory();
+  const provider = moduleFactory();
   checkIfMetricsEnabled().then(function(isEnabled) {
     provider.emit('setMetricsEnablement', isEnabled);
   });

--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -11,9 +11,9 @@ const OPTIONS_FILE_PATH = '/zork-options';
 function checkIfMetricsEnabled() {
   return OS.File.read(OPTIONS_FILE_PATH).then((array) => {
     try {
-      let decoder = new TextDecoder();
-      let text = decoder.decode(array);
-      let options = JSON.parse(text);
+      const decoder = new TextDecoder();
+      const text = decoder.decode(array);
+      const options = JSON.parse(text);
       return options['isMetricsEnabled'] === true;
     } catch (e) {
       console.error('Could not parse options file');

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -43,6 +43,14 @@ var PORTS = [9000, 9010, 9020];
 // Number of getters.
 let numOfGetters = 0;
 
+let isMetricsEnabled = false;
+if (typeof freedom !== 'undefined') {
+  var parentFreedomModule = freedom();
+  parentFreedomModule.on('setMetricsEnablement', function(newValue) {
+    isMetricsEnabled = newValue;
+  });
+}
+
 // Starts a TCP server on the first free port listed in PORTS.
 // Rejects if no port is free.
 function bind(i:number = 0) : Promise<tcp.Server> {

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -45,7 +45,7 @@ let numOfGetters = 0;
 
 let isMetricsEnabled = false;
 if (typeof freedom !== 'undefined') {
-  var parentFreedomModule = freedom();
+  const parentFreedomModule = freedom();
   parentFreedomModule.on('setMetricsEnablement', function(newValue) {
     isMetricsEnabled = newValue;
   });


### PR DESCRIPTION
This pull request modifies the Zork Firefox app so that it will set a isMetricsEnabled flag to true iff a "/zork-options" JSON file exists on that machine (i.e. Zork docker container) with ```"isMetricsEnabled": true```.

Note currently isMetricsEnabled is not yet used, and the Zork install scripts are not yet setting this file.  This just lays the groundwork for enabling server-side metrics.  Next changes will be:
* Setting this file in the docker install scripts
* Reporting metrics from the server if ```isMetricsEnabled==true```
* Asking users to opt into metrics collection during server creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2855)
<!-- Reviewable:end -->
