### PR TITLE
Add server-side metrics

### DIFF
--- a/docker/testing/run-scripts/image_make.sh
+++ b/docker/testing/run-scripts/image_make.sh
@@ -64,4 +64,5 @@ EOF
 
 ${BASH_SOURCE%/*}/gen_browser.sh "$@" >> $TMP_DIR/Dockerfile
 
+# TODO: remove dborkan before merging
 docker build -t dborkan/$BROWSER-$VERSION $TMP_DIR

--- a/docker/testing/run-scripts/image_make.sh
+++ b/docker/testing/run-scripts/image_make.sh
@@ -39,7 +39,7 @@ cat <<EOF > $TMP_DIR/Dockerfile
 FROM phusion/baseimage:0.9.19
 
 RUN apt-get -qq update
-RUN apt-get -qq --fix-missing install wget unzip bzip2 supervisor iptables unattended-upgrades
+RUN apt-get -qq install wget unzip bzip2 supervisor iptables unattended-upgrades
 
 RUN mkdir /test
 COPY test /test

--- a/docker/testing/run-scripts/image_make.sh
+++ b/docker/testing/run-scripts/image_make.sh
@@ -39,7 +39,7 @@ cat <<EOF > $TMP_DIR/Dockerfile
 FROM phusion/baseimage:0.9.19
 
 RUN apt-get -qq update
-RUN apt-get -qq install wget unzip bzip2 supervisor iptables unattended-upgrades
+RUN apt-get -qq --fix-missing install wget unzip bzip2 supervisor iptables unattended-upgrades
 
 RUN mkdir /test
 COPY test /test
@@ -64,4 +64,4 @@ EOF
 
 ${BASH_SOURCE%/*}/gen_browser.sh "$@" >> $TMP_DIR/Dockerfile
 
-docker build -t uproxy/$BROWSER-$VERSION $TMP_DIR
+docker build -t dborkan/$BROWSER-$VERSION $TMP_DIR

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -152,7 +152,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
   docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d $ZORK_IMAGE
   # TODO: switch based on input arg
-  docker exec  bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
+  docker exec uproxy-zork bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
   docker exec uproxy-zork /sbin/my_init -- /test/bin/load-zork.sh -z
 
   echo -n "Waiting for Zork to come up..."

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -11,7 +11,7 @@
 set -e
 
 PREBUILT=false
-ZORK_IMAGE="dborkan/zork"
+ZORK_IMAGE="dborkan/zork"   # TODO: change this before merging
 SSHD_IMAGE="uproxy/sshd"
 INVITE_CODE=
 UPDATE=false

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -153,7 +153,7 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d $ZORK_IMAGE
   # TODO: switch based on input arg
   docker exec uproxy-zork bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
-  docker exec uproxy-zork /sbin/my_init -- /test/bin/load-zork.sh -z
+  docker exec -d uproxy-zork /sbin/my_init -- /test/bin/load-zork.sh -z
 
   echo -n "Waiting for Zork to come up..."
   echo "CLOUD_INSTALL_STATUS_WAITING_FOR_UPROXY"

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -151,8 +151,10 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   # Full list of capabilities:
   #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
   docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d $ZORK_IMAGE
-  # TODO: switch based on input arg
-  docker exec uproxy-zork bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
+  if [ -n "$SERVER_ID" ]
+  then
+    docker exec uproxy-zork bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
+  fi
   docker exec -d uproxy-zork /sbin/my_init -- /test/bin/load-zork.sh -z
 
   echo -n "Waiting for Zork to come up..."

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -11,7 +11,7 @@
 set -e
 
 PREBUILT=false
-ZORK_IMAGE="uproxy/zork"
+ZORK_IMAGE="dborkan/zork"
 SSHD_IMAGE="uproxy/sshd"
 INVITE_CODE=
 UPDATE=false

--- a/docker/testing/run-scripts/run_cloud.sh
+++ b/docker/testing/run-scripts/run_cloud.sh
@@ -20,15 +20,17 @@ PUBLIC_IP=
 BANNER=
 AUTOMATED=false
 KEY=
+SERVER_ID=
 
 SSHD_PORT=5000
 
 function usage () {
-  echo "$0 [-p] [-z zork_image] [-s sshd_image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a] [-k key]"
+  echo "$0 [-p] [-z zork_image] [-m serverIdForMetrics] [-s sshd_image] [-i invite code] [-u] [-w] [-d ip] [-b banner] [-a] [-k key]"
   echo "  -p: use Zork from this client rather than the Docker image"
   echo "  -z: use a specified Zork image (defaults to uproxy/zork)"
   echo "  -s: use a specified sshd image (defaults to uproxy/sshd)"
   echo "  -i: bootstrap invite (only for new installs, or with -w)"
+  echo "  -m: unique serverId, used for metrics"
   echo "  -u: rebuild Docker images (preserves invites and metadata unless -w used)"
   echo "  -w: when -u used, do not copy invites or metadata from current installation"
   echo "  -d: override the detected public IP (for development only)"
@@ -39,7 +41,7 @@ function usage () {
   exit 1
 }
 
-while getopts pz:s:i:uwd:b:k:ah? opt; do
+while getopts pz:s:i:m:uwd:b:k:ah? opt; do
   case $opt in
     p) PREBUILT=true ;;
     z) ZORK_IMAGE="$OPTARG" ;;
@@ -51,6 +53,7 @@ while getopts pz:s:i:uwd:b:k:ah? opt; do
     b) BANNER="$OPTARG" ;;
     a) AUTOMATED=true ;;
     k) KEY="$OPTARG" ;;
+    m) SERVER_ID="$OPTARG" ;;
     *) usage ;;
   esac
 done
@@ -147,7 +150,10 @@ if ! docker ps -a | grep uproxy-zork >/dev/null; then
   # NET_ADMIN is required to run iptables inside the container.
   # Full list of capabilities:
   #   https://docs.docker.com/engine/reference/run/#runtime-privilege-linux-capabilities-and-lxc-configuration
-  docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d $ZORK_IMAGE /sbin/my_init -- /test/bin/load-zork.sh -z
+  docker run --restart=always --net=host --cap-add NET_ADMIN $HOSTARGS --name uproxy-zork -d $ZORK_IMAGE
+  # TODO: switch based on input arg
+  docker exec  bash -c "echo '{\"isMetricsEnabled\": true, \"serverId\": \"$SERVER_ID\"}' >/zork-options"
+  docker exec uproxy-zork /sbin/my_init -- /test/bin/load-zork.sh -z
 
   echo -n "Waiting for Zork to come up..."
   echo "CLOUD_INSTALL_STATUS_WAITING_FOR_UPROXY"

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -88,7 +88,7 @@ do_install() {
 
   echo "CLOUD_INSTALL_STATUS_DOWNLOADING_INSTALL_SCRIPTS"
   TMP_DIR=`mktemp -d`
-  # TODO: use this
+  # TODO: remove dborkan-server-metrics code before merging
   #git clone --depth 1 https://github.com/uProxy/uproxy.git $TMP_DIR
   git clone https://github.com/uProxy/uproxy.git $TMP_DIR
   cd $TMP_DIR
@@ -111,7 +111,7 @@ do_install() {
   then
     RUN_CLOUD_ARGS="$RUN_CLOUD_ARGS -m $SERVER_ID"
   fi
-  # TODO: use this
+  # TODO: remove $TMP_DIR/ use before merging
   #$TMP_DIR/docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
   docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
 }

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -88,7 +88,11 @@ do_install() {
 
   echo "CLOUD_INSTALL_STATUS_DOWNLOADING_INSTALL_SCRIPTS"
   TMP_DIR=`mktemp -d`
-  git clone --depth 1 https://github.com/uProxy/uproxy.git $TMP_DIR
+  # TODO: use this
+  #git clone --depth 1 https://github.com/uProxy/uproxy.git $TMP_DIR
+  git clone https://github.com/uProxy/uproxy.git $TMP_DIR
+  cd $TMP_DIR
+  git checkout dborkan-server-metrics
 
   RUN_CLOUD_ARGS=
   if [ "$AUTOMATED" = true ]
@@ -107,7 +111,9 @@ do_install() {
   then
     RUN_CLOUD_ARGS="$RUN_CLOUD_ARGS -m $SERVER_ID"
   fi
-  $TMP_DIR/docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
+  # TODO: use this
+  #$TMP_DIR/docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
+  docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
 }
 
 # Wrapped in a function for some protection against half-downloads.

--- a/install-cloud.sh
+++ b/install-cloud.sh
@@ -16,20 +16,23 @@ REQUIRED_COMMANDS="docker git nc"
 AUTOMATED=false
 KEY=
 UPDATE=false
+SERVER_ID=
 
 usage() {
-  echo "$0 [-a] [-k key] [-u] [-h]"
+  echo "$0 [-a] [-k key] [-m serverIdForMetrics] [-u] [-h]"
   echo "  -a: do not output complete invite URL"
   echo "  -k: public key, base64 encoded (if unspecified, a new invite code is generated)"
+  echo "  -m: unique serverId, used for metrics"
   echo "  -u: update Docker images (preserves invites and metadata)"
   echo "  -h, -?: this help message"
   exit 1
 }
 
-while getopts k:auh? opt; do
+while getopts k:m:auh? opt; do
   case $opt in
     a) AUTOMATED=true ;;
     k) KEY="$OPTARG" ;;
+    m) SERVER_ID="$OPTARG" ;;
     u) UPDATE=true ;;
     *) usage ;;
   esac
@@ -99,6 +102,10 @@ do_install() {
   if [ -n "$KEY" ]
   then
     RUN_CLOUD_ARGS="$RUN_CLOUD_ARGS -k $KEY"
+  fi
+  if [ -n "$SERVER_ID" ]
+  then
+    RUN_CLOUD_ARGS="$RUN_CLOUD_ARGS -m $SERVER_ID"
   fi
   $TMP_DIR/docker/testing/run-scripts/run_cloud.sh $RUN_CLOUD_ARGS firefox-stable
 }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tslint": "^3.10.2",
     "typescript": "^2.0.3",
     "uparams": "^1.2.0",
-    "uproxy-cloud-install": "^1.0.17",
+    "uproxy-cloud-install": "^1.0.21",
     "xregexp": "^2.0.0"
   },
   "scripts": {

--- a/src/generic_core/social.ts
+++ b/src/generic_core/social.ts
@@ -565,6 +565,11 @@ export function notifyUI(networkName :string, userId :string) {
           interactive: interactive,
           rememberLogin: rememberLogin
         };
+        // TODO: clean up
+        if (this.name === 'Cloud') {
+          // TODO: get instanceId..  right now this isn't set until after login
+          request.userName = Math.random().toString();
+        }
       }
 
       this.onceLoggedIn_ = this.freedomApi_.login(request)

--- a/src/lib/cloud/social/freedom-module.json
+++ b/src/lib/cloud/social/freedom-module.json
@@ -18,6 +18,7 @@
           "agent": "string",
           "version": "string",
           "url": "string",
+          "userName": "string",
           "interactive": "boolean",
           "rememberLogin": "boolean"
         }],

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -304,7 +304,6 @@ export class CloudSocialProvider {
     log.debug('login: %1', options);
     this.loadContacts_();
     this.instanceId_ = options.userName;
-    console.error('got this.instanceId_ ' + this.instanceId_);
     // TODO: emit an onUserProfile event, which can include an image URL
     // TODO: base this on the user's public key?
     //       (shown in the "connected accounts" page)

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -337,7 +337,6 @@ export class CloudSocialProvider {
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
-            // connection.sendMessage('instanceid ' + this.instanceId_);
             connection.sendMessage('give ' + this.instanceId_);
           });
         } else {

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -337,8 +337,8 @@ export class CloudSocialProvider {
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
-            connection.sendMessage('instanceid ' + this.instanceId_);
-            connection.sendMessage('give');
+            // connection.sendMessage('instanceid ' + this.instanceId_);
+            connection.sendMessage('give ' + this.instanceId_);
           });
         } else {
           if (destinationClientId in this.clients_) {

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -177,6 +177,8 @@ export class CloudSocialProvider {
 
   private static PING_INTERVAL_ = 60000;
 
+  private instanceId_ :string;
+
   constructor(private dispatchEvent_: (name: string, args: Object) => void) { }
 
   // Emits the messages necessary to make the user appear online
@@ -297,10 +299,13 @@ export class CloudSocialProvider {
     });
   }
 
-  public login = (options: freedom.Social.LoginRequest):
+  // public login = (options: freedom.Social.LoginRequest):
+  public login = (options: any):
       Promise<freedom.Social.ClientState> => {
     log.debug('login: %1', options);
     this.loadContacts_();
+    this.instanceId_ = options.userName;
+    console.error('got this.instanceId_ ' + this.instanceId_);
     // TODO: emit an onUserProfile event, which can include an image URL
     // TODO: base this on the user's public key?
     //       (shown in the "connected accounts" page)
@@ -332,6 +337,7 @@ export class CloudSocialProvider {
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
+            connection.sendMessage('instanceId ' + this.instanceId_);
             connection.sendMessage('give');
           });
         } else {

--- a/src/lib/cloud/social/provider.ts
+++ b/src/lib/cloud/social/provider.ts
@@ -337,7 +337,7 @@ export class CloudSocialProvider {
           }
           return this.reconnect_(this.savedContacts_[destinationClientId].invite).then(
               (connection: Connection) => {
-            connection.sendMessage('instanceId ' + this.instanceId_);
+            connection.sendMessage('instanceid ' + this.instanceId_);
             connection.sendMessage('give');
           });
         } else {

--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -7,14 +7,22 @@ Cu.import(self.data.url("freedom-for-firefox/freedom-for-firefox.jsm"));
 
 const OPTIONS_FILE_PATH = '/zork-options';
 
-// Returns Promise<boolean>
-function checkIfMetricsEnabled() {
+function setIfMetricsEnabled(provider) {
   return OS.File.read(OPTIONS_FILE_PATH).then((array) => {
     try {
       const decoder = new TextDecoder();
       const text = decoder.decode(array);
+      console.error('read text: ' + text);
       const options = JSON.parse(text);
-      return options['isMetricsEnabled'] === true;
+      console.error('loaded options: ', options);
+      if (options['isMetricsEnabled'] === true) {
+        console.error('emiting isMetricsEnabled');
+        provider.emit('setMetricsEnablement', true);
+      }
+      if (options['serverId']) {
+        console.error('emiting setServerId');
+        provider.emit('setServerId', options['serverId']);
+      }
     } catch (e) {
       console.error('Could not parse options file');
       return false;
@@ -32,9 +40,7 @@ freedom(manifest, {
   'debug': 'debug'
 }).then(function(moduleFactory) {
   const provider = moduleFactory();
-  checkIfMetricsEnabled().then(function(isEnabled) {
-    provider.emit('setMetricsEnablement', isEnabled);
-  });
+  setIfMetricsEnabled(provider);
 }, function() {
   console.error('could not load freedomjs module');
 });

--- a/src/lib/samples/zork-firefoxapp/index.js
+++ b/src/lib/samples/zork-firefoxapp/index.js
@@ -12,15 +12,11 @@ function setIfMetricsEnabled(provider) {
     try {
       const decoder = new TextDecoder();
       const text = decoder.decode(array);
-      console.error('read text: ' + text);
       const options = JSON.parse(text);
-      console.error('loaded options: ', options);
       if (options['isMetricsEnabled'] === true) {
-        console.error('emiting isMetricsEnabled');
         provider.emit('setMetricsEnablement', true);
       }
       if (options['serverId']) {
-        console.error('emiting setServerId');
         provider.emit('setServerId', options['serverId']);
       }
     } catch (e) {

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -44,22 +44,18 @@ var PORTS = [9000, 9010, 9020];
 let numOfGetters = 0;
 
 let isMetricsEnabled = false;
-let serverId :string = null;
+let serverId :string = null;  // Must be set in order to post metrics.
 if (typeof freedom !== 'undefined') {
   const parentFreedomModule = freedom();
-  // TODO: type checking?  is newVale really a boolean?
   parentFreedomModule.on('setMetricsEnablement', function(newValue) {
-    console.error('setMetricsEnablement: ' + newValue);
     isMetricsEnabled = newValue;
   });
   parentFreedomModule.on('setServerId', function(newValue) {
-    console.error('setServerId: ' + newValue);
     serverId = newValue;
   });
 }
 
-// TODO: getterInstanceId not optional
-function postMetrics(startUtcMs :number, endUtcMs :number, getterInstanceId ?:string) {
+function postMetrics(startUtcMs: number, endUtcMs: number, getterInstanceId?: string) {
   if (!isMetricsEnabled || !serverId || !getterInstanceId) {
     return;
   }
@@ -130,22 +126,13 @@ function serveConnection(connection: tcp.Connection): void {
         } : undefined);
         break;
       case 'give':
-        try {
+        // Getter's may send instanceId (used for metrics) as 2nd word.
+        // Old getters will not set this.
+        if (words.length >= 2) {
           getterInstanceId = words[1];
-        } catch (e) {
-          // TODO: better error handling
-          console.error('could not get instanceId')
         }
         give(lineFeeder, connection, getterInstanceId);
         break;
-      // case 'instanceid':
-      //   try {
-      //     getterInstanceId = words[1];
-      //   } catch (e) {
-      //     // TODO: better error handling
-      //     console.error('could not get instanceId')
-      //   }
-      //   break;
       case 'ping':
         sendReply('ping', connection);
         keepParsing = true;

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -68,12 +68,12 @@ function postMetrics(startUtcMs: number, endUtcMs: number, getterInstanceId?: st
   xhr.onerror = function(e :ErrorEvent) {
     log.error('error posting metrics: ', e)
   };
+  // TODO: set bytesDownloadedByGetter
   let data = {
     serverId: serverId,
     getterId: getterInstanceId,
     startUtcMilliseconds: startUtcMs,
-    endUtcMilliseconds: endUtcMs,
-    bytesDownloadedByGetter: 1234
+    endUtcMilliseconds: endUtcMs
   }
   xhr.send(JSON.stringify(data));
 }

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -132,7 +132,7 @@ function serveConnection(connection: tcp.Connection): void {
       case 'give':
         give(lineFeeder, connection, getterInstanceId);
         break;
-      case 'instanceId':
+      case 'instanceid':
         try {
           getterInstanceId = words[1];
         } catch (e) {

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -130,16 +130,22 @@ function serveConnection(connection: tcp.Connection): void {
         } : undefined);
         break;
       case 'give':
-        give(lineFeeder, connection, getterInstanceId);
-        break;
-      case 'instanceid':
         try {
           getterInstanceId = words[1];
         } catch (e) {
           // TODO: better error handling
           console.error('could not get instanceId')
         }
+        give(lineFeeder, connection, getterInstanceId);
         break;
+      // case 'instanceid':
+      //   try {
+      //     getterInstanceId = words[1];
+      //   } catch (e) {
+      //     // TODO: better error handling
+      //     console.error('could not get instanceId')
+      //   }
+      //   break;
       case 'ping':
         sendReply('ping', connection);
         keepParsing = true;

--- a/src/lib/zork/freedom-module.ts
+++ b/src/lib/zork/freedom-module.ts
@@ -62,8 +62,12 @@ function postMetrics(startUtcMs: number, endUtcMs: number, getterInstanceId?: st
 
   var xhr = new XMLHttpRequest();
   xhr.open('POST', 'https://cloud-install-bigquery-dot-uproxysite.appspot.com/server-metrics');
-  xhr.onload = function() { console.error('xhr onload ' + this.status); };
-  xhr.onerror = function(e :ErrorEvent) { console.error('error posting metrics: ' + e) };
+  xhr.onload = function() {
+    log.info('Posted metrics with result ' + this.status);
+  };
+  xhr.onerror = function(e :ErrorEvent) {
+    log.error('error posting metrics: ', e)
+  };
   let data = {
     serverId: serverId,
     getterId: getterInstanceId,
@@ -71,7 +75,6 @@ function postMetrics(startUtcMs: number, endUtcMs: number, getterInstanceId?: st
     endUtcMilliseconds: endUtcMs,
     bytesDownloadedByGetter: 1234
   }
-  console.error('making XHR: ' + JSON.stringify(data));
   xhr.send(JSON.stringify(data));
 }
 


### PR DESCRIPTION
Add server-side metrics

Notes:
* This builds on https://github.com/uProxy/uproxy/pull/2853 (supporting names for cloud servers).
* There are also several TODOs, mostly to use custom dborkan branches/builds for testing.  These need to be removed before merging.
* I am using the second argument to the zork "give" command to pass the instanceId.  I originally tried making a new "instance" command, however sending "instance" followed by "give" broke proxying (I believe the LineFeeder ended up in a weird state, but didn't fully debug it).  I think this design is a bit nicer as the getterInstanceId is really only used for the "give" command, and this handles backwards compatibility nicely (old Zork servers will ignore the instanceId, rather than respond that it's an unknown command).
* There is a bit of ugliness in the social.ts file to pass the instanceId to the cloud social provider.  This is because in the past we only generated the instanceId after logging into the social network (so that different accounts of Google/Facebook/etc would get different instanceIds).  Once we move to uProxy Air this can be cleaned up.
* This should be merged along with https://github.com/uProxy/uproxy-website/pull/180 and https://github.com/uProxy/uproxy-cloud-install/pull/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2865)
<!-- Reviewable:end -->
