### PR TITLE
backpressure, heartbeat datachannel, numGetters, misc.

### DIFF
--- a/src/lib/socks/node/socket.ts
+++ b/src/lib/socks/node/socket.ts
@@ -17,6 +17,14 @@ export class NodeForwardingSocket implements piece.SocksPiece {
     });
   }
 
+  public pause = () => {
+    this.socket.pause();
+  };
+
+  public resume = () => {
+    this.socket.resume();
+  };
+
   public onDataForSocksClient = (callback: (buffer: ArrayBuffer) => void): NodeForwardingSocket => {
     this.onDataCallback = callback;
     return this;


### PR DESCRIPTION
#2848 changed the numGetters tracking logic to check for ice connection state changes to the 'connected' and 'disconnected' states to update numGetters accordingly. This logic starts here: https://github.com/uProxy/uproxy/pull/2848/files#diff-1978b1ecb88355bcd34e7e58e5828653R198

But I just noticed #1511, in which @bemasc says: "In principle 'disconnected' may fire after 5 seconds of no response, but the connection may automatically transition back to the 'connected' state if pings start working again within 30 seconds." That would make the implementation above quite oversensitive.

I noticed our current code uses a heartbeat approach to track connection health (search [peerconnection.ts](https://github.com/uProxy/uproxy/blob/ffab27e6/src/lib/webrtc/peerconnection.ts) for "heartbeat"). This PR swaps out the bootstrap datachannel for a heartbeat datachannel, and changes the numGetters logic to check whether we've gotten any heartbeats within a HEARTBEAT_TIMEOUT. This is preferable, no?

Some other small fixes are also included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2856)
<!-- Reviewable:end -->
