### PR TITLE
FIX: keys were not being base64-decoded before being written to authorized_keys

### DIFF
--- a/docker/sshd/issue_invite.sh
+++ b/docker/sshd/issue_invite.sh
@@ -42,7 +42,7 @@ fi
 # any future features being enabled on us by default.
 KEY_OPTS='restrict,command="/login.sh",port-forwarding,permitopen="zork:9000"'
 HOMEDIR=`getent passwd $USERNAME | cut -d: -f6`
-echo "$KEY_OPTS $ENCODED_PUBLIC_KEY" >> $HOMEDIR/.ssh/authorized_keys
+echo "$KEY_OPTS $(echo -n $ENCODED_PUBLIC_KEY|base64 -d)" >> $HOMEDIR/.ssh/authorized_keys
 
 # If we generated an access code, output that access code.
 if [ -n "ENCODED_PRIVATE_KEY" ]; then


### PR DESCRIPTION
Addendum to https://github.com/uProxy/uproxy/pull/2873

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy/2874)
<!-- Reviewable:end -->
